### PR TITLE
Fix Profile Sync, Fix reset profile fields and member type profile field issue

### DIFF
--- a/src/bp-core/admin/bp-core-admin-settings.php
+++ b/src/bp-core/admin/bp-core-admin-settings.php
@@ -968,18 +968,3 @@ function bp_profile_names_tutorial() {
 
 	<?php
 }
-
-/**
- * Enable BP->WP profile syncing field.
- *
- * @since BuddyPress 1.6.0
- *
- */
-function bp_admin_setting_callback_profile_sync() {
-	?>
-
-	<input id="bp-disable-profile-sync" name="bp-disable-profile-sync" type="checkbox" value="1" <?php checked( !bp_disable_profile_sync( false ) ); ?> />
-	<label for="bp-disable-profile-sync"><?php _e( 'Enable BuddyPress to WordPress profile syncing', 'buddyboss' ); ?></label>
-
-	<?php
-}

--- a/src/bp-core/admin/settings/bp-admin-setting-xprofile.php
+++ b/src/bp-core/admin/settings/bp-admin-setting-xprofile.php
@@ -94,9 +94,6 @@ class BP_Admin_Setting_Xprofile extends BP_Admin_Setting_tab {
 		$args['class'] = 'nick-name-options display-options';
 		$this->add_field( 'bp-hide-nickname-last-name', __( '', 'buddyboss' ), 'bp_admin_setting_callback_nickname_hide_last_name', 'intval', $args );
 
-		// Profile sync setting.
-		$this->add_field( 'bp-disable-profile-sync',   __( 'Profile Name Syncing',  'buddyboss' ), 'bp_admin_setting_callback_profile_sync', 'intval' );
-
 		// Profile Names Tutorial
 		$this->add_field( 'bp-profile-names-tutorial','', 'bp_profile_names_tutorial' );
 

--- a/src/bp-core/bp-core-options.php
+++ b/src/bp-core/bp-core-options.php
@@ -513,7 +513,7 @@ function bp_disable_profile_sync( $default = false ) {
 	 *
 	 * @param bool $value Whether or not syncing is disabled.
 	 */
-	return (bool) apply_filters( 'bp_disable_profile_sync', (bool) bp_get_option( 'bp-disable-profile-sync', $default ) );
+	return (bool) apply_filters( 'bp_disable_profile_sync', $default );
 }
 
 /**

--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -1279,6 +1279,12 @@ function bp_xprofile_nickname_field_id( $no_fallback = false, $get_option = true
 		$field_id = bp_get_option( 'bp-xprofile-nickname-field-id', $no_fallback ? 0 : 0 );
 	}
 
+	// Set nickname field id to 0(zero) if first name and nickname both are same.
+	$first_name_id = bp_xprofile_firstname_field_id();
+	if ( $first_name_id === (int) $field_id ) {
+		$field_id = 0;
+	}
+
 	return (int) apply_filters( 'bp_xprofile_nickname_field_id', $field_id );
 }
 

--- a/src/bp-xprofile/bp-xprofile-template.php
+++ b/src/bp-xprofile/bp-xprofile-template.php
@@ -446,12 +446,14 @@ function bp_the_profile_field_ids() {
 			}
 		}
 
+		// Remove member type field if already added in DB and if profile type is disabled.
 		if ( function_exists('bp_member_type_enable_disable' ) && false === bp_member_type_enable_disable() ) {
-			if ( function_exists( 'bp_get_xprofile_member_type_field_id ') ) {
+			if ( function_exists( 'bp_get_xprofile_member_type_field_id') ) {
 				$field_ids = array_diff( $field_ids, array( bp_get_xprofile_member_type_field_id() ) );
 			}
 		}
 
+		// Remove member type field if there is no any member type in options.
 		if ( function_exists( 'bp_check_member_type_field_have_options' ) && false === bp_check_member_type_field_have_options() ) {
 			$field_ids = array_diff( $field_ids, array( bp_get_xprofile_member_type_field_id() ) );
 		}


### PR DESCRIPTION
This PR will fix below issues.

- Auto-sync WP to BP fields
- Auto-sync BP to WP fields
- Fix reset profile fields
- Fix member type profile field issue in edit page if profile type is disabled
