### PR TITLE
Notification for rejected group access request is not clearing

### DIFF
--- a/src/bp-groups/bp-groups-notifications.php
+++ b/src/bp-groups/bp-groups-notifications.php
@@ -1104,6 +1104,10 @@ function bp_groups_screen_my_groups_mark_notifications() {
 }
 add_action( 'groups_screen_my_groups', 'bp_groups_screen_my_groups_mark_notifications', 10 );
 add_action( 'groups_screen_group_home', 'bp_groups_screen_my_groups_mark_notifications', 10 );
+/*
+ * Request membership screen in clear read notification and count.
+ */
+add_action( 'groups_screen_group_request_membership', 'bp_groups_screen_my_groups_mark_notifications', 10 );
 
 /**
  * Mark group invitation notifications read when a member views their invitations.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #596 .

### How to test the changes in this Pull Request:

1. Go to any private group that you are not a member yet, then request for an access
2. Then login as the organizer of the group and reject the request 
3. Going back to the user who requested the access, navigate to the notifications dropdown and click "Membership for the .... rejected", and you will notice it will not disappear even after visiting

### Proof Screenshots or Video

https://www.loom.com/share/784c907b6ae1415ab0911a5eafc1d847

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
