### PR TITLE
Latest Activities widget is not working when Activity Type is set to Group Updates

### DIFF
--- a/src/bp-groups/bp-groups-activity.php
+++ b/src/bp-groups/bp-groups-activity.php
@@ -532,9 +532,13 @@ function bp_groups_group_details_updated_add_activity( $group_id, $old_group, $n
 	}
 
 	// If the admin has opted not to notify members, don't post an activity item either.
-	if ( empty( $notify_members ) ) {
-		return;
-	}
+	/*
+	 * Commented cause If user not selected "Notify group members of these changes via email" option 
+	 * that time activity should show in the activity area and widget area
+	 */
+	//if ( empty( $notify_members ) ) {
+	//	return;
+	//}
 
 	$group = groups_get_group(
 		array(


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #488 .

### How to test the changes in this Pull Request:

1. Go to Appearance > Widgets
2. Use (BB) Latest Activities widget
3. set activity type to Group Updates
4. Browse to the front end to check

### Proof Screenshots or Video

https://www.loom.com/share/ab62047376e84bb59b5a88683d5f6e6e

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
