### PR TITLE
Email Invites - text editor shows LearnDash shortcode icon

### DIFF
--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -4639,28 +4639,21 @@ function bp_allow_user_to_send_invites() {
  *
  * @since BuddyBoss 1.0.0
  *
- * @param array                                              $buttons The WP Editor buttons list.
- * @param array          The filtered WP Editor buttons list.
+ * @param  array $buttons  The WP Editor buttons list.
+ * @return array           The filtered WP Editor buttons list.
  */
 function bp_nouveau_btn_invites_mce_buttons( $buttons = array() ) {
-	$remove_buttons = array(
-		'wp_more',
-		'spellchecker',
-		'wp_adv',
-		'fullscreen',
-		'alignleft',
-		'alignright',
-		'aligncenter',
-		'formatselect',
+	$buttons = array(
+		'bold',
+		'italic',
+		'bullist',
+		'numlist',
+		'blockquote',
+		'link',
 	);
 
-	// Remove unused buttons
-	$buttons = array_diff( $buttons, $remove_buttons );
-
-	// Add the image button
-	// array_push( $buttons, 'image' );
-
-	return $buttons;
+	// Provide extensibility
+	return apply_filters( 'bp_nouveau_btn_invites_mce_buttons', $buttons );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #444.

### How to test the changes in this Pull Request:
Steps to reproduce the behavior:
1. Enable Email Invites component, and enable option to let users customize the email message
2. Enable LearnDash plugin
3. Go to Email Invites screen in your profile
4. You will see a square icon in text editor, hover it and it says "LearnDash Shortcodes".

### Proof Screenshots or Video
http://prntscr.com/qmujg6
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
