### PR TITLE
Message notification uses the wrong Avatar

### DIFF
--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -745,6 +745,23 @@ function bp_get_message_thread_avatar( $args = '' ) {
 	);
 
 	/**
+	 * For finding who is sender for single recipient
+	 *
+	 */
+	$last_sender_id = $messages_template->thread->last_sender_id;
+	if ( isset( $messages_template->thread->recipients ) ) {
+		$key_msg = [];
+		foreach ( $messages_template->thread->recipients as $key => $value) {
+			$key_msg[] = $key;
+		}
+		
+		if ( count( $key_msg ) == 2 ) {
+			$last_sender_id = $key_msg[0] == bp_loggedin_user_id() ? $key_msg[1] : $key_msg[0];
+		}
+		 
+	}
+
+	/**
 	 * Filters the avatar for the last sender in the current message thread.
 	 *
 	 * @since BuddyPress 1.0.0
@@ -757,7 +774,7 @@ function bp_get_message_thread_avatar( $args = '' ) {
 		'bp_get_message_thread_avatar',
 		bp_core_fetch_avatar(
 			array(
-				'item_id' => $messages_template->thread->last_sender_id,
+				'item_id' => $last_sender_id,
 				'type'    => $r['type'],
 				'alt'     => $r['alt'],
 				'css_id'  => $r['id'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Issue created in theme below link for that.
Closed: #404 

### How to test the changes in this Pull Request:

1. Go to messages
2. Create a message to anybody
3. Check your inbox notification

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->
https://prnt.sc/qepztq

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
