### PR TITLE
755 - fixed the forums subscription tab when WooCommerce Subscriptions plugin is activated

### DIFF
--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -370,6 +370,19 @@ function bp_core_fix_notices_woocommerce_admin_status( $tabs ) {
 }
 add_filter( 'woocommerce_admin_status_tabs', 'bp_core_fix_notices_woocommerce_admin_status' );
 
+function bp_core_fix_forums_subscriptions_tab( $passed ) {
+	$bp_current_component = bp_current_component();
+	$bp_current_action    = bp_current_action();
+
+	if ( 'forums' === $bp_current_component && 'subscriptions' === $bp_current_action ) {
+		$passed = false;
+	}
+
+	return $passed;
+}
+
+add_filter( 'woocommerce_account_endpoint_page_not_found', 'bp_core_fix_forums_subscriptions_tab' );
+
 /**
  * Fix Memberpress Privacy for BuddyPress pages.
  *

--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -370,11 +370,19 @@ function bp_core_fix_notices_woocommerce_admin_status( $tabs ) {
 }
 add_filter( 'woocommerce_admin_status_tabs', 'bp_core_fix_notices_woocommerce_admin_status' );
 
+/**
+ * Fix forums subscription tab in user's profile.
+ *
+ * @param $passed
+ *
+ * @return bool
+ * @since BuddyBoss 1.3.3
+ */
 function bp_core_fix_forums_subscriptions_tab( $passed ) {
 	$bp_current_component = bp_current_component();
 	$bp_current_action    = bp_current_action();
 
-	if ( 'forums' === $bp_current_component && 'subscriptions' === $bp_current_action ) {
+	if ( 'forums' === $bp_current_component && $bp_current_action === bbp_get_user_subscriptions_slug() ) {
 		$passed = false;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #755 .

### How to test the changes in this Pull Request:

1. Go to User's profile page
2. Click on 'Forums > Subscriptions'
3. Subscribed forums will be listed

### Proof Screenshots or Video
https://www.loom.com/share/0ba931403c8e47f9b4447dfd1198ee55
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> fixed the forums subscription tab when WooCommerce Subscriptions plugin is activated
