### PR TITLE
Messages start date is not correct in messages titlebar

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/messages/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/ajax.php
@@ -120,10 +120,7 @@ function bp_nouveau_ajax_messages_send_message() {
 					'count'         => bp_get_message_thread_total_count(),
 					'date'          => strtotime( bp_get_message_thread_last_post_date_raw() ) * 1000,
 					'display_date'  => bp_nouveau_get_message_date( bp_get_message_thread_last_post_date_raw() ),
-					'started_date'  => date_i18n(
-						get_option( 'date_format' ),
-						strtotime( $messages_template->thread->first_message_date )
-					)
+					'started_date' => bp_nouveau_get_message_date( $messages_template->thread->first_message_date, get_option('date_format') ),
 				);
 
 				if ( is_array( $messages_template->thread->recipients ) ) {
@@ -430,10 +427,7 @@ function bp_nouveau_ajax_get_user_message_threads() {
 			'count'         => bp_get_message_thread_total_count(),
 			'date'          => strtotime( bp_get_message_thread_last_post_date_raw() ) * 1000,
 			'display_date'  => bp_nouveau_get_message_date( bp_get_message_thread_last_post_date_raw() ),
-			'started_date' => date_i18n(
-				get_option('date_format'),
-				strtotime($messages_template->thread->first_message_date)
-			)
+			'started_date' => bp_nouveau_get_message_date( $messages_template->thread->first_message_date, get_option('date_format') ),
 		);
 
 		if ( is_array( $messages_template->thread->recipients ) ) {
@@ -643,10 +637,7 @@ function bp_nouveau_ajax_get_thread_messages() {
 		$thread->thread = array(
 			'id'      => bp_get_the_thread_id(),
 			'subject' => strip_tags( bp_get_the_thread_subject() ),
-			'started_date' => date_i18n(
-				get_option('date_format'),
-				strtotime($thread_template->thread->first_message_date)
-			)
+			'started_date' => bp_nouveau_get_message_date( $thread_template->thread->first_message_date, get_option('date_format') ),
 		);
 
 		if ( is_array( $thread_template->thread->recipients ) ) {

--- a/src/bp-templates/bp-nouveau/includes/messages/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/functions.php
@@ -382,14 +382,14 @@ function bp_nouveau_messages_at_on_tinymce_init( $settings, $editor_id ) {
  *
  * @since BuddyPress 3.0.0
  */
-function bp_nouveau_get_message_date( $date ) {
+function bp_nouveau_get_message_date( $date, $date_format = '' ) {
 	$now  = bp_core_current_time( true, 'timestamp' );
 	$date = strtotime( $date );
 
 	$now_date    = getdate( $now );
 	$date_date   = getdate( $date );
 	$compare     = array_diff( $date_date, $now_date );
-	$date_format = 'Y/m/d';
+	// $date_format = 'Y/m/d';
 
 	// Use Timezone string if set.
 	$timezone_string = bp_get_option( 'timezone_string' );
@@ -414,7 +414,9 @@ function bp_nouveau_get_message_date( $date ) {
 	// 	$date_format = 'M j';
 	// }
 
-	$date_format = 'M j';
+	if ( empty( $date_format ) ) {
+		$date_format = 'M j';
+	}
 
 	/**
 	 * Filters the message date for BuddyPress Nouveau display.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Video explanation:
https://www.loom.com/share/83f3b42f44f04b988e3d094be88f655e

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #475.

### How to test the changes in this Pull Request:

1. Compose a message.
2. View the time in title bar vs left.
3. See error

### Proof Screenshots or Video
http://prntscr.com/qmzupk
http://prntscr.com/qmzux4

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->