### PR TITLE
Wrong anchor for the notification of a reply forum.

### DIFF
--- a/src/bp-forums/notifications.php
+++ b/src/bp-forums/notifications.php
@@ -49,6 +49,7 @@ function bbp_format_buddypress_notifications( $action, $item_id, $secondary_item
 				array(
 					'action'   => 'bbp_mark_read',
 					'topic_id' => $topic_id,
+					'reply_id' => $item_id,
 				),
 				bbp_get_reply_url( $item_id )
 			),
@@ -132,7 +133,7 @@ function bbp_buddypress_add_notification( $reply_id = 0, $topic_id = 0, $forum_i
 	// Get some reply information
 	$args = array(
 		'user_id'          => $topic_author_id,
-		'item_id'          => $topic_id,
+		'item_id'          => $reply_id,
 		'component_name'   => bbp_get_component_name(),
 		'component_action' => 'bbp_new_reply',
 		'date_notified'    => get_post( $reply_id )->post_date,
@@ -196,8 +197,16 @@ function bbp_buddypress_mark_notifications( $action = '' ) {
 		do_action( 'bbp_notifications_handler', $success, $user_id, $topic_id, $action );
 	}
 
-	// Redirect to the topic
-	$redirect = bbp_get_reply_url( $topic_id );
+	if (
+		!empty( $_GET['reply_id'] )
+		&& get_post_type( (int)$_GET['reply_id'] ) == 'reply'
+	) {
+		// Redirect to the reply
+		$redirect = bbp_get_reply_url( (int) $_GET['reply_id'] );
+	} else {
+		// Redirect to the topic
+		$redirect = bbp_get_reply_url( $topic_id );
+	}
 
 	// Redirect
 	wp_safe_redirect( $redirect );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->
Closes #390.

### Proof Screenshots or Video
https://screencast-o-matic.com/watch/cqlv6Kvryp
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
