### PR TITLE
#T335 Fix AMP page image not coming

### DIFF
--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -4910,10 +4910,6 @@ function bp_activity_action_parse_url() {
 				}
 			}
 
-			if ( empty( $images ) ) {
-				$images = $parser->getAmpImageSources( false );
-			}
-
 			$json_data['title']       = $title;
 			$json_data['description'] = $description;
 			$json_data['images']      = $images;

--- a/src/bp-activity/vendors/website-parser/website_parser.php
+++ b/src/bp-activity/vendors/website-parser/website_parser.php
@@ -216,6 +216,24 @@ class WebsiteParser
                     }
                 }
             }
+
+	        $match_images = array();
+            //search for AMP images
+	        preg_match_all($this->amp_img_expression, $this->content, $match_images);
+
+	        if (isset($match_images[2]) && count($match_images[2])) {
+		        foreach ($match_images[2] as $match_image) {
+			        $match_image = trim($match_image);
+
+			        if ($match_image) {
+
+				        if (!preg_match($this->full_link_pattern, $match_image, $match))
+					        $match_image = $this->sanitizeUrl($match_image);
+
+				        $this->image_sources[] = $match_image;
+			        }
+		        }
+	        }
         }
 
         $this->image_sources = array_values(array_unique(array_filter($this->image_sources)));
@@ -223,41 +241,6 @@ class WebsiteParser
         return $this->image_sources;
 
     }
-
-	/**
-	 * Extract all images sources from grabbed contents
-	 * @param boolean $grab , flag to perform real time grab or use class content
-	 * @return array, an array of extracted images sources
-	 */
-	public function getAmpImageSources($grab = false)
-	{
-		if ($grab)
-			$this->grabContent();
-
-		if (!is_null($this->content)) {
-
-			preg_match_all($this->amp_img_expression, $this->content, $match_images);
-
-			if (isset($match_images[2]) && count($match_images[2])) {
-				foreach ($match_images[2] as $match_image) {
-					$match_image = trim($match_image);
-
-					if ($match_image) {
-
-						if (!preg_match($this->full_link_pattern, $match_image, $match))
-							$match_image = $this->sanitizeUrl($match_image);
-
-						$this->image_sources[] = $match_image;
-					}
-				}
-			}
-		}
-
-		$this->image_sources = array_values(array_unique(array_filter($this->image_sources)));
-
-		return $this->image_sources;
-
-	}
 
     /**
      * Extract title from grabbed contents


### PR DESCRIPTION
This PR will fix the image not coming on AMP pages.

Trello: https://trello.com/c/UGdMmDF3/1335-when-adding-external-links-in-the-activity-page-some-links-have-preview-images-others-show-only-the-excerpt-50444