### PR TITLE
T#1178 Email invite link is disappearing in BuddyPanel

### DIFF
--- a/src/bp-invites/classes/class-bp-invites-component.php
+++ b/src/bp-invites/classes/class-bp-invites-component.php
@@ -220,6 +220,11 @@ class BP_Invites_Component extends BP_Component {
 				$access       = bp_core_can_edit_settings();
 				$invites_link = trailingslashit( $user_domain . $slug );
 
+				// Condition for set the $access to true if Email Invites added in BuddyPanel.
+				if ( 'invites' === $slug && false === $access && '' !== $nav_name ) {
+					$access = true;
+				}
+
 				if ( $access ) {
 
 					if ( true === bp_allow_user_to_send_invites() ) {


### PR DESCRIPTION
This PR will fix the Email invite link is disappearing in BuddyPanel when viewing another user profile.

Trello: https://trello.com/c/IwnIkEvO/1178-email-invite-link-is-disappearing-in-buddypanel-when-viewing-another-user-profile-49547