### PR TITLE
#637 Fix Member Type orderby issue

### DIFF
--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -3263,31 +3263,34 @@ if ( true === bp_disable_group_type_creation() ) {
  * @since BuddyBoss 1.0.0
  */
 function bp_register_active_group_types() {
+	$group_type_ids = bp_get_active_group_types();
 
-	$post_ids = bp_get_active_group_types();
+	if ( ! empty( $group_type_ids ) ) {
 
-	// build to register the group type
-	$group_types = array();
-
-	foreach ( $post_ids as $post_id ) {
-
-		$name          = get_post_meta( $post_id, '_bp_group_type_label_name', true );
-		$key           = get_post_meta( $post_id, '_bp_group_type_key', true );
-		$singular_name = get_post_meta( $post_id, '_bp_group_type_label_singular_name', true );
+		// Get all registered group types in BP.
 		$group_types   = bp_groups_get_group_types();
-		if ( ! in_array( $singular_name, $group_types, true ) ) {
-			$temp = array(
-				'labels'                => array(
-					'name'          => $name,
-					'singular_name' => $singular_name,
-				),
-				'has_directory'         => strtolower( $name ),
-				'show_in_create_screen' => true,
-				'show_in_list'          => true,
-				'description'           => '',
-				'create_screen_checked' => false,
-			);
-			bp_groups_register_group_type( $key, $temp );
+
+		foreach ( $group_type_ids as $group_type_id ) {
+			$name          = get_post_meta( $group_type_id, '_bp_group_type_label_name', true );
+			$key           = get_post_meta( $group_type_id, '_bp_group_type_key', true );
+			$singular_name = get_post_meta( $group_type_id, '_bp_group_type_label_singular_name', true );
+
+			if ( ! in_array( $singular_name, $group_types, true ) ) {
+				$temp = array(
+					'labels'                => array(
+						'name'          => $name,
+						'singular_name' => $singular_name,
+					),
+					'has_directory'         => strtolower( $name ),
+					'show_in_create_screen' => true,
+					'show_in_list'          => true,
+					'description'           => '',
+					'create_screen_checked' => false,
+				);
+
+				// Register group type.
+				bp_groups_register_group_type( $key, $temp );
+			}
 		}
 	}
 }

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -3216,21 +3216,29 @@ function bp_group_get_group_type_key( $post_id ) {
  * Get all active group types.
  *
  * @since BuddyBoss 1.0.0
+ * @param array $args Arguments
  *
- * @return type array
+ * @return array Group types
  */
-function bp_get_active_group_types() {
-	$query = new WP_Query(
-		array(
-			'posts_per_page' => -1,
-			'post_type'      => bp_groups_get_group_type_post_type(),
-			'post_status'    => 'publish',
-			'fields'         => 'ids',
-			'orderby'        => 'menu_order',
-		)
-	);
+function bp_get_active_group_types( $args = array() ) {
+	$bp_active_group_types = array();
 
-	return $query->posts;
+	$args = bp_parse_args( $args, array(
+		'posts_per_page' => - 1,
+		'post_type'      => bp_groups_get_group_type_post_type(),
+		'orderby'        => 'menu_order',
+		'order'          => 'ASC',
+		'fields'         => 'ids'
+	), 'group_types' );
+
+	$bp_active_group_types_query = new \WP_Query( $args );
+
+	if ( $bp_active_group_types_query->have_posts() ) {
+		$bp_active_group_types = $bp_active_group_types_query->posts;
+	}
+	wp_reset_postdata();
+
+	return apply_filters( 'bp_get_active_group_types', $bp_active_group_types );
 }
 
 if ( true === bp_disable_group_type_creation() ) {
@@ -3257,9 +3265,6 @@ if ( true === bp_disable_group_type_creation() ) {
 function bp_register_active_group_types() {
 
 	$post_ids = bp_get_active_group_types();
-
-	// update meta cache to avoid multiple db calls
-	update_meta_cache( 'post', $post_ids );
 
 	// build to register the group type
 	$group_types = array();

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -3316,8 +3316,9 @@ function bp_get_active_member_types( $force_refresh = false ) {
 	if ( true === $force_refresh || false === $bp_active_member_types ) {
 
 		global $wpdb;
-		$query                  = "SELECT DISTINCT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_status = %s ORDER BY menu_order";
-		$bp_active_member_types = $wpdb->get_col( $wpdb->prepare( $query, bp_get_member_type_post_type(), 'publish' ) );
+		$member_type_order_by   = apply_filters( 'member_type_order_by', "menu_order" );
+		$query                  = "SELECT DISTINCT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_status = %s ORDER BY {$member_type_order_by}";
+		$bp_active_member_types = $wpdb->get_col( $wpdb->prepare( $query, bp_get_member_type_post_type(), 'publish' ) ); // db call ok; no-cache ok;
 
 		// Cache the whole WP_Query object in the cache and store it for 5 minutes (300 secs).
 		wp_cache_set( 'bp_active_member_types', $bp_active_member_types, 'active_member_types', 5 * MINUTE_IN_SECONDS );

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -3409,37 +3409,30 @@ function bp_get_users_of_removed_member_types() {
  * @since BuddyBoss 1.0.0
  */
 function bp_register_active_member_types() {
+	$member_type_ids = bp_get_active_member_types(
+		array(
+			'meta_query' => array(
+				array(
+					'key'   => '_bp_member_type_enable_filter',
+					'value' => 1,
+				),
+			)
+		)
+	);
 
-	$post_ids = bp_get_active_member_types();
+	if ( ! empty( $member_type_ids ) ) {
 
-	// update meta cache to avoid multiple db calls
-	update_meta_cache( 'post', $post_ids );
-	// build to register the memebr type
-	$member_types = array();
+		foreach ( $member_type_ids as $member_type_id ) {
+			$key = bp_get_member_type_key( $member_type_id );
 
-	foreach ( $post_ids as $post_id ) {
-
-		$key = bp_get_member_type_key( $post_id );
-
-		$enable_filter = get_post_meta( $post_id, '_bp_member_type_enable_filter', true );
-
-		$has_dir = false;
-
-		if ( $enable_filter ) {
-			$has_dir = true;
+			bp_register_member_type( $key, array(
+				'labels'        => array(
+					'name'          => get_post_meta( $member_type_id, '_bp_member_type_label_name', true ),
+					'singular_name' => get_post_meta( $member_type_id, '_bp_member_type_label_singular_name', true ),
+				),
+				'has_directory' => true,
+			) );
 		}
-
-		$member_types[ $key ] = array(
-			'labels'        => array(
-				'name'          => get_post_meta( $post_id, '_bp_member_type_label_name', true ),
-				'singular_name' => get_post_meta( $post_id, '_bp_member_type_label_singular_name', true ),
-			),
-			'has_directory' => $has_dir,
-		);
-	}
-
-	foreach ( $member_types as $member_type => $args ) {
-		bp_register_member_type( $member_type, $args );
 	}
 }
 

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -3304,22 +3304,22 @@ function bp_member_type_by_type( $type_id ) {
  *
  * @since BuddyBoss 1.0.0
  *
+ * @param array $args Arguments
+ *
  * @return array Member types
  */
-function bp_get_active_member_types() {
+function bp_get_active_member_types( $args = array() ) {
 	$bp_active_member_types = array();
 
-	$bp_active_member_types_query = new \WP_Query(
-		apply_filters( 'bp_get_active_member_types_args',
-			array(
-				'posts_per_page' => - 1,
-				'post_type'      => bp_get_member_type_post_type(),
-				'orderby'        => 'menu_order',
-				'order'          => 'ASC',
-				'fields'         => 'ids'
-			)
-		)
-	);
+	$args = bp_parse_args( $args, array(
+		'posts_per_page' => - 1,
+		'post_type'      => bp_get_member_type_post_type(),
+		'orderby'        => 'menu_order',
+		'order'          => 'ASC',
+		'fields'         => 'ids'
+	), 'member_types' );
+
+	$bp_active_member_types_query = new \WP_Query( $args );
 
 	if ( $bp_active_member_types_query->have_posts() ) {
 		$bp_active_member_types = $bp_active_member_types_query->posts;

--- a/src/bp-templates/bp-nouveau/buddypress/common/filters/group-filters.php
+++ b/src/bp-templates/bp-nouveau/buddypress/common/filters/group-filters.php
@@ -13,40 +13,35 @@ if ( false === bp_disable_group_type_creation() ) {
 	return '';
 }
 
-$group_types = bp_get_active_group_types();
-$display_arr = array();
-foreach ( $group_types as $group_type_id ) {
+// Get active group types
+$group_types = bp_get_active_group_types(
+	array(
+		'meta_query' => array(
+			array(
+				'key'   => '_bp_group_type_enable_filter',
+				'value' => 1,
+			),
+		)
+	)
+);
 
-	if ( !get_post_meta( $group_type_id, '_bp_group_type_enable_filter', true ) ) {
-		continue;
-	}
-
-	$group_key        = bp_group_get_group_type_key( $group_type_id );
-	$group_type_label = bp_groups_get_group_type_object( $group_key )->labels['name'];
-
-
-	if ( !empty( $group_key ) ) {
-		$display_arr[] = array(
-			'group_type_label' => $group_type_label,
-			'group_type_name' => $group_key,
-		);
-	}
-
-}
-
-if ( isset( $display_arr ) && !empty( $display_arr )) {
+if ( ! empty( $group_types ) ) {
 	?>
 	<div id="group-type-filters" class="component-filters clearfix">
 		<div id="group-type-select" class="last filter">
 			<label class="bp-screen-reader-text" for="group-type-order-by">
-				<span ><?php bp_nouveau_filter_label(); ?></span>
+				<span><?php bp_nouveau_filter_label(); ?></span>
 			</label>
 			<div class="select-wrap">
-				<select id="group-type-order-by" data-bp-group-type-filter="<?php bp_nouveau_search_object_data_attr() ?>">
+				<select id="group-type-order-by"
+				        data-bp-group-type-filter="<?php bp_nouveau_search_object_data_attr() ?>">
 					<option value=""><?php _e( 'All Types', 'buddyboss' ); ?></option><?php
-					foreach ( $display_arr as $group ) {
+					foreach ( $group_types as $group_type_id ) {
+						$group_type_key   = bp_group_get_group_type_key( $group_type_id );
+						$group_type_label = bp_groups_get_group_type_object( $group_type_key )->labels['name'];
 						?>
-						<option value="<?php echo $group['group_type_name']; ?>"><?php echo $group['group_type_label']; ?></option><?php
+						<option
+						value="<?php echo esc_attr( $group_type_key ); ?>"><?php echo esc_attr( $group_type_label ); ?></option><?php
 					}
 					?>
 				</select>

--- a/src/bp-templates/bp-nouveau/buddypress/common/filters/member-filters.php
+++ b/src/bp-templates/bp-nouveau/buddypress/common/filters/member-filters.php
@@ -12,41 +12,34 @@ if ( false === $is_member_type_enabled ) {
 	return '';
 }
 
-$member_types = bp_get_active_member_types();
-$display_arr  = array();
+// Get active member types
+$member_types = bp_get_active_member_types(
+	array(
+		'meta_query' => array(
+			array(
+				'key'     => '_bp_member_type_enable_filter',
+				'value'   => 1,
+			),
+		)
+	)
+);
 
-foreach ( $member_types as $member_type_id ) {
-
-	if ( !get_post_meta( $member_type_id, '_bp_member_type_enable_filter', true ) ) {
-		continue;
-	}
-
-	$type_name        = bp_get_member_type_key( $member_type_id );
-	$type_id          = bp_member_type_term_taxonomy_id( $type_name );
-	$member_type_name = get_post_meta( $member_type_id, '_bp_member_type_label_singular_name', true );
-
-	$display_arr[] = array(
-		'id'             => $type_id,
-		'member_type_id' => $member_type_id,
-		'name'           => $member_type_name,
-	);
-
-}
-
-if ( isset( $display_arr ) && !empty( $display_arr )) {
+if ( ! empty( $member_types ) ) {
 	?>
 	<div id="member-type-filters" class="component-filters clearfix">
 		<div id="member-type-select" class="last filter">
 			<label class="bp-screen-reader-text" for="member-type-order-by">
-				<span ><?php bp_nouveau_filter_label(); ?></span>
+				<span><?php bp_nouveau_filter_label(); ?></span>
 			</label>
 			<div class="select-wrap">
 				<select id="member-type-order-by" data-bp-member-type-filter="members">
 					<option value=""><?php _e( 'All Types', 'buddyboss' ); ?></option><?php
-					foreach ( $display_arr as $member ) {
+					foreach ( $member_types as $member_type_id ) {
+						$type_name        = bp_get_member_type_key( $member_type_id );
+						$member_type_name = get_post_meta( $member_type_id, '_bp_member_type_label_singular_name', true );
 						?>
-						<option value="<?php echo $member['member_type_id']; ?>">
-							<?php echo $member['name']; ?>
+						<option value="<?php echo esc_attr( $member_type_id ); ?>">
+							<?php echo esc_attr( $member_type_name ); ?>
 						</option>
 						<?php
 					}

--- a/src/bp-templates/bp-nouveau/buddypress/common/filters/member-filters.php
+++ b/src/bp-templates/bp-nouveau/buddypress/common/filters/member-filters.php
@@ -4,9 +4,6 @@
  *
  * @since BuddyBoss 1.0.0
  */
-?>
-
-<?php
 
 // Check profile type enable?
 $is_member_type_enabled = bp_member_type_enable_disable();
@@ -16,7 +13,8 @@ if ( false === $is_member_type_enabled ) {
 }
 
 $member_types = bp_get_active_member_types();
-$display_arr = array();
+$display_arr  = array();
+
 foreach ( $member_types as $member_type_id ) {
 
 	if ( !get_post_meta( $member_type_id, '_bp_member_type_enable_filter', true ) ) {
@@ -28,9 +26,9 @@ foreach ( $member_types as $member_type_id ) {
 	$member_type_name = get_post_meta( $member_type_id, '_bp_member_type_label_singular_name', true );
 
 	$display_arr[] = array(
-		'id' => $type_id,
+		'id'             => $type_id,
 		'member_type_id' => $member_type_id,
-		'name' => $member_type_name,
+		'name'           => $member_type_name,
 	);
 
 }

--- a/src/bp-xprofile/classes/class-bp-xprofile-field-type-member-types.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field-type-member-types.php
@@ -176,14 +176,16 @@ class BP_XProfile_Field_Type_Member_Types extends BP_XProfile_Field_Type {
 		}
 
 		// Get posts of custom post type selected.
-		$posts = new \WP_Query(
+		$member_type_order_by = apply_filters( 'member_type_order_by', 'menu_order' );
+		$posts                = new \WP_Query(
 			array(
 				'posts_per_page' => - 1,
 				'post_type'      => bp_get_member_type_post_type(),
 				'orderby'        => 'title',
-				'order'          => 'ASC',
+				'order'          => $member_type_order_by,
 			)
 		);
+
 		if ( $posts ) {
 
 			$html .= '<option value="">' . /* translators: no option picked in select box */ esc_html__( '----', 'buddyboss' ) . '</option>';

--- a/src/bp-xprofile/classes/class-bp-xprofile-field-type-member-types.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field-type-member-types.php
@@ -175,29 +175,21 @@ class BP_XProfile_Field_Type_Member_Types extends BP_XProfile_Field_Type {
 			}
 		}
 
-		// Get posts of custom post type selected.
-		$member_type_order_by = apply_filters( 'member_type_order_by', 'menu_order' );
-		$posts                = new \WP_Query(
-			array(
-				'posts_per_page' => - 1,
-				'post_type'      => bp_get_member_type_post_type(),
-				'orderby'        => 'title',
-				'order'          => $member_type_order_by,
-			)
-		);
+		// Get all active member types.
+		$bp_active_member_types = bp_get_active_member_types();
 
-		if ( $posts ) {
+		if ( ! empty( $bp_active_member_types ) ) {
 
 			$html .= '<option value="">' . /* translators: no option picked in select box */ esc_html__( '----', 'buddyboss' ) . '</option>';
 
-			foreach ( $posts->posts as $post ) {
-				$enabled = get_post_meta( $post->ID, '_bp_member_type_enable_profile_field', true );
-				$name    = get_post_meta( $post->ID, '_bp_member_type_label_singular_name', true );
+			foreach ( $bp_active_member_types as $bp_active_member_type ) {
+				$enabled = get_post_meta( $bp_active_member_type, '_bp_member_type_enable_profile_field', true );
+				$name    = get_post_meta( $bp_active_member_type, '_bp_member_type_label_singular_name', true );
 				if ( '' === $enabled || '1' === $enabled ) {
 					$html .= sprintf(
 						'<option value="%s" %s>%s</option>',
-						$post->ID,
-						( $post_selected == $post->ID ) ? ' selected="selected"' : '',
+						$bp_active_member_type,
+						( $post_selected == $bp_active_member_type ) ? ' selected="selected"' : '',
 						$name
 					);
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #637  .

### How to test the changes in this Pull Request:

1. Create Profile Types samples, ex: Profile Type A, Profile Type B, Profile Type C

> 2a. On Profile Type B, set the Post Attribute to 0
> 2b. On Profile Type A, set the Post Attribute to 1
> 2b. On Profile Type C, set the Post Attribute to 2

2. On Frontend, the dropdown is not following the Post Attribute ordering

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Profile Types ordering - Post Attribute not working
