### PR TITLE
Group photos always appear on search no matter what you search for.

### DIFF
--- a/src/bp-friends/bp-friends-filters.php
+++ b/src/bp-friends/bp-friends-filters.php
@@ -75,20 +75,30 @@ function bp_friends_filter_media_scope( $retval = array(), $filter = array() ) {
 		return $retval;
 	}
 
+	$args = array(
+		'relation' => 'AND',
+		array(
+			'column'  => 'user_id',
+			'compare' => 'IN',
+			'value'   => (array) $friends,
+		),
+		array(
+			'column' => 'privacy',
+			'value'  => 'friends',
+		),
+	);
+
+	if ( ! empty( $filter['search_terms'] ) ) {
+		$args[] = array(
+			'column'  => 'title',
+			'compare' => 'LIKE',
+			'value'   => $filter['search_terms'],
+		);
+	}
+
 	$retval = array(
 		'relation' => 'OR',
-		array(
-			'relation' => 'AND',
-			array(
-				'column'  => 'user_id',
-				'compare' => 'IN',
-				'value'   => (array) $friends,
-			),
-			array(
-				'column' => 'privacy',
-				'value'  => 'friends',
-			),
-		),
+		$args
 	);
 
 	return $retval;

--- a/src/bp-friends/bp-friends-filters.php
+++ b/src/bp-friends/bp-friends-filters.php
@@ -75,7 +75,7 @@ function bp_friends_filter_media_scope( $retval = array(), $filter = array() ) {
 		return $retval;
 	}
 
-	$args = array(
+	$retval = array(
 		'relation' => 'AND',
 		array(
 			'column'  => 'user_id',
@@ -89,17 +89,12 @@ function bp_friends_filter_media_scope( $retval = array(), $filter = array() ) {
 	);
 
 	if ( ! empty( $filter['search_terms'] ) ) {
-		$args[] = array(
+		$retval[] = array(
 			'column'  => 'title',
 			'compare' => 'LIKE',
 			'value'   => $filter['search_terms'],
 		);
 	}
-
-	$retval = array(
-		'relation' => 'OR',
-		$args
-	);
 
 	return $retval;
 }

--- a/src/bp-groups/bp-groups-filters.php
+++ b/src/bp-groups/bp-groups-filters.php
@@ -569,20 +569,30 @@ function bp_groups_filter_media_scope( $retval = array(), $filter = array() ) {
 		$group_ids = array( 'groups' => 0 );
 	}
 
+	$args = array(
+		'relation' => 'AND',
+		array(
+			'column'  => 'group_id',
+			'compare' => 'IN',
+			'value'   => (array) $group_ids['groups'],
+		),
+		array(
+			'column' => 'privacy',
+			'value'  => 'grouponly',
+		),
+	);
+
+	if ( ! empty( $filter['search_terms'] ) ) {
+		$args[] = array(
+			'column'  => 'title',
+			'compare' => 'LIKE',
+			'value'   => $filter['search_terms'],
+		);
+	}
+
 	$retval = array(
 		'relation' => 'OR',
-		array(
-			'relation' => 'AND',
-			array(
-				'column'  => 'group_id',
-				'compare' => 'IN',
-				'value'   => (array) $group_ids['groups'],
-			),
-			array(
-				'column' => 'privacy',
-				'value'  => 'grouponly',
-			),
-		),
+		$args
 	);
 
 	return $retval;

--- a/src/bp-media/classes/class-bp-media.php
+++ b/src/bp-media/classes/class-bp-media.php
@@ -468,8 +468,6 @@ class BP_Media {
 		// Query first for media IDs.
 		$media_ids_sql = "{$select_sql} {$from_sql} {$join_sql} {$where_sql} ORDER BY {$order_by} {$sort}, m.id {$sort}";
 
-		error_log($media_ids_sql);
-
 		if ( ! empty( $per_page ) && ! empty( $page ) ) {
 			// We query for $per_page + 1 items in order to
 			// populate the has_more_items flag.

--- a/src/bp-media/classes/class-bp-media.php
+++ b/src/bp-media/classes/class-bp-media.php
@@ -468,6 +468,8 @@ class BP_Media {
 		// Query first for media IDs.
 		$media_ids_sql = "{$select_sql} {$from_sql} {$join_sql} {$where_sql} ORDER BY {$order_by} {$sort}, m.id {$sort}";
 
+		error_log($media_ids_sql);
+
 		if ( ! empty( $per_page ) && ! empty( $page ) ) {
 			// We query for $per_page + 1 items in order to
 			// populate the has_more_items flag.

--- a/src/bp-members/bp-members-filters.php
+++ b/src/bp-members/bp-members-filters.php
@@ -202,6 +202,14 @@ function bp_members_filter_media_personal_scope( $retval = array(), $filter = ar
 		),
 	);
 
+	if ( ! empty( $filter['search_terms'] ) ) {
+		$retval[] = array(
+			'column'  => 'title',
+			'compare' => 'LIKE',
+			'value'   => $filter['search_terms'],
+		);
+	}
+
 	return $retval;
 }
 add_filter( 'bp_media_set_personal_scope_args', 'bp_members_filter_media_personal_scope', 10, 2 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This will fix search results for photos directory.

Fixes #440 

### How to test the changes in this Pull Request:

1. Go to Photos directory
2. Search any photo with any title of the photo.
3. It should search photos with search terms only not other result should be returned.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Media - Fix photos directory's search results.
