### PR TITLE
Group Names with & symbol displays html equivalent &amp;

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -442,7 +442,7 @@ function bp_nouveau_prepare_group_for_js( $item ) {
 
 	return array(
 		'id'          => $item->id,
-		'name'        => $item->name,
+		'name'        => wp_specialchars_decode( $item->name ),
 		'avatar_url'  => $item_avatar_url,
 		'object_type' => 'group',
 		'is_public'   => ( 'public' === $item->status ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #550 

### How to test the changes in this Pull Request:

1. Create a New Group with & symbol on the name (eg: Test & Group)
2. Go to Activity Page
3. Select Post in: Group option
4. Type in the group name

### Proof Screenshots or Video
http://prntscr.com/qyy89u
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->