### PR TITLE
MemberPress rule are not working for Members pages and New activity Feed Page

### DIFF
--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -398,4 +398,4 @@ function bp_core_memberpress_the_content( $content ) {
 
 	return $content;
 }
-add_filter( 'the_content', 'bb_memberpress_the_content', 999 );
+add_filter( 'the_content', 'bp_core_memberpress_the_content', 999 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #474.

### How to test the changes in this Pull Request:

1. Create a Membership
2. Set rules for BuddyPress page restriction.
3. Register for this Membership.
4. BuddyPress pages are not-accessible.

### Proof Screenshots or Video
https://screencast-o-matic.com/watch/cYV2iavk8Z

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->