### PR TITLE
Revert "Lost Password link not working when WooCommerce plugin active"

### DIFF
--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -414,16 +414,3 @@ function bp_core_memberpress_the_content( $content ) {
 	return $content;
 }
 add_filter( 'the_content', 'bp_core_memberpress_the_content', 999 );
-
-/**
- * Removed WC filter to the settings page when its active.
- *
- * @since BuddyBoss 1.3.2
- */
-function bp_settings_remove_wc_lostpassword_url() {
-
-	if ( class_exists( 'woocommerce' ) ) {
-		remove_filter( 'lostpassword_url', 'wc_lostpassword_url', 10, 1 );
-	}
-}
-add_action( 'bp_before_member_settings_template', 'bp_settings_remove_wc_lostpassword_url' );


### PR DESCRIPTION
Reverts buddyboss/buddyboss-platform#783