### PR TITLE
fix bp template stack filter array checked for null and empty and array

### DIFF
--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -275,10 +275,15 @@ function bp_get_template_stack() {
 	} else {
 		$filter = &$wp_filter[ $tag ];
 
-		if ( ! isset( $merged_filters[ $tag ] ) ) {
+		if ( ( is_array( $filter ) && ! empty( $filter ) ) && ! isset( $merged_filters[ $tag ] ) ) {
 			ksort( $filter );
 			$merged_filters[ $tag ] = true;
 		}
+	}
+
+	// check filter if not array.
+	if ( ! is_array( $filter ) || empty( $filter ) ) {
+		return (array) apply_filters( 'bp_get_template_stack', array() );
 	}
 
 	// Ensure we're always at the beginning of the filter array.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

fix bp template stack filter array checked for null and empty and array
