### PR TITLE
#581 - Added exclude group query for user in which user is not able to post the activity

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -440,14 +440,31 @@ function bp_nouveau_ajax_get_activity_objects() {
 	}
 
 	if ( 'group' === $_POST['type'] ) {
-		$groups = groups_get_groups(
-			array(
-				'user_id'      => bp_loggedin_user_id(),
-				'search_terms' => $_POST['search'],
-				'show_hidden'  => true,
-				'per_page'     => 2,
-			)
-		);
+		$exclude_groups = array();
+
+		$exclude_groups_query = groups_get_groups( array(
+			'user_id'      => bp_loggedin_user_id(),
+			'search_terms' => $_POST['search'],
+			'show_hidden'  => true,
+			'per_page'     => - 1,
+			'fields'       => 'ids',
+		) );
+
+		if ( ! empty( $exclude_groups_query['groups'] ) ) {
+			foreach ( $exclude_groups_query['groups'] as $exclude_group ) {
+				if ( false === groups_is_user_allowed_posting( bp_loggedin_user_id(), $exclude_group ) ) {
+					$exclude_groups[] = $exclude_group;
+				}
+			}
+		}
+
+		$groups = groups_get_groups( array(
+			'user_id'      => bp_loggedin_user_id(),
+			'search_terms' => $_POST['search'],
+			'show_hidden'  => true,
+			'per_page'     => 2,
+			'exclude'      => $exclude_groups,
+		) );
 
 		wp_send_json_success( array_map( 'bp_nouveau_prepare_group_for_js', $groups['groups'] ) );
 	} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #581 .

### How to test the changes in this Pull Request:

1. In group settings set as - only admin/organizers can post in the group activity.
2. See that users will no longer be able to write in the groups activity feed in the main group page.
3. Go to the sitewide activity page.
4. Try to post something then post by - group - select the group in where you have set the only admin/organizers can post in the group activity. settings.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->
https://www.loom.com/share/36b8e12641444623aa6440d39843b542

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added exclude group query for user in which user is not able to post the activity