### PR TITLE
Profile Type filter in members directory is not working when there is a hidden profile type

### DIFF
--- a/src/bp-core/classes/class-bp-user-query.php
+++ b/src/bp-core/classes/class-bp-user-query.php
@@ -441,17 +441,8 @@ class BP_User_Query {
 			$member_type_clause = $this->get_sql_clause_for_member_types( $member_type__not_in, 'NOT IN' );
 
 			// Profile types to include.
-		}
-		if ( ! empty( $member_type ) ) {
-			/*
-			 * Added for profile type filter
-			 * filter issue solved when profile type has checked '[]Hide all members of this type from Members Directory'
-			 */
-			if ( ! empty( $member_type__not_in ) ) {
-				$member_type_clause .= ' AND '.$this->get_sql_clause_for_member_types( $member_type, 'IN' );
-			}else{
-				$member_type_clause = $this->get_sql_clause_for_member_types( $member_type, 'IN' );
-			}
+		} elseif ( ! empty( $member_type ) ) {
+			$member_type_clause = $this->get_sql_clause_for_member_types( $member_type, 'IN' );
 		}
 
 		if ( ! empty( $member_type_clause ) ) {

--- a/src/bp-core/classes/class-bp-user-query.php
+++ b/src/bp-core/classes/class-bp-user-query.php
@@ -441,8 +441,17 @@ class BP_User_Query {
 			$member_type_clause = $this->get_sql_clause_for_member_types( $member_type__not_in, 'NOT IN' );
 
 			// Profile types to include.
-		} elseif ( ! empty( $member_type ) ) {
-			$member_type_clause = $this->get_sql_clause_for_member_types( $member_type, 'IN' );
+		}
+		if ( ! empty( $member_type ) ) {
+			/*
+			 * Added for profile type filter
+			 * filter issue solved when profile type has checked '[]Hide all members of this type from Members Directory'
+			 */
+			if ( ! empty( $member_type__not_in ) ) {
+				$member_type_clause .= ' AND '.$this->get_sql_clause_for_member_types( $member_type, 'IN' );
+			}else{
+				$member_type_clause = $this->get_sql_clause_for_member_types( $member_type, 'IN' );
+			}
 		}
 
 		if ( ! empty( $member_type_clause ) ) {

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -378,7 +378,7 @@ function bp_has_members( $args = array() ) {
 
 	$args = bp_parse_args( $args, array() );
 	// Exclude Member Types
-	if ( ( empty( $args['scope'] ) || 'all' === $args['scope'] ) && ( ! bp_is_user() && empty( $member_type ) ) ) {
+	if ( ( empty( $args['scope'] ) || 'all' === $args['scope'] ) && ( ! bp_is_user() && empty( $member_type ) && empty( $args['member_type'] ) ) ) {
 	    // get all excluded member types.
 	    $bp_member_type_ids = bp_get_removed_member_types();
 	    if ( isset( $bp_member_type_ids ) && ! empty( $bp_member_type_ids ) ) {


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fixes #732 .

### How to test the changes in this Pull Request:

1. Create another profile type
2. Under, permission, enable "Hide all members of this type from Members Directory"
3. Go to members directory and try to use the profile type filter


### Proof Screenshots or Video

https://www.loom.com/share/c2c326e158874f9eb75c50f12a2a737d

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
