### PR TITLE
Custom CSS class not showing for forum page only.

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -249,10 +249,10 @@ class BP_Nouveau extends BP_Theme_Compat {
 
 		if ( 'forum' === get_post_type() || 'topic' === get_post_type() ) {
 			// Unset current_page_parent class if exists.
-			if( in_array( 'current_page_parent', $classes ) ) {
-				unset($classes[array_search('current_page_parent',$classes)]);
+			if ( in_array( 'current_page_parent', $classes ) ) {
+				unset( $classes[ array_search( 'current_page_parent', $classes ) ] );
 			}
-			if ( isset($item->url) ) {
+			if ( isset( $item->url ) ) {
 				if ( isset( $current_url ) && isset( $item->url ) && strstr( $current_url, $item->url ) ) {
 					$classes[] = 'current-menu-item';
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #349.

### How to test the changes in this Pull Request:

1. Go to 'Appearance -> Menus' and put custom class on a menu.
2. Go to 'Forums'
3. Click on 'Inspect element'
4. No class will show on menu

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
