### PR TITLE
T52542: Fix Compatibility with WP Ultimo - Network Search Component.

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/search/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/search/functions.php
@@ -39,6 +39,12 @@ function bp_nouveau_search_register_scripts( $scripts = array() ) {
  * @since BuddyPress 3.0.0
  */
 function bp_nouveau_search_enqueue_scripts() {
+	
+	/* To show number of listing per page. */
+	$per_page = '5';	
+	if ( function_exists( 'bp_search_get_form_option' ) ) {
+		$per_page = bp_search_get_form_option( 'bp_search_number_of_results', 5 );
+	}
 
 	$data = array(
 		'nonce'                 => wp_create_nonce( 'bp_search_ajax' ),
@@ -48,7 +54,7 @@ function bp_nouveau_search_enqueue_scripts() {
 		//'search_url'    => home_url( '/' ), Now we are using form[role='search'] selector
 		'loading_msg'           => __( "Loading Suggestions", "buddyboss" ),
 		'enable_ajax_search'    => function_exists( 'bp_is_search_autocomplete_enable' ) && bp_is_search_autocomplete_enable(),
-		'per_page'              => bp_search_get_form_option( 'bp_search_number_of_results', 5 ),
+		'per_page'              => $per_page,
 		'autocomplete_selector' => "form[role='search'], form.search-form, form.searchform, form#adminbarsearch, .bp-search-form>#search-form",
 		'form_selector'         => '',
 	);


### PR DESCRIPTION
https://trello.com/c/NCTWA7oH/1505-compatibility-with-wp-ultimo-network-search-component

### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #287.

### How to test the changes in this Pull Request:

Step 1. Visit the register page link.

Step 2. Select a plan.

Step 3. Once on the template page, hover over the picture and you will see "View Template"

Step 4. Click  "View Template" and the page will come up blank.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
