### PR TITLE
T#1354 excluded/hidden members in profile's members widget

### DIFF
--- a/src/bp-members/bp-members-widgets.php
+++ b/src/bp-members/bp-members-widgets.php
@@ -70,6 +70,7 @@ function bp_core_ajax_widget_members() {
 		'max'             => $max_members,
 		'populate_extras' => true,
 		'search_terms'    => false,
+		'exclude'		  => bp_get_users_of_removed_member_types(),
 	);
 
 	// Query for members.

--- a/src/bp-members/classes/class-bp-core-members-widget.php
+++ b/src/bp-members/classes/class-bp-core-members-widget.php
@@ -97,6 +97,7 @@ class BP_Core_Members_Widget extends WP_Widget {
 			'max'             => $settings['max_members'],
 			'populate_extras' => true,
 			'search_terms'    => false,
+			'exclude'		  => bp_get_users_of_removed_member_types(),
 		);
         
         if ( empty($members_args['max']) ) {


### PR DESCRIPTION
https://trello.com/c/2MC93SAl/1354-when-setting-a-profile-type-to-be-hidden-in-members-directory-page-it-should-also-be-hidden-in-a-single-members-page-51317