### PR TITLE
More button is missing on (BB) Connections

### DIFF
--- a/src/bp-members/classes/class-bp-core-members-widget.php
+++ b/src/bp-members/classes/class-bp-core-members-widget.php
@@ -126,7 +126,7 @@ class BP_Core_Members_Widget extends WP_Widget {
 																 <?php
 																	if ( 'active' === $settings['member_default'] ) :
 																		?>
-					class="selected"<?php endif; ?>><?php esc_html_e( 'Active-1', 'buddyboss' ); ?></a>
+					class="selected"<?php endif; ?>><?php esc_html_e( 'Active', 'buddyboss' ); ?></a>
 
 				<?php if ( bp_is_active( 'friends' ) ) : ?>
 					<span class="bp-separator" role="separator"><?php echo esc_html( $separator ); ?></span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #299.

### How to test the changes in this Pull Request:

1. Go to widgets.
2. Add (BB) Connections widgets to any sidebar
3. go to front page and no "More" button is showing even there are still some remaining items needs to be shown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
