### PR TITLE
T#57720: BB Connections widget tabs not working properly.

### DIFF
--- a/src/bp-friends/bp-friends-widgets.php
+++ b/src/bp-friends/bp-friends-widgets.php
@@ -60,33 +60,19 @@ function bp_core_ajax_widget_friends() {
 			break;
 	}
 	
-	$id     = bp_displayed_user_id();
+	$user_id     = bp_displayed_user_id();
 	
-	global $bp;
-	
-	if ( ! $id ) {
+	if ( ! $user_id ) {
 		
 		// If member widget is putted on other pages then will not get the bp_displayed_user_id so set the bp_loggedin_user_id to bp_displayed_user_id.
-		$id     = bp_loggedin_user_id();
+		$user_id     = bp_loggedin_user_id();
 		
-		// If $id still blank then return.
-		if ( ! $id ) {
-			return;
-		}
-
-		// Set the global $bp->displayed_user variables.
-		$bp->displayed_user->id       = $id;
-		$bp->displayed_user->userdata = bp_core_get_core_userdata( $id );
-		$bp->displayed_user->fullname = isset( $bp->displayed_user->userdata->display_name ) ? $bp->displayed_user->userdata->display_name : '';
-		$bp->displayed_user->domain   = bp_core_get_user_domain( $id );
 	}
 	
-	// If $id still blank then return.
-	if ( ! $id ) {
+	// If $user_id still blank then return.
+	if ( ! $user_id ) {
 		return;
 	}
-
-	$user_id = bp_displayed_user_id();
 
 	$members_args = array(
 		'user_id'         => absint( $user_id ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #356.

### How to test the changes in this Pull Request:

1. Add BB Connections widget to Activity feed on Widgets
2. Try to change tabs on Newest, Active, Popular - the Active tab shows users that are not active

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
