### PR TITLE
#308 - gif button fix on single activity page

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/activity/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/functions.php
@@ -58,6 +58,12 @@ function bp_nouveau_activity_enqueue_scripts() {
 	}
 
 	wp_enqueue_script( 'bp-nouveau-activity' );
+
+	// Enqueue activity form parts and js required for single activity
+	if ( bp_nouveau_current_user_can( 'publish_activity' ) && bp_is_single_activity() ) {
+		wp_enqueue_script( 'bp-nouveau-activity-post-form' );
+		bp_get_template_part( 'common/js-templates/activity/form' );
+	}
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the gif button issue on single activity page when commenting on post or comment.

Closes #308 .

### How to test the changes in this Pull Request:

1. Go to activity news feed and click on activity timestamp to go to single activity
2. Click on comment button and click on gif icon to add it as a reply or comment
3. It will open the dropdown popup with list of gif to choose from

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> GIF fix on single activity page
