### PR TITLE
Discussions, replies and favorites if user is non-admin bug fix

### DIFF
--- a/src/bp-forums/replies/template.php
+++ b/src/bp-forums/replies/template.php
@@ -179,6 +179,32 @@ function bbp_has_replies( $args = '' ) {
 	// Get Forums
 	$bbp = bbpress();
 
+	if ( bp_is_forums_component() ) {
+		/*
+		* WP is injecting meta_query to prevent Subscribers accessing the Private posts/pages
+		* 
+		* to bypass - add custom meta_query
+		*
+		* this was also reported in community as bug of bbpress 
+		*/
+		$forums_pages = get_pages( array( 
+						'post_type' 	=> bbp_get_forum_post_type(), 
+						'numberposts' 	=> -1,
+						'post_status' 	=> [ 'publish', 'private' ],
+						'parent'		=> 0
+					) 
+				);
+
+		$r['meta_query'] = array(
+	        'relation' => 'OR',
+	        array(
+	            'key'     => '_bbp_forum_id',
+	            'value'   => wp_list_pluck( $forums_pages, 'ID' ),
+	            'compare' => 'IN',
+	        )
+	    );
+    }
+
 	// Call the query
 	$bbp->reply_query = new WP_Query( $r );
 

--- a/src/bp-forums/templates/default/bbpress-functions.php
+++ b/src/bp-forums/templates/default/bbpress-functions.php
@@ -418,12 +418,16 @@ class BBP_Default extends BBP_Theme_Compat {
 
 		// Single topic
 		} elseif ( bbp_is_single_topic() ) {
+			// @Mehul/@Chetan get_the_ID() is always returning 0 - please remove this comment before merging thanks
+			
+			$topic = get_page_by_title( bbp_get_reply_topic_title(), OBJECT, 'topic' );
+
 			wp_localize_script( 'bbpress-topic', 'bbpTopicJS', array(
 				'bbp_ajaxurl'        => bbp_get_ajax_url(),
 				'generic_ajax_error' => __( 'Something went wrong. Refresh your browser and try again.', 'buddyboss' ),
 				'is_user_logged_in'  => is_user_logged_in(),
-				'fav_nonce'          => wp_create_nonce( 'toggle-favorite_' .     get_the_ID() ),
-				'subs_nonce'         => wp_create_nonce( 'toggle-subscription_' . get_the_ID() )
+				'fav_nonce'          => wp_create_nonce( 'toggle-favorite_' .     $topic->ID ),
+				'subs_nonce'         => wp_create_nonce( 'toggle-subscription_' . $topic->ID )
 			) );
 		}
 	}

--- a/src/bp-forums/topics/template.php
+++ b/src/bp-forums/topics/template.php
@@ -198,6 +198,32 @@ function bbp_has_topics( $args = '' ) {
 	// Get Forums
 	$bbp = bbpress();
 
+	if ( bp_is_forums_component() ) {
+		/*
+		* WP is injecting meta_query to prevent Subscribers accessing the Private posts/pages
+		* 
+		* to bypass - add custom meta_query
+		*
+		* this was also reported in community as bug of bbpress 
+		*/
+		$forums_pages = get_pages( array( 
+						'post_type' 	=> bbp_get_forum_post_type(), 
+						'numberposts' 	=> -1,
+						'post_status' 	=> [ 'publish', 'private' ],
+						'parent'		=> 0
+					) 
+				);
+		
+		$r['meta_query'] = array(
+	        'relation' => 'OR',
+	        array(
+	            'key'     => '_bbp_forum_id',
+	            'value'   => wp_list_pluck( $forums_pages, 'ID' ),
+	            'compare' => 'IN',
+	        )
+	    );
+    }
+
 	// Call the query
 	$bbp->topic_query = new WP_Query( $r );
 


### PR DESCRIPTION
Able to replicate this on Demo and my dev site (tried and tested by other devs as well)

Steps to replicate:
1. Create a Private Group then associate it with a Forum Discussion
2. Add a non-admin member to the group (on the screenshot, Charles)
3. Using the non-admin member, add new discussion in a Private Group created
4. Using the non-admin member, go to profile > forums. Under My Discussions, you won't be able to see the discussion created in #3
5. Using the admin, go to the creator of the profile (Charles) > forums, under My Discussion you will see the discussion created in #3

Bug:
Even when a member of the private group creates a discussion, add a reply. The user can't see the discussion they created in their profile > forums >  My Discussion/ My Replies