### PR TITLE
#760 Subgroup not displayed in subgroup tab

### DIFF
--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -396,7 +396,7 @@ function bp_has_groups( $args = '' ) {
 	// Exclude Group Types
 	if (
 		( empty( $args['scope'] ) || ( ! empty( $args['scope'] ) && 'all' === $args['scope'] ) ) &&
-		! bp_is_user_groups() &&
+		! bp_is_user_groups() && ! bp_is_group_subgroups() && 
 		( wp_doing_ajax() && empty( $group_type ) )
 	) {
 		// get all excluded group types.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #797  .

### How to test the changes in this Pull Request:

1. Create a group type and enable "Hide all groups of this type from Groups Directory"
2. Make this group a subgroup of another group
3. The group doesn't show in the subgroup tab (filter "All type") unless I select the correct group type in the filter

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
