### PR TITLE
More button on friends widget fix

### DIFF
--- a/src/bp-friends/classes/class-bp-core-friends-widget.php
+++ b/src/bp-friends/classes/class-bp-core-friends-widget.php
@@ -115,7 +115,7 @@ class BP_Core_Friends_Widget extends WP_Widget {
 		$members_args = array(
 			'user_id'         => absint( $user_id ),
 			'type'            => sanitize_text_field( $instance['friend_default'] ),
-			'max'             => absint( $instance['max_friends'] ),
+			'per_page'        => absint( $instance['max_friends'] ),
 			'populate_extras' => 1,
 		);
 
@@ -191,6 +191,13 @@ class BP_Core_Friends_Widget extends WP_Widget {
 
 				<?php endwhile; ?>
 			</ul>
+			<?php if ( $members_template->total_member_count > absint( $instance['max_friends'] ) ) : ?>
+				<div class="more-block">
+					<a href="<?php echo esc_url( $link ); ?>" class="count-more more-connection"><?php _e( 'More', 'buddyboss' ); ?>
+						 <i class="bb-icon-angle-right"></i>
+					</a>
+				</div>
+			<?php endif; ?>
 			<?php wp_nonce_field( 'bp_core_widget_friends', '_wpnonce-friends' ); ?>
 			<input type="hidden" name="friends_widget_max" id="friends_widget_max" value="<?php echo absint( $instance['max_friends'] ); ?>" />
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

More button will be shown if more than max users settings from widget and it will navigate to the user's connection tab.

Fixes #299  .

### How to test the changes in this Pull Request:

1. Add (BB) My Connection widget to the Members Directory page.
2. Go to the Member directory on front end and if you have more than 5 connections
3. More button will be shown below widget.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Widgets - (BB) My Connection widget more link fix.
