### PR TITLE
T#1234 - Show compose message screen when user click on message button

### DIFF
--- a/src/bp-templates/bp-nouveau/js/buddypress-messages.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-messages.js
@@ -189,6 +189,9 @@ window.bp = window.bp || {};
 			this.views.add( { id: 'compose', view: form } );
 
 			form.inject( '.bp-messages-content' );
+			
+			//show compose message screen
+			$('.bp-messages-container').removeClass('bp-view-message').addClass('bp-compose-message');
 		},
 
 		threadsView: function() {


### PR DESCRIPTION
**issue:** When you go to click message someone from their profile on mobile it just takes you to your inbox not to compose new message. Works perfect on desktop resolution. Issue is only present on mobile display.

@mehulkaklotar Please let me know if this is the correct way or not.