### PR TITLE
Reply to link fix on My Replies page

### DIFF
--- a/src/bp-forums/replies/template.php
+++ b/src/bp-forums/replies/template.php
@@ -1225,7 +1225,7 @@ function bbp_get_reply_author_link( $args = '' ) {
 		),
 		'get_reply_author_link'
 	);
-	
+
 	// Default return value
 	$author_link = '';
 
@@ -1694,7 +1694,7 @@ function bbp_get_reply_to_link( $args = array() ) {
 
 	// Build the URI and return value
 	$uri = remove_query_arg( array( 'bbp_reply_to' ) );
-	$uri = add_query_arg( array( 'bbp_reply_to' => $reply->ID ) );
+	$uri = add_query_arg( array( 'bbp_reply_to' => $reply->ID ), bbp_get_topic_permalink( bbp_get_reply_topic_id( $reply->ID ) ) );
 	$uri = wp_nonce_url( $uri, 'respond_id_' . $reply->ID );
 	$uri = $uri . '#new-post';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

It will change the url of reply to links according to topic permalink on all the pages on site.

Fixes #583  .
Theme PR https://github.com/buddyboss/buddyboss-theme/pull/476

### How to test the changes in this Pull Request:

1. Log in to an account
2. In the profile dropdown, go to forum > My replies
3. using the "three dots" click on reply to any of your previous replies
4. There is an overlay on the page (opacity) but the modal to write reply is not displayed

### Proof Screenshots or Video

https://www.loom.com/share/a2b0ffb96fa2460cac93966df0164e9a

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Replies - Reply link on My Replies page fixed.
