### PR TITLE
Hidden groups unavailable for Learndash group sync with Social group.

### DIFF
--- a/src/bp-integrations/learndash/buddypress/Group.php
+++ b/src/bp-integrations/learndash/buddypress/Group.php
@@ -44,9 +44,13 @@ class Group {
 		}
 
 		return groups_get_groups(
+		/*
+		 * Added show_hidden For show all the hidden group also in Associated Social Group
+		 */
 			array(
 				'orderby'    => 'name',
 				'order'      => 'asc',
+				'show_hidden'=> true,
 				'meta_query' => array( $meta_query ),
 				'per_page'   => - 1,
 			)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #617 .

### How to test the changes in this Pull Request:

1. Go to BuddyBoss > Groups > Add new 
2. Choose 'hidden' in Group privacy. 
3. Go back to Learndash > Groups , edit
4. You will not see hidden group in 'Associated social group' setting.  

### Proof Screenshots or Video
https://www.loom.com/share/a69533b2743d434194f81dbb3f5c80a0

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
