### PR TITLE
Unsubscribe in email redirects to email preferences

### DIFF
--- a/src/bp-forums/common/functions.php
+++ b/src/bp-forums/common/functions.php
@@ -1158,6 +1158,7 @@ function bbp_notify_topic_subscribers( $reply_id = 0, $topic_id = 0, $forum_id =
 			'reply.url'        => $reply_url,
 			'reply.content'    => $reply_content,
 			'poster.name'      => $reply_author_name,
+			'unsubscribe'      => $topic_url,
 		),
 	);
 
@@ -1281,6 +1282,7 @@ function bbp_notify_forum_subscribers( $topic_id = 0, $forum_id = 0, $anonymous_
 			'discussion.url'     => $topic_url,
 			'discussion.content' => $topic_content,
 			'poster.name'        => $topic_author_name,
+			'unsubscribe'        => $forum_url,
 		),
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When clicking the unsubscribe link, it redirects to Email Preferences and no unsubscribe button is seen. User must find the forums to click unsubscribe.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #536.

### How to test the changes in this Pull Request:

1. As a subscriber, go to a forum discussion and subscribe to it
2. Add new replies/topics to that discussion so that you will be notified about the discussion
3. Check your email, click on the Unsubscribe link on the message.
4. You will be redirected to "Email Preferences" instead of unsubscribing to that forum discussion

### Proof Screenshots or Video
http://somup.com/cYnejEh1Iw

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->