### PR TITLE
#T1293 When I turn off activity feeds or Network Search Groups member list does not display

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -579,6 +579,7 @@ class BP_Nouveau extends BP_Theme_Compat {
 		 */
 		$supported_objects = (array) apply_filters( 'bp_nouveau_supported_components', bp_core_get_packaged_component_ids() );
 		$object_nonces     = array();
+		$group_sub_objects = false;
 
 		foreach ( $supported_objects as $key_object => $object ) {
 			if ( ! bp_is_active( $object ) || 'forums' === $object ) {
@@ -587,10 +588,14 @@ class BP_Nouveau extends BP_Theme_Compat {
 			}
 
 			if ( 'groups' === $object ) {
-				$supported_objects = array_merge( $supported_objects, array( 'group_members', 'group_requests', 'group_subgroups' ) );
+				$group_sub_objects = true;
 			}
 
 			$object_nonces[ $object ] = wp_create_nonce( 'bp_nouveau_' . $object );
+		}
+
+		if ( true === $group_sub_objects ) {
+			$supported_objects = array_merge( $supported_objects, array( 'group_members', 'group_requests', 'group_subgroups' ) );
 		}
 
 		// Add components & nonces


### PR DESCRIPTION
Trello: https://trello.com/c/mP6uZ9ec/1293-when-i-turn-off-activity-feeds-component-groups-member-list-does-not-display