### PR TITLE
T#1752 - fixed : Member type not showing on connection page

### DIFF
--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -3977,52 +3977,27 @@ function bp_get_user_member_type( $user_id ) {
 		$user_id = bp_displayed_user_id();
 	}
 
-	$member_type = '';
+	$member_type = __( 'Member', 'buddyboss' );
 
-	if ( bp_is_members_directory() ) {
+	if ( true === bp_member_type_enable_disable() ) {
+		if ( true === bp_member_type_display_on_profile() ) {
 
-		$member_type = __( 'Member', 'buddyboss' );
+			// Get the profile type.
+			$type = bp_get_member_type( $user_id );
 
-		if ( true === bp_member_type_enable_disable() ) {
-			if ( true === bp_member_type_display_on_profile() ) {
-
-				// Get the profile type.
-				$type = bp_get_member_type( $user_id );
-
-				// Output the
-				if ( $type_obj = bp_get_member_type_object( $type ) ) {
-					$member_type = $type_obj->labels['singular_name'];
-				}
-
-				$string = '<span class="bp-member-type">' . $member_type . '</span>';
-			} else {
-				$string = '<span class="bp-member-type">' . $member_type . '</span>';
+			// Output the
+			if ( $type_obj = bp_get_member_type_object( $type ) ) {
+				$member_type = $type_obj->labels['singular_name'];
 			}
+
+			$string = '<span class="bp-member-type">' . $member_type . '</span>';
 		} else {
 			$string = '<span class="bp-member-type">' . $member_type . '</span>';
 		}
 	} else {
-
-		if ( true === bp_member_type_enable_disable() ) {
-			if ( true === bp_member_type_display_on_profile() ) {
-
-				// Get the profile type.
-				$type = bp_get_member_type( $user_id );
-
-				// Output the
-				if ( $type_obj = bp_get_member_type_object( $type ) ) {
-					$member_type = $type_obj->labels['singular_name'];
-					$string      = '<span class="bp-member-type">' . $member_type . '</span>';
-				} else {
-					$string = '';
-				}
-			} else {
-				$string = '';
-			}
-		} else {
-			$string = '';
-		}
+		$string = '<span class="bp-member-type">' . $member_type . '</span>';
 	}
+
 
 	return apply_filters( 'bp_member_type_name_string', $string, $member_type, $user_id );
 }


### PR DESCRIPTION
Trello: https://trello.com/c/9a5YbBEc/1752-member-type-not-showing-on-my-connection-page

@mehulkaklotar @chetansatasiya 
Please verify these changes which are made after discussion with Chetan and also check the video included in Trello card to understand the issue.

Please let me know if need any updates.

Thanks