### PR TITLE
T1808: Issue: Email invites link not working when PMPro is activated - #57154

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -3238,6 +3238,13 @@ function bp_send_email( $email_type, $to, $args = array() ) {
 	static $is_default_wpmail = null;
 	static $wp_html_emails    = null;
 
+	if ( function_exists( 'pmpro_wp_mail_content_type' ) ) {
+		/**
+		 * Removed Paid Memberships Pro plugin's filter.
+		 */
+		remove_filter( 'wp_mail_content_type', 'pmpro_wp_mail_content_type' );
+	}
+
 	// Has wp_mail() been filtered to send HTML emails?
 	if ( is_null( $wp_html_emails ) ) {
 		/** This filter is documented in wp-includes/pluggable.php */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Closes #354.

### How to test the changes in this Pull Request:

1. Activate BuddyBoss Platform
2. Activate Paid Membership Pro
3. Enable Email Invites
4. On frontend, try inviting a user
5. Check invitation on invited user email

### Proof Screenshots or Video
http://prntscr.com/qa5v3v
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
