### PR TITLE
Can not translate 'Send Message' button on 'Groups > message' page.

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress/groups/single/messages.php
+++ b/src/bp-templates/bp-nouveau/buddypress/groups/single/messages.php
@@ -169,7 +169,7 @@ $group_members = groups_get_group_members( $args );
 								if ( empty( $group_members['members'] ) ) {
 									$disabled = 'disabled';
 								} ?>
-								<input <?php echo esc_attr( $disabled ); ?> type="submit" name="send_group_message_button" value="Send Message" id="send_group_message_button" class="small">
+								<input <?php echo esc_attr( $disabled ); ?> type="submit" name="send_group_message_button" value="<?php _e( 'Send Message', 'buddyboss' ); ?>" id="send_group_message_button" class="small">
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #825 .

### How to test the changes in this Pull Request:

**To Reproduce**
Steps to reproduce the behavior:
1. Enable groups Message
2. Go to Groups > Message as organizer
3. 'Send Message' button is at right bottom.

### Proof Screenshots or Video
https://prnt.sc/s8kxa0

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
