### PR TITLE
Forum - "Time Limit" settings are not working fix

### DIFF
--- a/src/bp-forums/replies/functions.php
+++ b/src/bp-forums/replies/functions.php
@@ -650,6 +650,11 @@ function bbp_edit_reply_handler( $action = '' ) {
 		bbp_add_error( 'bbp_reply_blacklist', __( '<strong>ERROR</strong>: Your reply cannot be edited at this time.', 'buddyboss' ) );
 	}
 
+	// Reply past edit lock checking.
+	if ( ! current_user_can( 'edit_others_replies' ) && bbp_past_edit_lock( $reply->post_date_gmt ) ) {
+		bbp_add_error( 'bbp_reply_edit_lock', __( '<strong>ERROR</strong>: Your reply cannot be edited now.', 'buddyboss' ) );
+	}
+
 	/** Reply Status */
 
 	// Maybe put into moderation

--- a/src/bp-forums/templates/default/bbpress/form-reply.php
+++ b/src/bp-forums/templates/default/bbpress/form-reply.php
@@ -20,7 +20,7 @@
 
 	<div id="new-reply-<?php bbp_topic_id(); ?>" class="bbp-reply-form">
 
-		<form id="new-post" name="new-post" method="post" action="<?php the_permalink(); ?>">
+		<form id="new-post" name="new-post" method="post" action="<?php bbp_is_reply_edit() ? bbp_reply_edit_url() : the_permalink(); ?>">
 
 			<?php do_action( 'bbp_theme_before_reply_form' ); ?>
 

--- a/src/bp-forums/templates/default/bbpress/form-topic.php
+++ b/src/bp-forums/templates/default/bbpress/form-topic.php
@@ -26,7 +26,7 @@
 
 	<div id="new-topic-<?php bbp_topic_id(); ?>" class="bbp-topic-form">
 
-		<form id="new-post" name="new-post" method="post" action="<?php the_permalink(); ?>">
+		<form id="new-post" name="new-post" method="post" action="<?php bbp_is_topic_edit() ? bbp_topic_edit_url() : the_permalink(); ?>">
 
 			<?php do_action( 'bbp_theme_before_topic_form' ); ?>
 

--- a/src/bp-forums/topics/functions.php
+++ b/src/bp-forums/topics/functions.php
@@ -638,6 +638,11 @@ function bbp_edit_topic_handler( $action = '' ) {
 		bbp_add_error( 'bbp_topic_blacklist', __( '<strong>ERROR</strong>: Your discussion cannot be edited at this time.', 'buddyboss' ) );
 	}
 
+	// Topic past edit lock checking.
+	if ( ! current_user_can( 'edit_others_topics' ) && bbp_past_edit_lock( $topic->post_date_gmt ) ) {
+		bbp_add_error( 'bbp_reply_edit_lock', __( '<strong>ERROR</strong>: Your reply cannot be edited now.', 'buddyboss' ) );
+	}
+
 	/** Topic Status */
 
 	// Maybe put into moderation


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #654  .

### How to test the changes in this Pull Request:

1. Go to 'BuddyBoss > Settings > Forums > Set time limit settings'
2. Create one reply to any discussion in the front end
3. Wait for 5 minutes(the time you set in the backend) and try to edit the reply
4. See error

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Forums - Show errors on edit forms when edit is locked.
