### PR TITLE
#479 - forums search without forums slug redirect to home fixed

### DIFF
--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -246,7 +246,7 @@ function bp_core_set_uri_globals() {
 	}
 
 	// Search doesn't have an associated page, so we check for it separately.
-	if ( ! empty( $bp_uri[0] ) && ( bp_get_search_slug() == $bp_uri[0] ) ) {
+	if ( isset( $_POST['search-terms'] ) && ! empty( $bp_uri[0] ) && ( bp_get_search_slug() == $bp_uri[0] ) ) {
 		$matches[]   = 1;
 		$match       = new stdClass();
 		$match->key  = 'search';

--- a/src/bp-forums/classes/class-bbpress.php
+++ b/src/bp-forums/classes/class-bbpress.php
@@ -870,7 +870,7 @@ if ( ! class_exists( 'bbPress' ) ) :
 
 			// Search Permastruct
 			add_permastruct(
-				$user_id,
+				$search_id,
 				$search_slug . '/%' . $search_id . '%',
 				array(
 					'with_front'  => false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #479  .

### How to test the changes in this Pull Request:

1. Go to forums page, enable forum banner.
2. Search for some text on forums page.
3. Press 'Enter' on your keyboard.
4. See error, it redirects to his homepage.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

https://www.loom.com/share/ce8f156e45b1411fbcec43e80ed0c97c

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Forums - Search form in forums redirect to homepage fix when root slug not used
