### PR TITLE
#761 Server goes away when activate platform plugin with 60000 users

### DIFF
--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -1306,8 +1306,6 @@ function bp_activity_favorites_upgrade_data() {
 	}
 }
 
-add_action( 'bp_init', 'bp_activity_favorites_upgrade_data' );
-
 /**
  * Check whether an activity item exists with a given content string.
  *

--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -1255,7 +1255,7 @@ function bp_activity_favorites_upgrade_data() {
 
 	if ( ! $bp_activity_favorites && bp_is_active( 'activity' ) ) {
 
-		if ( bp_is_large_install( 100 ) ) {
+		if ( bp_is_large_install() ) {
 			$admin_url = bp_get_admin_url( add_query_arg( array( 'page' => 'bp-tools' ), 'admin.php' ) );
 			$notice    = sprintf(
 				'%1$s <a href="%2$s">%3$s</a> %4$s',
@@ -1279,13 +1279,13 @@ function bp_activity_favorites_upgrade_data() {
 		// User Loop
 		if ( $user_query->get_results() ) {
 			foreach ( $user_query->get_results() as $user_id ) {
-				$my_favs = bp_get_user_meta( $user_id, 'bp_favorite_activities', true );
+				$user_favs = bp_get_user_meta( $user_id, 'bp_favorite_activities', true );
 
-				if ( empty( $my_favs ) || ! is_array( $my_favs ) ) {
+				if ( empty( $user_favs ) || ! is_array( $user_favs ) ) {
 					continue;
 				}
 
-				foreach ( $my_favs as $fav ) {
+				foreach ( $user_favs as $fav ) {
 
 					// Update the users who have favorited this activity.
 					$users = bp_activity_get_meta( $fav, 'bp_favorite_users', true );

--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -1253,7 +1253,22 @@ function bp_activity_get_favorite_users_tooltip_string( $activity_id ) {
 function bp_activity_favorites_upgrade_data() {
 	$bp_activity_favorites = bp_get_option( 'bp_activity_favorites', false );
 
-	if ( ! $bp_activity_favorites ) {
+	if ( ! $bp_activity_favorites && bp_is_active( 'activity' ) ) {
+
+		if ( bp_is_large_install( 100 ) ) {
+			$admin_url = bp_get_admin_url( add_query_arg( array( 'page' => 'bp-tools' ), 'admin.php' ) );
+			$notice    = sprintf(
+				'%1$s <a href="%2$s">%3$s</a> %4$s',
+				__( 'Due to the large users you must need to update users activity favorites via BuddyBoss > ', 'buddyboss' ),
+				esc_url( $admin_url ),
+				__( 'Tools', 'buddyboss' ),
+				__( ' > Repair Community and check the checkobx "Update activity favorites data." and click on Repair Items. ', 'buddyboss' ),
+			);
+
+			bp_core_add_admin_notice( $notice, 'error' );
+			return;
+		}
+
 		$args = array(
 			'fields' => 'ID',
 		);

--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -1145,7 +1145,7 @@ add_action( 'wp_ajax_bp_admin_repair_tools_wrapper_function', 'bp_admin_repair_t
 /**
  * Check if BuddyPress activity favorites data needs upgrade & Update to BuddyBoss activity like data
  *
- * @since BuddyBoss 1.3.2
+ * @since BuddyBoss 1.3.3
  */
 function bp_admin_update_activity_favourite() {
 

--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -403,6 +403,15 @@ function bp_admin_repair_list() {
 		}
 	}
 
