### PR TITLE
T58743: First and last name fields still show on the Privacy page even they have been disabled.

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress/members/single/settings/profile.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/settings/profile.php
@@ -40,6 +40,25 @@ bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
 						<?php
 						while ( bp_profile_fields() ) :
 							bp_the_profile_field();
+							
+							// Get the current display settings from BuddyBoss > Settings > Profiles > Display Name Format.
+							$current_value = bp_get_option( 'bp-display-name-format' );
+							
+							// If First Name selected then do not add last name field.
+							if ( 'first_name' === $current_value && bp_get_the_profile_field_id() === bp_xprofile_lastname_field_id() ) {
+								if ( function_exists( 'bp_hide_last_name') && false === bp_hide_last_name() ) {
+									continue;
+								}
+								// If Nick Name selected then do not add first & last name field.
+							} elseif ( 'nickname' === $current_value && bp_get_the_profile_field_id() === bp_xprofile_lastname_field_id() ) {
+								if ( function_exists( 'bp_hide_nickname_last_name') && false === bp_hide_nickname_last_name() ) {
+									continue;
+								}
+							} elseif ( 'nickname' === $current_value && bp_get_the_profile_field_id() === bp_xprofile_firstname_field_id() ) {
+								if ( function_exists( 'bp_hide_nickname_first_name') && false === bp_hide_nickname_first_name() ) {
+									continue;
+								}
+							}
 						?>
 
 							<tr <?php bp_field_css_class(); ?>>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #427.

### How to test the changes in this Pull Request:

1. Set Display Name Format to Nickname
2. Disable First Name and Last Name
3. Save the settings
4. Go to front page and navigate to Account > Privacy page
5. The First name and Last name still shows even they were disabled

### Proof Screenshots or Video

https://www.loom.com/share/8fe6109c79ef457f9d1baaa3ef1f9ad0

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
