### PR TITLE
758 - allow to send group message without checking connection

### DIFF
--- a/src/bp-messages/bp-messages-functions.php
+++ b/src/bp-messages/bp-messages-functions.php
@@ -90,6 +90,7 @@ function messages_new_message( $args = '' ) {
 	$message->mark_visible = $r['mark_visible'];
 
 	$new_reply = false;
+	$is_group_thread = isset( $r['group_thread'] ) ? $r['group_thread'] : false;
 	// If we have a thread ID...
 	if ( ! empty( $r['thread_id'] ) ) {
 
@@ -116,6 +117,13 @@ function messages_new_message( $args = '' ) {
 
 		$new_reply = true;
 
+		$first_message = BP_Messages_Thread::get_first_message( (int) $thread->thread_id );
+		if ( isset( $first_message->id ) ) {
+			$group = bp_messages_get_meta( $first_message->id, 'group_id', true ); // group id
+			if ( !empty( $group ) ) {
+				$is_group_thread = true;
+			}
+		}
 		// ...otherwise use the recipients passed
 	} else {
 
@@ -254,7 +262,7 @@ function messages_new_message( $args = '' ) {
 	}
 
 	// check if force friendship is enabled and check recipients
-	if ( bp_force_friendship_to_message() && bp_is_active( 'friends' ) ) {
+	if ( bp_force_friendship_to_message() && bp_is_active( 'friends' ) && $is_group_thread <> true) {
 
 		$error_messages = array(
 			'new_message'       => __( 'You need to be connected with this member in order to send a message.', 'buddyboss' ),

--- a/src/bp-messages/bp-messages-functions.php
+++ b/src/bp-messages/bp-messages-functions.php
@@ -262,7 +262,7 @@ function messages_new_message( $args = '' ) {
 	}
 
 	// check if force friendship is enabled and check recipients
-	if ( bp_force_friendship_to_message() && bp_is_active( 'friends' ) && $is_group_thread <> true) {
+	if ( bp_force_friendship_to_message() && bp_is_active( 'friends' ) && true !== $is_group_thread ) {
 
 		$error_messages = array(
 			'new_message'       => __( 'You need to be connected with this member in order to send a message.', 'buddyboss' ),

--- a/src/bp-messages/bp-messages-functions.php
+++ b/src/bp-messages/bp-messages-functions.php
@@ -117,9 +117,8 @@ function messages_new_message( $args = '' ) {
 
 		$new_reply = true;
 
-		$first_message = BP_Messages_Thread::get_first_message( (int) $thread->thread_id );
-		if ( isset( $first_message->id ) ) {
-			$group = bp_messages_get_meta( $first_message->id, 'group_id', true ); // group id
+		if ( isset( $thread->messages[0]->id ) ) {
+			$group = bp_messages_get_meta( $thread->messages[0]->id, 'group_id', true ); // group id
 			if ( !empty( $group ) ) {
 				$is_group_thread = true;
 			}

--- a/src/bp-templates/bp-nouveau/includes/groups/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/ajax.php
@@ -1854,6 +1854,7 @@ function bp_groups_messages_new_message( $args = '' ) {
 			'is_hidden'     => false,
 			'mark_visible'  => false,
 			'error_type'    => 'wp_error',
+			'group_thread'  => true,
 		),
 		'bp_groups_messages_new_message'
 	);

--- a/src/bp-templates/bp-nouveau/includes/messages/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/ajax.php
@@ -1682,6 +1682,7 @@ function bp_nouveau_get_thread_messages( $thread_id, $post ) {
 
 		if ( 'group' === $message_from && bp_get_the_thread_id() === (int) $group_message_thread_id && 'all' === $message_users && 'open' === $message_type ) {
 			$is_group_thread = 1;
+			unset($thread->feedback_error);
 		}
 	}
 

--- a/src/bp-templates/bp-nouveau/js/buddypress-messages.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-messages.js
@@ -2584,6 +2584,9 @@ window.bp = window.bp || {};
 					bp.Nouveau.Messages.displayFeedback( response.feedback_error.feedback, response.feedback_error.type );
 					// hide reply form.
 					this.$( '#send-reply' ).hide();
+					if ( ! _.isUndefined( response.thread.is_group_thread ) && response.thread.is_group_thread === 1 ) {
+						this.$( '#send-reply' ).show();
+					}
 				}
 
 			if ( this.firstFetch ) {


### PR DESCRIPTION
### All Submissions:

- [x]  Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
- [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/buddyboss/buddyboss-platform/issues/758

### How to test the changes in this Pull Request:

1. Go to WP Admin > BuddyBoss > Settings > Connection
2. Enable Require users to be connected before they can message each other
3. Go to Group > Send Messages in the front end.


### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
