### PR TITLE
Cannot comment on the forum, discussion, and replies in the activity  stream

### DIFF
--- a/src/bp-forums/activity.php
+++ b/src/bp-forums/activity.php
@@ -304,9 +304,7 @@ if ( ! class_exists( 'BBP_BuddyPress_Activity' ) ) :
 			}
 
 			// Check if blog & forum activity stream commenting is off
-			// Commented below from the condition because getting bool value
-			// ( false === $activities_template->disable_blogforum_replies )
-			if ( !empty( (int) $activities_template->disable_blogforum_replies ) ) {
+			if ( !empty( $activities_template->disable_blogforum_replies ) ) {
 
 				// Get the current action name
 				$action_name = bp_get_activity_action_name();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #476 

Closes #467 

Closes #537

### How to test the changes in this Pull Request:

1. Go to 'Buddyboss >> Setting >> Activity >> Post Comment Section
2. Enable the post comment.
3. Now open any forum or discussion and reply.
4. Go to the sitewide activity page and you will see the activity post there but no way to comment on it.

### Proof Screenshots or Video

https://www.loom.com/share/99453f18e504434eb431c51fd2545e0a

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
