### PR TITLE
Warning are thrown while creating a site on a network when the platform plugin is active on WP multisite network.

### DIFF
--- a/src/bp-core/bp-core-wp-emails.php
+++ b/src/bp-core/bp-core-wp-emails.php
@@ -1270,11 +1270,11 @@ if ( ! function_exists( 'bp_email_newblog_notify_siteadmin' ) ) {
 		$siteurl          = site_url();
 		restore_current_blog();
 
-		/* translators: New site notification email. 1: Site URL, 2: User IP address, 3: Settings screen URL */
-		$msg  = '<p>' . sprintf( __( 'New Site: %1$s', 'buddyboss' ), $blogname ) . '</p>';
-		$msg .= '<p>' . sprintf( __( 'URL: %2$s', 'buddyboss' ), $siteurl ) . '</p>';
-		$msg .= '<p>' . sprintf( __( 'Remote IP address: %3$s', 'buddyboss' ), wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) . '</p>';
-		$msg .= '<p>' . sprintf( __( 'Disable these notifications: %4$s', 'buddyboss' ), $options_site_url ) . '</p>';
+		/* translators: New site notification email. */
+		$msg  = '<p>' . sprintf( __( 'New Site: %s', 'buddyboss' ), $blogname ) . '</p>';
+		$msg .= '<p>' . sprintf( __( 'URL: %s', 'buddyboss' ), $siteurl ) . '</p>';
+		$msg .= '<p>' . sprintf( __( 'Remote IP address: %s', 'buddyboss' ), wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) . '</p>';
+		$msg .= '<p>' . sprintf( __( 'Disable these notifications:%s', 'buddyboss' ), $options_site_url ) . '</p>';
 
 		add_filter( 'wp_mail_content_type', 'bp_email_set_content_type' ); // add this to support html in email
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [BuddyBoss Contributing guideline](https://github.com/buddyboss/buddyboss-platform/blob/dev/contributing.md)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
It should not throw warnings and works fine without issues.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #535.

### How to test the changes in this Pull Request:

1. Go to Network Dashboard > Sites > Add new (make sure the Platform plugin is active on a network)
2. Add a new site
3. See error

### Proof Screenshots or Video
Before: 
- http://prntscr.com/qwrh1g
- http://prntscr.com/qwrhxq

After:
- http://prntscr.com/qwrioa

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
