### PR TITLE
T57494 - Notices in the menu when debug mode is on.

### DIFF
--- a/src/bp-forums/admin/forums.php
+++ b/src/bp-forums/admin/forums.php
@@ -120,7 +120,7 @@ if ( ! class_exists( 'BBP_Forums_Admin' ) ) :
 		public function bbp_set_hidden_forum_states( $states, $post ) {
 			global $post;
 
-			if ( bbp_get_forum_post_type() === get_post_type( $post->ID ) && bbp_get_hidden_status_id() === bbp_get_forum_visibility( $post->ID ) ) {
+			if ( is_array( $post ) && bbp_get_forum_post_type() === get_post_type( $post->ID ) && bbp_get_hidden_status_id() === bbp_get_forum_visibility( $post->ID ) ) {
 
 				$states[] = __( 'Hidden', 'buddyboss' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #319.

### How to test the changes in this Pull Request:

1. Freshly installed WordPress and activate the BuddyBoss platform plugin.
2. Go to Buddyboss -> Component
3. Activate the " Forum Discussions " component.
4. Enable WP_DEBUG from the wp-config.php file
5. Go to Appearance -> Menu
5. You can see the notices in " Add menu items " metabox.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

