### PR TITLE
T1821: Learndash modal registration is not sending an email activation when BuddyBoss Platform is enabled

### DIFF
--- a/src/bp-integrations/learndash/bp-learndash-filters.php
+++ b/src/bp-integrations/learndash/bp-learndash-filters.php
@@ -1,17 +1,23 @@
 <?php
 
-add_action( 'bp_core_before_wpsignup_redirect', 'bp_ld_popup_register_redirect', 10 );
+add_filter( 'bp_core_wpsignup_redirect', 'bp_ld_popup_register_redirect', 10 );
 
 /**
  * Do not redirect to user on register page if user doing registration on LD Popup.
  *
- * @param $redirect
+ * @param bool $bool
  *
- * @since BuddyBoss 1.1.9
+ * @since BuddyBoss 1.2.3
  */
-function bp_ld_popup_register_redirect() {
-	if ( isset( $_POST ) && isset( $_POST['learndash-registration-form'] ) && 'true' === $_POST['learndash-registration-form'] ) {
-		$url = isset( $_POST['redirect_to'] ) ? $_POST['redirect_to'] : bp_get_signup_page();
-		bp_core_redirect( esc_url( $url ) );
+function bp_ld_popup_register_redirect( $bool ) {
+
+	if (
+		   isset( $_POST )
+		&& isset( $_POST['learndash-registration-form'] )
+		&& 'true' === $_POST['learndash-registration-form']
+	) {
+		return false;
 	}
+
+	return $bool;
 }

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -2390,7 +2390,9 @@ function bp_core_wpsignup_redirect() {
 		return;
 	}
 
-	bp_core_redirect( bp_get_signup_page() );
+	if ( apply_filters( 'bp_core_wpsignup_redirect', true ) ) {
+		bp_core_redirect( bp_get_signup_page() );
+	}
 }
 add_action( 'bp_init', 'bp_core_wpsignup_redirect' );
 
@@ -3857,7 +3859,7 @@ function bp_member_type_shortcode_add_body_class( $class ) {
 		$class[] = 'buddypress';
 		$class[] = 'buddyboss';
 		/**
-		 *This class commented because this class will add when buddypanel enable 
+		 *This class commented because this class will add when buddypanel enable
 		 *and this condition already in the theme
 		 */
 		//$class[] = 'bb-buddypanel';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Learndash modal registration is not sending an email activation when BuddyBoss Platform is enabled

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Closes #358.

### How to test the changes in this Pull Request:

1. Make sure that Login & Registration is enabled in Learndash LMS settings
2. Create a course with Access Mode set to as "Free"
3. Go to courses page, make sure you are logged out
4. Navigate to the created course and click Login to Enroll
5. Try to register
6. Check your email to set the password.

### Proof Screenshots or Video
https://screencast-o-matic.com/watch/cqlDirvhWB
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> LearnDash - Fixed modal registration sending an email for activation
