### PR TITLE
Fix/group network urls

### DIFF
--- a/src/bp-groups/bp-groups-admin.php
+++ b/src/bp-groups/bp-groups-admin.php
@@ -842,7 +842,7 @@ function bp_groups_admin_create() {
 
 		<?php endif; ?>
 
-		<form action="<?php echo esc_url( bp_get_admin_url( 'admin-post.php' ) ); ?>" id="bp-groups-edit-form" method="post">
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" id="bp-groups-edit-form" method="post">
 			<div id="poststuff">
 
 				<div id="post-body" class="metabox-holder columns-<?php echo 1 == get_current_screen()->get_columns() ? '1' : '2'; ?>">

--- a/src/bp-groups/bp-groups-admin.php
+++ b/src/bp-groups/bp-groups-admin.php
@@ -693,8 +693,7 @@ function bp_groups_admin_edit() {
 							'page'   => 'bp-groups',
 							'create' => 'create-from-admin',
 							'action' => 'edit',
-						),
-						admin_url( 'admin.php' )
+						), bp_get_admin_url( 'admin.php' )
 					)
 				);
 				?>
@@ -716,8 +715,7 @@ function bp_groups_admin_edit() {
 								'page'   => 'bp-groups',
 								'create' => 'create-from-admin',
 								'action' => 'edit',
-							),
-							admin_url( 'admin.php' )
+							), bp_get_admin_url( 'admin.php' )
 						)
 					);
 					?>
@@ -844,7 +842,7 @@ function bp_groups_admin_create() {
 
 		<?php endif; ?>
 
-		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" id="bp-groups-edit-form" method="post">
+		<form action="<?php echo esc_url( bp_get_admin_url( 'admin-post.php' ) ); ?>" id="bp-groups-edit-form" method="post">
 			<div id="poststuff">
 
 				<div id="post-body" class="metabox-holder columns-<?php echo 1 == get_current_screen()->get_columns() ? '1' : '2'; ?>">
@@ -949,8 +947,7 @@ function bp_process_create_group_admin() {
 				'page'   => 'bp-groups',
 				'gid'    => $new_group_id,
 				'action' => 'edit',
-			),
-			admin_url( 'admin.php' )
+			), bp_get_admin_url( 'admin.php' )
 		)
 	);
 	exit();
@@ -1093,8 +1090,7 @@ function bp_groups_admin_index() {
 							'page'   => 'bp-groups',
 							'create' => 'create-from-admin',
 							'action' => 'edit',
-						),
-						admin_url( 'admin.php' )
+						), bp_get_admin_url( 'admin.php' )
 					)
 				);
 				?>
@@ -1121,8 +1117,7 @@ function bp_groups_admin_index() {
 							'page'   => 'bp-groups',
 							'create' => 'create-from-admin',
 							'action' => 'edit',
-						),
-						admin_url( 'admin.php' )
+						), bp_get_admin_url( 'admin.php' )
 					)
 				);
 				?>
@@ -2267,7 +2262,7 @@ function bp_group_type_show_data( $column, $post_id ) {
 
 		case 'total_groups':
 			$group_key      = bp_group_get_group_type_key( $post_id );
-			$group_type_url = admin_url().'admin.php?page=bp-groups&bp-group-type='.$group_key;
+			$group_type_url = bp_get_admin_url().'admin.php?page=bp-groups&bp-group-type='.$group_key;
 			printf(
 				__( '<a href="%1$s">%2$s</a>', 'buddyboss' ),
 				esc_url( $group_type_url ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes all group's network admin urls which were going 404 before for links like `Add Group`, `Delete Group`,  group types count navigating to groups etc.

### How to test the changes in this Pull Request:

1. Enable multinetwork and network activate platform plugin.
2. Go to Group's admin and try to add new Group.
3. It should go to create group screen in admin.
4. Like wise test the delete group and group types count navigation to groups list too.

### Proof Screenshots or Video

https://www.loom.com/share/df800a4fe46a435885bd1c095eb1c252

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Groups - WP Multi-Network admin links fixed 
