### PR TITLE
#760 Organizers are not able to send invites grom sub-groups

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/groups/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/ajax.php
@@ -294,23 +294,6 @@ function bp_nouveau_ajax_get_users_to_invite() {
 
 	if ( 'groups_get_group_potential_invites' === $request['action'] ) {
 
-		// check if subgroup.
-		$parent_group_id = bp_get_parent_group_id( $request['group_id'] );
-
-		if ( isset( $parent_group_id ) && $parent_group_id > 0 ) {
-
-			$check_admin = groups_is_user_admin( bp_loggedin_user_id(), $parent_group_id );
-			$check_moder = groups_is_user_mod( bp_loggedin_user_id(), $parent_group_id );
-
-			// Check role of current logged in user for this group.
-			if ( false === $check_admin && false === $check_moder ) {
-				wp_send_json_error( array(
-					'feedback' => __( 'You are not authorized to send invites to other users.', 'buddyboss' ),
-					'type'     => 'info',
-				) );
-			}
-		}
-
 		$group_type = bp_groups_get_group_type( $request['group_id'] );
 
 		// Include profile type if in Group Types > E.g Team > Group Invites ( Meta Box ) specific profile type selected.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #760 .

### How to test the changes in this Pull Request:

1. In the Backend go to BuddyBoss->Settings->Groups and enable "Allow groups to have subgroups": http://prntscr.com/s10t7t
2. Now go to frontend as User1 and create a group ( This is parent group ).
3. Now login with User2 and be a member of the group created by User1.
4. Now by User2, create a sub-group. Select a group as parent group your are a member of( In this case group created by User1 ).
5. After creating sub-group by User2, go to "Send Invites".

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
