### PR TITLE
922 - Fixed Notification count issue

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/messages/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/ajax.php
@@ -1749,6 +1749,7 @@ function bp_nouveau_get_thread_messages( $thread_id, $post ) {
 	$thread->per_page                = $thread_template->thread->messages_perpage;
 	$thread->messages_count          = $thread_template->thread->total_messages;
 	$thread->next_messages_timestamp = $thread_template->thread->messages[ count( $thread_template->thread->messages ) - 1 ]->date_sent;
+	$thread->total_unread_messages   = bp_get_total_unread_messages_count();
 
 	return $thread;
 }

--- a/src/bp-templates/bp-nouveau/js/buddypress-messages.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-messages.js
@@ -498,6 +498,12 @@ window.bp = window.bp || {};
 				this.options.recipients     = resp.thread.recipients;
 			}
 
+			if ( ! _.isUndefined( resp.total_unread_messages ) ) {
+				var msg = $('.bb-icon-inbox-small');
+				$(msg).parent().children('.count').remove();
+				$(msg).parent().append( '<span class="count"> ' + resp.total_unread_messages + ' </span>' );
+			}
+
 			return resp.messages;
 		}
 	} );

--- a/src/bp-templates/bp-nouveau/js/buddypress-messages.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-messages.js
@@ -501,7 +501,9 @@ window.bp = window.bp || {};
 			if ( ! _.isUndefined( resp.total_unread_messages ) ) {
 				var msg = $('.bb-icon-inbox-small');
 				$(msg).parent().children('.count').remove();
-				$(msg).parent().append( '<span class="count"> ' + resp.total_unread_messages + ' </span>' );
+				if( resp.total_unread_messages > 0 ) {
+					$(msg).parent().append( '<span class="count"> ' + resp.total_unread_messages + ' </span>' );
+				}
 			}
 
 			return resp.messages;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [ ] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #922 

### How to test the changes in this Pull Request:

1. Go to user > profile > messages
2. Click on the unread message
3. check the message notification icon on the top header
4. it should show the latest count for unread message

### Proof Screenshots or Video
https://www.loom.com/share/c3ed0973b31348949fd163fe5c145794

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
