### PR TITLE
T55183 : Badge should be shown to verified members on the forum page.

### DIFF
--- a/src/bp-forums/replies/template.php
+++ b/src/bp-forums/replies/template.php
@@ -1191,49 +1191,50 @@ function bbp_get_reply_author_avatar( $reply_id = 0, $size = 40 ) {
 function bbp_reply_author_link( $args = '' ) {
 	echo bbp_get_reply_author_link( $args );
 }
-
-/**
- * Return the author link of the reply
- *
- * @since bbPress (r2717)
- *
- * @param mixed $args Optional. If an integer, it is used as reply id.
- * @uses bbp_get_reply_id() To get the reply id
- * @uses bbp_is_reply_anonymous() To check if the reply is by an
- *                                 anonymous user
- * @uses bbp_get_reply_author_url() To get the reply author url
- * @uses bbp_get_reply_author_avatar() To get the reply author avatar
- * @uses bbp_get_reply_author_display_name() To get the reply author display
- *                                      name
- * @uses bbp_get_user_display_role() To get the reply author display role
- * @uses bbp_get_reply_author_id() To get the reply author id
- * @uses apply_filters() Calls 'bbp_get_reply_author_link' with the
- *                        author link and args
- * @return string Author link of reply
- */
+	/**
+	 * Return the author link of the reply
+	 *
+	 * @since bbPress (r2717)
+	 *
+	 * @param mixed $args Optional. If an integer, it is used as reply id.
+	 * @uses bbp_get_reply_id() To get the reply id
+	 * @uses bbp_is_reply_anonymous() To check if the reply is by an
+	 *                                 anonymous user
+	 * @uses bbp_get_reply_author_url() To get the reply author url
+	 * @uses bbp_get_reply_author_avatar() To get the reply author avatar
+	 * @uses bbp_get_reply_author_display_name() To get the reply author display
+	 *                                      name
+	 * @uses bbp_get_user_display_role() To get the reply author display role
+	 * @uses bbp_get_reply_author_id() To get the reply author id
+	 * @uses apply_filters() Calls 'bbp_get_reply_author_link' with the
+	 *                        author link and args
+	 * @return string Author link of reply
+	 */
 function bbp_get_reply_author_link( $args = '' ) {
 
 	// Parse arguments against default values
 	$r = bbp_parse_args(
-        $args,
-        array(
-            'post_id'    => 0,
-            'link_title' => '',
-            'type'       => 'both',
-            'size'       => 80,
-            'sep'        => '&nbsp;',
-            'show_role'  => false,
-        ),
-        'get_reply_author_link'
-    );
-
+		$args,
+		array(
+			'post_id'    => 0,
+			'link_title' => '',
+			'type'       => 'both',
+			'size'       => 80,
+			'sep'        => '&nbsp;',
+			'show_role'  => false,
+		),
+		'get_reply_author_link'
+	);
+	
 	// Default return value
 	$author_link = '';
 
 	// Used as reply_id
-	$reply_id = is_numeric( $args )
-		? bbp_get_reply_id( $args )
-		: bbp_get_reply_id( $r['post_id'] );
+	if ( is_numeric( $args ) ) {
+		$reply_id = bbp_get_reply_id( $args );
+	} else {
+		$reply_id = bbp_get_reply_id( $r['post_id'] );
+	}
 
 	// Reply ID is good
 	if ( ! empty( $reply_id ) ) {
@@ -1244,32 +1245,25 @@ function bbp_get_reply_author_link( $args = '' ) {
 
 		// Tweak link title if empty
 		if ( empty( $r['link_title'] ) ) {
-			$author = bbp_get_reply_author_display_name( $reply_id );
-			$title  = empty( $anonymous )
-				? esc_attr__( "View %s's profile",  'buddyboss' )
-				: esc_attr__( "Visit %s's website", 'buddyboss' );
+			$link_title = sprintf( empty( $anonymous ) ? __( 'View %s\'s profile', 'buddyboss' ) : __( 'Visit %s\'s website', 'buddyboss' ), bbp_get_reply_author_display_name( $reply_id ) );
 
-			$link_title = sprintf( $title, $author );
-
-		// Use what was passed if not
+			// Use what was passed if not
 		} else {
 			$link_title = $r['link_title'];
 		}
 
 		// Setup title and author_links array
+		$link_title   = ! empty( $link_title ) ? ' title="' . esc_attr( $link_title ) . '"' : '';
 		$author_links = array();
-		$link_title   = ! empty( $link_title )
-			? ' title="' . esc_attr( $link_title ) . '"'
-			: '';
 
-		// Get avatar (unescaped, because HTML)
-		if ( ( 'avatar' === $r['type'] ) || ( 'both' === $r['type'] ) ) {
+		// Get avatar
+		if ( 'avatar' === $r['type'] || 'both' === $r['type'] ) {
 			$author_links['avatar'] = bbp_get_reply_author_avatar( $reply_id, $r['size'] );
 		}
 
-		// Get display name (escaped, because never HTML)
-		if ( ( 'name' === $r['type'] ) || ( 'both' === $r['type'] ) ) {
-			$author_links['name'] = esc_html( bbp_get_reply_author_display_name( $reply_id ) );
+		// Get display name
+		if ( 'name' === $r['type'] || 'both' === $r['type'] ) {
+			$author_links['name'] = bbp_get_reply_author_display_name( $reply_id );
 		}
 
 		// Empty array
@@ -1287,11 +1281,11 @@ function bbp_get_reply_author_link( $args = '' ) {
 		unset( $links );
 
 		// Filter sections if avatar size is 1 or type is name else assign the author links array itself. Added condition not to show verified badges on avatar.
-		if ( 1 == $r['size'] || 'name' === $r['type'] ) {
-			$sections    = apply_filters( 'bbp_get_reply_author_links', $author_links, $r, $args );
-		} else {
-			$sections    	 = $author_links;
-		}
+        if ( 1 == $r['size'] || 'name' === $r['type'] ) {
+            $sections   = apply_filters( 'bbp_get_topic_author_links', $author_links, $r, $args );
+        } else {
+            $sections   = $author_links;
+        }
 
 		// Assemble sections into author link
 		$author_link = implode( $r['sep'], $sections );
@@ -1305,10 +1299,11 @@ function bbp_get_reply_author_link( $args = '' ) {
 		if ( true === $r['show_role'] ) {
 			$author_link .= bbp_get_reply_author_role( array( 'reply_id' => $reply_id ) );
 		}
+
 	}
 
 	// Filter & return
-	return apply_filters( 'bbp_get_reply_author_link', $author_link, $r, $args );
+	return apply_filters( 'bbp_get_reply_author_link', $author_link, $r );
 }
 
 /**

--- a/src/bp-forums/topics/template.php
+++ b/src/bp-forums/topics/template.php
@@ -1468,52 +1468,52 @@ function bbp_get_topic_author_avatar( $topic_id = 0, $size = 40 ) {
 function bbp_topic_author_link( $args = '' ) {
 	echo bbp_get_topic_author_link( $args );
 }
-
-/**
- * Return the author link of the topic
- *
- * @since bbPress (r2717)
- *
- * @param mixed|int $args If it is an integer, it is used as topic id.
- *                         Optional.
- * @uses bbp_get_topic_id() To get the topic id
- * @uses bbp_get_topic_author_display_name() To get the topic author
- * @uses bbp_is_topic_anonymous() To check if the topic is by an
- *                                 anonymous user
- * @uses bbp_get_topic_author_url() To get the topic author url
- * @uses bbp_get_topic_author_avatar() To get the topic author avatar
- * @uses bbp_get_topic_author_display_name() To get the topic author display
- *                                      name
- * @uses bbp_get_user_display_role() To get the topic author display role
- * @uses bbp_get_topic_author_id() To get the topic author id
- * @uses apply_filters() Calls 'bbp_get_topic_author_link' with the link
- *                        and args
- * @return string Author link of topic
- */
+	/**
+	 * Return the author link of the topic
+	 *
+	 * @since bbPress (r2717)
+	 *
+	 * @param mixed|int $args If it is an integer, it is used as topic id.
+	 *                         Optional.
+	 * @uses bbp_get_topic_id() To get the topic id
+	 * @uses bbp_get_topic_author_display_name() To get the topic author
+	 * @uses bbp_is_topic_anonymous() To check if the topic is by an
+	 *                                 anonymous user
+	 * @uses bbp_get_topic_author_url() To get the topic author url
+	 * @uses bbp_get_topic_author_avatar() To get the topic author avatar
+	 * @uses bbp_get_topic_author_display_name() To get the topic author display
+	 *                                      name
+	 * @uses bbp_get_user_display_role() To get the topic author display role
+	 * @uses bbp_get_topic_author_id() To get the topic author id
+	 * @uses apply_filters() Calls 'bbp_get_topic_author_link' with the link
+	 *                        and args
+	 * @return string Author link of topic
+	 */
 function bbp_get_topic_author_link( $args = '' ) {
 
 	// Parse arguments against default values
 	$r = bbp_parse_args(
-        $args,
-        array(
-            'post_id'    => 0,
-            'link_title' => '',
-            'type'       => 'both',
-            'size'       => 80,
-            'sep'        => '&nbsp;',
-            'show_role'  => false,
-        ),
-        'get_topic_author_link'
-    );
-
-
+		$args,
+		array(
+			'post_id'    => 0,
+			'link_title' => '',
+			'type'       => 'both',
+			'size'       => 80,
+			'sep'        => '&nbsp;',
+			'show_role'  => false,
+		),
+		'get_topic_author_link'
+	);
+	
 	// Default return value
 	$author_link = '';
 
 	// Used as topic_id
-	$topic_id = is_numeric( $args )
-		? bbp_get_topic_id( $args )
-		: bbp_get_topic_id( $r['post_id'] );
+	if ( is_numeric( $args ) ) {
+		$topic_id = bbp_get_topic_id( $args );
+	} else {
+		$topic_id = bbp_get_topic_id( $r['post_id'] );
+	}
 
 	// Topic ID is good
 	if ( ! empty( $topic_id ) ) {
@@ -1524,34 +1524,27 @@ function bbp_get_topic_author_link( $args = '' ) {
 
 		// Tweak link title if empty
 		if ( empty( $r['link_title'] ) ) {
-			$author = bbp_get_topic_author_display_name( $topic_id );
-			$title  = empty( $anonymous )
-				? esc_attr__( "View %s's profile",  'buddyboss' )
-				: esc_attr__( "Visit %s's website", 'buddyboss' );
+			$link_title = sprintf( empty( $anonymous ) ? __( 'View %s\'s profile', 'buddyboss' ) : __( 'Visit %s\'s website', 'buddyboss' ), bbp_get_topic_author_display_name( $topic_id ) );
 
-			$link_title = sprintf( $title, $author );
-
-		// Use what was passed if not
+			// Use what was passed if not
 		} else {
 			$link_title = $r['link_title'];
 		}
 
 		// Setup title and author_links array
+		$link_title   = ! empty( $link_title ) ? ' title="' . esc_attr( $link_title ) . '"' : '';
 		$author_links = array();
-		$link_title   = ! empty( $link_title )
-			? ' title="' . esc_attr( $link_title ) . '"'
-			: '';
 
-		// Get avatar (unescaped, because HTML)
-		if ( ( 'avatar' === $r['type'] ) || ( 'both' === $r['type'] ) ) {
+		// Get avatar
+		if ( 'avatar' === $r['type'] || 'both' === $r['type'] ) {
 			$author_links['avatar'] = bbp_get_topic_author_avatar( $topic_id, $r['size'] );
 		}
 
-		// Get display name (escaped, because never HTML)
-		if ( ( 'name' === $r['type'] ) || ( 'both' === $r['type'] ) ) {
-			$author_links['name'] = esc_html( bbp_get_topic_author_display_name( $topic_id ) );
+		// Get display name
+		if ( 'name' === $r['type'] || 'both' === $r['type'] ) {
+			$author_links['name'] = bbp_get_topic_author_display_name( $topic_id );
 		}
-
+		
 		// Empty array
 		$links  = array();
 		$sprint = '<span %1$s>%2$s</span>';
@@ -1567,12 +1560,12 @@ function bbp_get_topic_author_link( $args = '' ) {
 		unset( $links );
 
 		// Filter sections if avatar size is 1 or type is name else assign the author links array itself. Added condition not to show verified badges on avatar.
-		if ( 1 == $r['size'] || 'name' === $r['type'] ) {
-			$sections   = apply_filters( 'bbp_get_topic_author_links', $author_links, $r, $args );
-		} else {
-			$sections   = $author_links;
-		}
-		
+        if ( 1 == $r['size'] || 'name' === $r['type'] ) {
+            $sections   = apply_filters( 'bbp_get_topic_author_links', $author_links, $r, $args );
+        } else {
+            $sections   = $author_links;
+        }
+
 		// Assemble sections into author link
 		$author_link = implode( $r['sep'], $sections );
 
@@ -1588,7 +1581,7 @@ function bbp_get_topic_author_link( $args = '' ) {
 	}
 
 	// Filter & return
-	return apply_filters( 'bbp_get_topic_author_link', $author_link, $r, $args );
+	return apply_filters( 'bbp_get_topic_author_link', $author_link, $args );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #332.

### How to test the changes in this Pull Request:


Steps to replicate:
1. Download the plugin and activate
2. Go to BuddyBoss > Verified Member
3. Make sure the following settings are enabled:
- Display in Topics
- Display in Replies
4. Go to Users > choose any users (with published forums or discussion) > extended profile > marked check the - Verified Member
5. Now go to activity feeds, you can see a checked icon beside the verified user
6. Try to go to forums or discussions then the badge beside the username is not displaying
7. try to deactivate the BuddyBoss platform and use bbPress instead, then the badge icon is displaying properly on the forums

---

Plugin link: https://wordpress.org/plugins/bp-verified-member/

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
