### PR TITLE
'Comments' option not appearing for Posts in Activity. 

### DIFF
--- a/src/bp-blogs/bp-blogs-activity.php
+++ b/src/bp-blogs/bp-blogs-activity.php
@@ -133,13 +133,13 @@ function bp_blogs_register_post_tracking_args( $params = null, $post_type = 0 ) 
 		$bp_exclude_cpt = array( 'forum', 'topic', 'reply', 'page', 'attachment', 'bp-group-type', 'bp-member-type' );
 
 		$bp_allowed_cpt = array();
-		foreach ( $post_types as $post_type ) {
+		foreach ( $post_types as $p_type ) {
 			// Exclude all the custom post type which is already in BuddyPress Activity support.
-			if ( in_array( $post_type, $bp_exclude_cpt, true ) ) {
+			if ( in_array( $p_type, $bp_exclude_cpt, true ) ) {
 				continue;
 			}
 
-			$bp_allowed_cpt[] = $post_type;
+			$bp_allowed_cpt[] = $p_type;
 		}
 
 		$comment_post_types       = apply_filters( 'bp_blogs_record_comment_post_types', $bp_allowed_cpt );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #925 .

### How to test the changes in this Pull Request:
1. Create a post.
2. Enable http://prntscr.com/sk45yh
3. You will not see the comments option for Post in activity.

### Proof Screenshots or Video
http://prntscr.com/t2qzp9
http://prntscr.com/t2qzvw
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

