### PR TITLE
Fix forum desc field missing issue

### DIFF
--- a/src/bp-groups/bp-groups-activity.php
+++ b/src/bp-groups/bp-groups-activity.php
@@ -532,13 +532,9 @@ function bp_groups_group_details_updated_add_activity( $group_id, $old_group, $n
 	}
 
 	// If the admin has opted not to notify members, don't post an activity item either.
-	/*
-	 * Commented cause If user not selected "Notify group members of these changes via email" option 
-	 * that time activity should show in the activity area and widget area
-	 */
-	//if ( empty( $notify_members ) ) {
-	//	return;
-	//}
+	if ( empty( $notify_members ) ) {
+		return;
+	}
 
 	$group = groups_get_group(
 		array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #505 .

### How to test the changes in this Pull Request:

1. Go to 'Admin Dashboard >> Pages >> Add New'
2. Add this [bbp-forum-form] shortcode using Gutenburg or Elementor and publish the page.
3. View the page and see the error.

### Proof Screenshots or Video

https://www.loom.com/share/c7d680b16a1846c2abe177651a829eba

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
