### PR TITLE
T#1269 HTML tags are displaying in forums

### DIFF
--- a/src/bp-forums/common/formatting.php
+++ b/src/bp-forums/common/formatting.php
@@ -68,11 +68,13 @@ function bbp_kses_allowed_tags() {
 
 		// Images
 		'img'          => array(
-			'src'      => true,
-			'border'   => true,
-			'alt'      => true,
-			'height'   => true,
-			'width'    => true,
+			'src'             => true,
+			'border'          => true,
+			'alt'             => true,
+			'height'          => true,
+			'width'           => true,
+			'class'           => true,
+			'data-emoji-char' => true,
 		)
 	) );
 }


### PR DESCRIPTION
This PR will fix the HTML tag display issue on forums.

https://trello.com/c/JgL5sNrs/1269-oversized-emojis-and-html-tags-are-displaying-in-forums-for-non-admin-accounts