### PR TITLE
T#1417 fixed bug for Lessons and Topics published date

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -1375,7 +1375,7 @@ function bp_core_time_since( $older_date, $newer_date = false ) {
  * @return string|null
  */
 function bp_core_format_date( $date = '', $format = '' ) {
-	echo bp_core_get_format_date( $date, $format );
+	echo bp_core_get_format_date( strtotime( $date ), $format );
 }
 
 /**
@@ -1396,7 +1396,7 @@ function bp_core_get_format_date( $date = '', $format = '' ) {
         $format = bp_core_date_format();
     }
 
-    return date_i18n( $format, strtotime( $date ) );
+    return date_i18n( $format, $date );
 }
 
 


### PR DESCRIPTION
https://trello.com/c/X3mmmG2n/1417-published-date-on-lessons-and-topics-are-displayed-wrong-when-using-the-buddyboss-theme