### PR TITLE
Lost Password link not working when WooCommerce plugin active

### DIFF
--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -418,7 +418,7 @@ add_filter( 'the_content', 'bp_core_memberpress_the_content', 999 );
 /**
  * Removed WC filter to the settings page when its active.
  *
- * @since BuddyBoss 1.3.1
+ * @since BuddyBoss 1.3.2
  */
 function bp_settings_remove_wc_lostpassword_url() {
 

--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -414,3 +414,16 @@ function bp_core_memberpress_the_content( $content ) {
 	return $content;
 }
 add_filter( 'the_content', 'bp_core_memberpress_the_content', 999 );
+
+/**
+ * Removed WC filter to the settings page when its active.
+ *
+ * @since BuddyBoss 1.3.1
+ */
+function bp_settings_remove_wc_lostpassword_url() {
+
+	if ( class_exists( 'woocommerce' ) ) {
+		remove_filter( 'lostpassword_url', 'wc_lostpassword_url', 10, 1 );
+	}
+}
+add_action( 'bp_before_member_settings_template', 'bp_settings_remove_wc_lostpassword_url' );

--- a/src/bp-settings/bp-settings-template.php
+++ b/src/bp-settings/bp-settings-template.php
@@ -104,16 +104,3 @@ function bp_settings_pending_email_notice() {
 	<?php
 }
 add_action( 'bp_before_member_settings_template', 'bp_settings_pending_email_notice' );
-
-/**
- * Removed WC filter to the settings page when its active.
- *
- * @since BuddyBoss 1.3.1
- */
-function bp_settings_remove_wc_lostpassword_url() {
-
-	if ( class_exists( 'woocommerce' ) ) {
-		remove_filter( 'lostpassword_url', 'wc_lostpassword_url', 10, 1 );
-	}
-}
-add_action( 'bp_before_member_settings_template', 'bp_settings_remove_wc_lostpassword_url' );

--- a/src/bp-settings/bp-settings-template.php
+++ b/src/bp-settings/bp-settings-template.php
@@ -104,3 +104,16 @@ function bp_settings_pending_email_notice() {
 	<?php
 }
 add_action( 'bp_before_member_settings_template', 'bp_settings_pending_email_notice' );
+
+/**
+ * Removed WC filter to the settings page when its active.
+ *
+ * @since BuddyBoss 1.3.1
+ */
+function bp_settings_remove_wc_lostpassword_url() {
+
+	if ( class_exists( 'woocommerce' ) ) {
+		remove_filter( 'lostpassword_url', 'wc_lostpassword_url', 10, 1 );
+	}
+}
+add_action( 'bp_before_member_settings_template', 'bp_settings_remove_wc_lostpassword_url' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #778 .

### How to test the changes in this Pull Request:

1. Active WC
2. Login with any subscriber user
3. Go to Account -> Login Information
4. Find out link "Lost password" and click on it

### Proof Screenshots or Video

https://www.loom.com/share/fb80556f53df466a854b1e1c45b895cd

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
