### PR TITLE
T#55237: On the edit profile page, some options of WYSIWYG editor are not working

### DIFF
--- a/src/bp-xprofile/bp-xprofile-filters.php
+++ b/src/bp-xprofile/bp-xprofile-filters.php
@@ -194,7 +194,7 @@ function xprofile_filter_kses( $content, $data_obj = null, $field_id = null  ) {
 /**
  * Filters profile field values for whitelisted HTML.
  *
- * @since BuddyPress 5.0.0
+ * @since BuddyBoss 1.2.3
  *
  * @param string $value    Field value.
  * @param string $type     Field type.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #314.

### How to test the changes in this Pull Request:

1. Go to wp-admin
2. Click on Buddyboss -> Profiles
3. Create new profile custom field with Type as " Paragraph Text "
4. In frontend click on the login user name on the top right corner.
5. Hover on profile and click on Edit.
6. Add text in " Paragraph Text " and perform the operation such as bulleted list, numbered list, underline, etc.
7. Save and check the above-selected option not saved.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

