### PR TITLE
#520 - Added fix for the username already exist for the multisite

### DIFF
--- a/src/bp-xprofile/bp-xprofile-filters.php
+++ b/src/bp-xprofile/bp-xprofile-filters.php
@@ -143,7 +143,7 @@ function xprofile_filter_kses( $content, $data_obj = null, $field_id = null  ) {
 
 	$xprofile_allowedtags             = $allowedtags;
 	$xprofile_allowedtags['a']['rel'] = array();
-	
+
 	if ( null === $field_id && $data_obj instanceof BP_XProfile_ProfileData ) {
 		$field_id = $data_obj->field_id;
 	}
@@ -782,6 +782,23 @@ function bp_xprofile_validate_nickname_value( $retval, $field_id, $value, $user_
 	}
 
 	global $wpdb;
+
+	if( ! is_user_logged_in() ){
+		$user_where = array(
+			'user_login = "' . $value . '"',
+		);
+
+		$user_sql = sprintf(
+			'SELECT count(*) FROM %s WHERE %s',
+			$wpdb->users,
+			implode( ' AND ', $user_where )
+		);
+
+		if ( $wpdb->get_var( $user_sql ) > 0 ) {
+			return sprintf( __( '%s has already been taken.', 'buddyboss' ), $field_name );
+		}
+	}
+
 	$where = array(
 		'meta_key = "nickname"',
 		'meta_value = "' . $value . '"',


### PR DESCRIPTION
Added fix for username exist check

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #520 

### How to test the changes in this Pull Request:

1. Try to edit any of your existing users by changing its current NICKNAME, make sure that nickname is different from USERNAME.
2. On your registration page, try to register and use the USERNAME of the account you have just modified, as the nickname.
3. The page will just refresh with no error being shown.

### Proof Screenshots or Video
https://www.loom.com/share/6c12ab68927343f989634763fe9fb210

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added fix for username exist check.
