### PR TITLE
T1394 Email invite is causing an error

### DIFF
--- a/src/bp-invites/classes/class-bp-invites-component.php
+++ b/src/bp-invites/classes/class-bp-invites-component.php
@@ -227,7 +227,7 @@ class BP_Invites_Component extends BP_Component {
 
 				if ( $access ) {
 
-					if ( true === bp_allow_user_to_send_invites() ) {
+					if ( true === bp_allow_user_to_send_invites() && bp_is_my_profile() ) {
 						// Add 'Send Invites' to the main navigation.
 						$main_nav = array(
 							'name'                => $nav_name,


### PR DESCRIPTION
This PR will fix the below email invites error.

> An error of type E_COMPILE_ERROR was caused in line 117 of the file /var/www/html/wp->content/plugins/buddyboss-platform/bp-invites/classes/class-bp-invites-component.php.

>Error message: require(): Failed opening required '/var/www/html/wp-content/plugins/buddyboss->platform/bp-invites/actions/sent-invites.php' (include_path='.:/usr/share/pear7:/usr/share/php')

Trello: https://trello.com/c/toDMQLuR/1394-email-invite-is-causing-an-error