### PR TITLE
Repair function for bp_groups_get_group_roles() in BB Platform

### DIFF
--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -1180,7 +1180,7 @@ function groups_avatar_upload_dir( $group_id = 0 ) {
 /**
  * Get the Group roles.
  *
- * @since BuddyPress 5.0.0
+ * @since BuddyBoss 1.2.5
  *
  * @return array The list of Group role objects.
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In BuddyPress 5.0 they edited code related to Group Memberships and Invites, to use the API. Platform does not have this code. The API is needed that function.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #517 .

### How to test the changes in this Pull Request:

1. Activate BuddyBoss Platform API plugin.
2. Activate BuddyBoss Platform.
3. Add this to your site URL /wp-json/buddypress/v1/friends

### Proof Screenshots or Video
http://prntscr.com/qs3vjn

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->