### PR TITLE
Fixed - Products posted to activity, If image width is small it's showing misaligned

### DIFF
--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -4864,7 +4864,7 @@ function bp_update_activity_feed_of_custom_post_type( $post_id, $post, $update )
 			$src = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full', false );
 
 			if ( isset( $src[0] ) ) {
-				$activity_summary .= sprintf( ' <img src="%s">', esc_url( $src[0] ) );
+				$activity_summary .= sprintf( '<br/><img src="%s">', esc_url( $src[0] ) );
 			}
 			// Backward compatibility filter for the blogs component.
 			if ( 'blogs' == $activity_post_object->component_id ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

Fixes #752  .

### How to test the changes in this Pull Request:

https://screencast-o-matic.com/watch/cYf2ICzVvK

### Proof Screenshots or Video
https://prnt.sc/s0f3dq

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?