### PR TITLE
#1512 The network search does not adhere to PMPro settings.

### DIFF
--- a/src/bp-search/bp-search-functions.php
+++ b/src/bp-search/bp-search-functions.php
@@ -673,7 +673,7 @@ if ( in_array( 'geo-my-wp/geo-my-wp.php', apply_filters( 'active_plugins', get_o
  *
  * @return array
  */
-function bp_is_post_restricted( $post_id = 0, $user_id = 0, $type = 'post' ) {
+function bp_search_is_post_restricted( $post_id = 0, $user_id = 0, $type = 'post' ) {
 
 	$restricted_post_data = array();
 

--- a/src/bp-templates/bp-nouveau/buddypress/search/loop/forum-ajax.php
+++ b/src/bp-templates/bp-nouveau/buddypress/search/loop/forum-ajax.php
@@ -1,6 +1,6 @@
 <?php
 $total = bbp_get_forum_topic_count( get_the_ID() );
-$result = bp_is_post_restricted( get_the_ID(), get_current_user_id(), 'forum' );
+$result = bp_search_is_post_restricted( get_the_ID(), get_current_user_id(), 'forum' );
 ?>
 <div class="bp-search-ajax-item bp-search-ajax-item_forum">
 	<a href="<?php echo esc_url(add_query_arg( array( 'no_frame' => '1' ), bbp_get_forum_permalink( get_the_ID()) )); ?>">

--- a/src/bp-templates/bp-nouveau/buddypress/search/loop/forum.php
+++ b/src/bp-templates/bp-nouveau/buddypress/search/loop/forum.php
@@ -2,7 +2,7 @@
 $forum_id    = get_the_ID();
 $total_topic = bbp_get_forum_topic_count( $forum_id );
 $total_reply = bbp_get_forum_reply_count( $forum_id );
-$result      = bp_is_post_restricted( $forum_id, get_current_user_id(), 'forum' );
+$result      = bp_search_is_post_restricted( $forum_id, get_current_user_id(), 'forum' );
 ?>
 <li class="bp-search-item bp-search-item_forum">
 	<div class="list-wrap">

--- a/src/bp-templates/bp-nouveau/buddypress/search/loop/post-ajax.php
+++ b/src/bp-templates/bp-nouveau/buddypress/search/loop/post-ajax.php
@@ -1,5 +1,5 @@
 <?php
-$result = bp_is_post_restricted( get_the_ID(), get_current_user_id(), 'post' );
+$result = bp_search_is_post_restricted( get_the_ID(), get_current_user_id(), 'post' );
 ?>
 <div class="bp-search-ajax-item bp-search-ajax-item_post">
 	<a href="<?php echo esc_url(add_query_arg( array( 'no_frame' => '1' ), get_permalink() ));?>">

--- a/src/bp-templates/bp-nouveau/buddypress/search/loop/post.php
+++ b/src/bp-templates/bp-nouveau/buddypress/search/loop/post.php
@@ -1,5 +1,5 @@
 <?php
-$result = bp_is_post_restricted( get_the_ID(), get_current_user_id(), 'post' );
+$result = bp_search_is_post_restricted( get_the_ID(), get_current_user_id(), 'post' );
 ?>
 <li class="bp-search-item bp-search-item_post <?php echo esc_attr( $result['post_class'] ); ?>">
 	<div class="list-wrap">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #312.
Closes #429.

### How to test the changes in this Pull Request:

1. Activate the Paid Membership Pro plugin
2. Restrict some posts and pages for the according to membership level 
3. Search for the things and you will see restricted message

### Proof Screenshots or Video
https://www.loom.com/share/b9c62a547c3445128b476f1f02be602b

<!-- Add proof video or screenshots of what is fixed or added -->

### Note:
I didn't change the raw queries to WordPress queries but I have added the support for the PMPRO in the template as discussed.

### Other information:

* [x] Have you successfully run tests with your changes locally?
