### PR TITLE
Fix Wrong date display issue

### DIFF
--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -4769,7 +4769,7 @@ function bp_group_member_joined_since( $args = array() ) {
 
 		// Set user date to user registered date when date_modified is 0000-00-00 00:00:00
 		if( strtotime( $members_template->member->date_modified ) < 0 ) {
-			$members_template->member->date_modified = $members_template->member->user_registered;
+			$members_template->member->date_modified = '';
 		}
 
 		// We do not want relative time, so return now.


### PR DESCRIPTION
This PR will fix the wrong date display issue on group members listing.

Screenshot: https://prnt.sc/ozlwwr