### PR TITLE
Wrong link in message notification when LearnDash is activated with WPML 

### DIFF
--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -97,6 +97,21 @@ function bp_helper_plugins_loaded_callback() {
 		}
 
 		add_action( 'parse_query', 'bp_core_fix_wpml_redirection', 5 );
+
+		/**
+		 * Fix for url with wpml
+		 *
+		 * @since BuddyBoss 1.2.6
+		 *
+		 * @param $url
+		 * @return string
+		 */
+		function bp_core_wpml_fix_get_root_domain( $url ) {
+			return untrailingslashit( $url );
+		}
+
+		add_filter( 'bp_core_get_root_domain', 'bp_core_wpml_fix_get_root_domain' );
+
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #534 

### How to test the changes in this Pull Request:

1. Setup WPML make sure that the Language URL Format is set to Different languages directories
2. Go to the front end and click any message notification
3. Will redirect on a blank messages page

### Proof Screenshots or Video
http://prntscr.com/qyg8bc
http://prntscr.com/qyg8lz
http://prntscr.com/qyg8vl

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->