### PR TITLE
#725 - Fixed the undefined variables error in who's online widget

### DIFF
--- a/src/bp-members/classes/class-bp-core-whos-online-widget.php
+++ b/src/bp-members/classes/class-bp-core-whos-online-widget.php
@@ -65,7 +65,9 @@ class BP_Core_Whos_Online_Widget extends WP_Widget {
 
 		// Back up global.
 		$old_members_template = $members_template;
-
+		$online_count         = 0;
+		$connection_count     = 0;
+		
 		// Setup args for querying members.
 		$online_args = array(
 			'user_id'         => 0,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #725 .

### How to test the changes in this Pull Request:

1. Make sure there are no other online users
2. Enable WP_DEBUG
3. Insert Who's Online widget to any widget area
4. Go to the page where the widget is inserted

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->
https://www.loom.com/share/a854eddd5e674a6da2fad551578c1010

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed the undefined variables error in who's online widget
