### PR TITLE
When 'Post formatting' is unselected in forum settings, the forum reply pop up doesn't work.

### DIFF
--- a/src/bp-forums/templates/default/bbpress-functions.php
+++ b/src/bp-forums/templates/default/bbpress-functions.php
@@ -151,12 +151,13 @@ if ( ! class_exists( 'BBP_Default' ) ) :
 				wp_enqueue_script( 'bp-medium-editor' );
 				wp_enqueue_style( 'bp-medium-editor' );
 				wp_enqueue_style( 'bp-medium-editor-beagle' );
-				wp_enqueue_script( 'bp-select2' );
-				if ( wp_script_is( 'bp-select2-local', 'registered' ) ) {
-					wp_enqueue_script( 'bp-select2-local' );
-				}
-				wp_enqueue_style( 'bp-select2' );
 			}
+
+			wp_enqueue_script( 'bp-select2' );
+			if ( wp_script_is( 'bp-select2-local', 'registered' ) ) {
+				wp_enqueue_script( 'bp-select2-local' );
+			}
+			wp_enqueue_style( 'bp-select2' );
 
 			// Forum-specific scripts
 			if ( bbp_is_single_forum() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #577 

### How to test the changes in this Pull Request:

1. Go to Buddyboss -> Settings -> forums
2. Disable the 'Post formatting'.
3. Go to forums.
4. Click on 'New discussion' (doesn't work.)
5. Go to discussion, click on 'reply'

### Proof Screenshots or Video
http://somup.com/cYnqhzhqyj
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
