### PR TITLE
Setting up "Photos" on user's profile page results into 404 error.

### DIFF
--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -250,6 +250,13 @@ class BP_Members_Component extends BP_Component {
 		}
 		$default_tab = bp_is_active( $default_tab ) ? $default_tab : 'profile';
 
+		/**
+		 * - Enable Photos as default user profile page.
+		 */
+		if ( 'media' === $default_tab ) {
+			$default_tab = 'photos';
+		}
+
 		$bp->default_component = apply_filters( 'bp_member_default_component', ( '' === $default_tab ) ? $bp->default_component : $default_tab );
 
 		/** Canonical Component Stack ****************************************


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #499.

### How to test the changes in this Pull Request:

1. Go to 'Dashboard > Appearance > Customize > BuddyBoss Platform > profile navigation'
2. Set "Photos" as the default tab
3. Go to user's profile page on the front end and visit the photos tab
4. See error

### Proof Screenshots or Video
http://prntscr.com/qq7ca5
http://prntscr.com/qq7cgi

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