+	if ( bp_is_active( 'activity' ) ) {
+		$repair_list[102] = array(
+			'bp-sync-activity-favourite',
+			__( 'Update activity favorites data.', 'buddyboss' ),
+			'bp_admin_update_activity_favourite',
+		);
+    }
+
+
 	ksort( $repair_list );
 
 	/**
@@ -1126,7 +1135,84 @@ function bp_admin_repair_tools_wrapper_function() {
 		$status = bp_admin_reinstall_emails();
 	} elseif ( 'bp-assign-member-type' === $type ) {
 		$status = bp_admin_assign_member_type();
+	} elseif ( 'bp-sync-activity-favourite' === $type ) {
+		$status = bp_admin_update_activity_favourite();
 	}
 	wp_send_json_success( $status );
 }
 add_action( 'wp_ajax_bp_admin_repair_tools_wrapper_function', 'bp_admin_repair_tools_wrapper_function' );
+
+/**
+ * Check if BuddyPress activity favorites data needs upgrade & Update to BuddyBoss activity like data
+ *
+ * @since BuddyBoss 1.3.2
+ */
+function bp_admin_update_activity_favourite() {
+
+	$bp_activity_favorites = bp_get_option( 'bp_activity_favorites', false );
+
+	if ( ! $bp_activity_favorites ) {
+
+		$offset = isset( $_POST['offset'] ) ? (int) ( $_POST['offset'] ) : 0;
+
+		$args = array(
+			'number' => 50,
+			'offset' => $offset,
+		);
+
+		$users = get_users( $args );
+
+		if ( ! empty( $users ) ) {
+
+		    foreach ( $users as $user ) {
+			    $my_favs = bp_get_user_meta( $user->ID, 'bp_favorite_activities', true );
+			    if ( empty( $my_favs ) || ! is_array( $my_favs ) ) {
+				    $offset ++;
+				    continue;
+			    }
+			    foreach ( $my_favs as $fav ) {
+
+				    // Update the users who have favorited this activity.
+				    $favorite_users = bp_activity_get_meta( $fav, 'bp_favorite_users', true );
+				    if ( empty( $favorite_users ) || ! is_array( $favorite_users ) ) {
+					    $favorite_users = array();
+				    }
+				    // Add to activity's favorited users.
+				    $favorite_users[] = $user->ID;
+
+				    // Update activity meta
+				    bp_activity_update_meta( $fav, 'bp_favorite_users', array_unique( $favorite_users ) );
+
+			    }
+			    $offset ++;
+		    }
+
+			$records_updated = sprintf( __( '%s members activity favorite updated successfully.', 'buddyboss' ), number_format_i18n( $offset ) );
+
+			return array(
+				'status'  => 'running',
+				'offset'  => $offset,
+				'records' => $records_updated,
+			);
+
+		} else {
+
+			bp_update_option( 'bp_activity_favorites', true );
+
+			$statement = __( 'Members activity favorite updated %s', 'buddyboss' );
+
+			return array(
+				'status'  => 1,
+				'message' => sprintf( $statement, __( 'Complete!', 'buddyboss' ) ),
+			);
+		}
+
+	} else {
+		$statement = __( 'Members activity favorite updated %s', 'buddyboss' );
+
+		return array(
+			'status'  => 1,
+			'message' => sprintf( $statement, __( 'Complete!', 'buddyboss' ) ),
+		);
+    }
+}

--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -1165,12 +1165,12 @@ function bp_admin_update_activity_favourite() {
 		if ( ! empty( $users ) ) {
 
 		    foreach ( $users as $user ) {
-			    $my_favs = bp_get_user_meta( $user->ID, 'bp_favorite_activities', true );
-			    if ( empty( $my_favs ) || ! is_array( $my_favs ) ) {
+			    $user_favs = bp_get_user_meta( $user->ID, 'bp_favorite_activities', true );
+			    if ( empty( $user_favs ) || ! is_array( $user_favs ) ) {
 				    $offset ++;
 				    continue;
 			    }
-			    foreach ( $my_favs as $fav ) {
+			    foreach ( $user_favs as $fav ) {
 
 				    // Update the users who have favorited this activity.
 				    $favorite_users = bp_activity_get_meta( $fav, 'bp_favorite_users', true );

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4186,12 +4186,12 @@ function bp_check_member_send_invites_tab_member_type_allowed() {
  *
  * @return bool
  */
-function bp_is_large_install() {
+function bp_is_large_install( $count = 10000 ) {
 	// Use the Multisite function if available.
 	if ( function_exists( 'wp_is_large_network' ) ) {
 		$is_large = wp_is_large_network( 'users' );
 	} else {
-		$is_large = bp_core_get_total_member_count() > 10000;
+		$is_large = bp_core_get_total_member_count() > $count;
 	}
 
 	/**

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4186,12 +4186,12 @@ function bp_check_member_send_invites_tab_member_type_allowed() {
  *
  * @return bool
  */
-function bp_is_large_install( $count = 10000 ) {
+function bp_is_large_install() {
 	// Use the Multisite function if available.
 	if ( function_exists( 'wp_is_large_network' ) ) {
 		$is_large = wp_is_large_network( 'users' );
 	} else {
-		$is_large = bp_core_get_total_member_count() > $count;
+		$is_large = bp_core_get_total_member_count() > 10000;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #761 .

### How to test the changes in this Pull Request:

1. Add 50000 or more users.
2. Try to activate the platform.
3. You can't activate due to the mysql service down.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
