### PR TITLE
#T1130 - message thread list pagination fix

### DIFF
--- a/src/bp-templates/bp-nouveau/js/buddypress-messages.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-messages.js
@@ -1430,7 +1430,8 @@ window.bp = window.bp || {};
 
 			if ( ( target[0].scrollHeight - ( target.scrollTop() ) ) == target.innerHeight() &&
 				this.collection.length &&
-				this.collection.options.page < this.collection.options.total_page
+				this.collection.options.page < this.collection.options.total_page &&
+				! target.find('.bp-user-messages-loading').length
 			) {
 				this.collection.options.page = this.collection.options.page + 1;
 


### PR DESCRIPTION
Message thread list was sending 10-15 requests when scrolled down to fetch more threads. 