### PR TITLE
Fix #562 Xprofile dropdown field new options not saving after certain options

### DIFF
--- a/src/bp-xprofile/bp-xprofile-admin.php
+++ b/src/bp-xprofile/bp-xprofile-admin.php
@@ -528,7 +528,7 @@ function xprofile_admin_manage_field( $group_id, $field_id = null ) {
 	if ( isset( $_POST['saveField'] ) ) {
 
 		// Check nonce
-		check_admin_referer( 'bp_xprofile_admin_field', 'bp_xprofile_admin_field' );
+		wp_verify_nonce( $_POST['bp_xprofile_admin_field'], 'bp_xprofile_admin_field' );
 
 		if ( BP_XProfile_Field::admin_validate() ) {
 			$field->is_required = $_POST['required'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [ ] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #562 .

### How to test the changes in this Pull Request:

1. Mentioned in issue in #562 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
