### PR TITLE
New settings in Profile Name metabox for Profile Name Sync with WP

### DIFF
--- a/src/bp-core/admin/bp-core-admin-settings.php
+++ b/src/bp-core/admin/bp-core-admin-settings.php
@@ -968,3 +968,18 @@ function bp_profile_names_tutorial() {
 
 	<?php
 }
+
+/**
+ * Enable BP->WP profile syncing field.
+ *
+ * @since BuddyPress 1.6.0
+ *
+ */
+function bp_admin_setting_callback_profile_sync() {
+	?>
+
+	<input id="bp-disable-profile-sync" name="bp-disable-profile-sync" type="checkbox" value="1" <?php checked( !bp_disable_profile_sync( false ) ); ?> />
+	<label for="bp-disable-profile-sync"><?php _e( 'Enable BuddyPress to WordPress profile syncing', 'buddyboss' ); ?></label>
+
+	<?php
+}

--- a/src/bp-core/admin/settings/bp-admin-setting-xprofile.php
+++ b/src/bp-core/admin/settings/bp-admin-setting-xprofile.php
@@ -94,6 +94,9 @@ class BP_Admin_Setting_Xprofile extends BP_Admin_Setting_tab {
 		$args['class'] = 'nick-name-options display-options';
 		$this->add_field( 'bp-hide-nickname-last-name', __( '', 'buddyboss' ), 'bp_admin_setting_callback_nickname_hide_last_name', 'intval', $args );
 
+		// Profile sync setting.
+		$this->add_field( 'bp-disable-profile-sync',   __( 'Profile Name Syncing',  'buddyboss' ), 'bp_admin_setting_callback_profile_sync', 'intval' );
+
 		// Profile Names Tutorial
 		$this->add_field( 'bp-profile-names-tutorial','', 'bp_profile_names_tutorial' );
 


### PR DESCRIPTION
This PR will add the BuddyPress removed functionality back to in Platform and it will sync the First, Last & Nick Name field with BP to WP & WP to BP.

There will be a new setting in the Platform like `BuddyBoss > Settings > Profile Names > Profile Name Syncing`

Screenshot https://prnt.sc/olz601

![sync](https://user-images.githubusercontent.com/7081284/62128558-4cb0dd80-b2f2-11e9-98a0-2f9490041124.png)
