### PR TITLE
bug fix re call to distance search icon for Profile Search

### DIFF
--- a/src/bp-core/profile-search/templates/members/bps-form-default.php
+++ b/src/bp-core/profile-search/templates/members/bps-form-default.php
@@ -130,7 +130,7 @@ foreach ( $F->fields as $f ) {
 			$km          = __( 'km', 'buddyboss' );
 			$miles       = __( 'miles', 'buddyboss' );
 			$placeholder = __( 'Start typing, then select a location', 'buddyboss' );
-			$icon_url    = plugins_url( 'bp-profile-search/templates/members/locator.png' );
+			$icon_url    = BP_PLATFORM_API . 'bp-core/profile-search/templates/members/locator.png';
 			$icon_title  = __( 'get current location', 'buddyboss' );
 			?>
 			<input type="number" min="1" style="width: 5em;" name="<?php echo $name . '[distance]'; ?>" value="<?php echo $value['distance']; ?>">
@@ -160,7 +160,7 @@ foreach ( $F->fields as $f ) {
 			?>
 			<select id="<?php echo $id; ?>" name="<?php echo $name; ?>">
 			<?php foreach ( $f->options as $key => $label ) { ?>
-				<option 
+				<option
 				<?php
 				if ( $key == $value ) {
 					echo 'selected="selected"';}
@@ -175,7 +175,7 @@ foreach ( $F->fields as $f ) {
 			?>
 			<select id="<?php echo $id; ?>" name="<?php echo $name . '[]'; ?>" multiple="multiple">
 			<?php foreach ( $f->options as $key => $label ) { ?>
-				<option 
+				<option
 				<?php
 				if ( in_array( $key, $f->values ) ) {
 					echo 'selected="selected"';}
@@ -189,7 +189,7 @@ foreach ( $F->fields as $f ) {
 		case 'radio':
 			?>
 			<?php foreach ( $f->options as $key => $label ) { ?>
-				<label><input type="radio" 
+				<label><input type="radio"
 				<?php
 				if ( $key == $value ) {
 					echo 'checked="checked"';}
@@ -203,7 +203,7 @@ foreach ( $F->fields as $f ) {
 		case 'checkbox':
 			?>
 			<?php foreach ( $f->options as $key => $label ) { ?>
-				<label><input type="checkbox" 
+				<label><input type="checkbox"
 				<?php
 				if ( in_array( $key, $f->values ) ) {
 					echo 'checked="checked"';}

--- a/src/bp-core/profile-search/templates/members/bps-form-default.php
+++ b/src/bp-core/profile-search/templates/members/bps-form-default.php
@@ -130,7 +130,7 @@ foreach ( $F->fields as $f ) {
 			$km          = __( 'km', 'buddyboss' );
 			$miles       = __( 'miles', 'buddyboss' );
 			$placeholder = __( 'Start typing, then select a location', 'buddyboss' );
-			$icon_url    = BP_PLATFORM_API . 'bp-core/profile-search/templates/members/locator.png';
+			$icon_url    = buddypress()->plugin_url . 'bp-core/profile-search/templates/members/locator.png';
 			$icon_title  = __( 'get current location', 'buddyboss' );
 			?>
 			<input type="number" min="1" style="width: 5em;" name="<?php echo $name . '[distance]'; ?>" value="<?php echo $value['distance']; ?>">

--- a/src/bp-templates/bp-nouveau/buddypress/common/search/profile-search.php
+++ b/src/bp-templates/bp-nouveau/buddypress/common/search/profile-search.php
@@ -222,7 +222,7 @@ $F = bp_profile_search_escaped_form_data( $form_id );
 					$km          = __( 'km', 'buddyboss' );
 					$miles       = __( 'miles', 'buddyboss' );
 					$placeholder = __( 'Start typing, then select a location', 'buddyboss' );
-					$icon_url    = BP_PLATFORM_API . 'bp-core/profile-search/templates/members/locator.png';
+					$icon_url    = buddypress()->plugin_url  . 'bp-core/profile-search/templates/members/locator.png';
 					$icon_title  = __( 'get current location', 'buddyboss' ); ?>
 
 					<input type="number" min="1" name="<?php echo $name . '[distance]'; ?>" value="<?php echo $value['distance']; ?>"/>

--- a/src/bp-templates/bp-nouveau/buddypress/common/search/profile-search.php
+++ b/src/bp-templates/bp-nouveau/buddypress/common/search/profile-search.php
@@ -222,7 +222,7 @@ $F = bp_profile_search_escaped_form_data( $form_id );
 					$km          = __( 'km', 'buddyboss' );
 					$miles       = __( 'miles', 'buddyboss' );
 					$placeholder = __( 'Start typing, then select a location', 'buddyboss' );
-					$icon_url    = plugins_url( 'bp-profile-search/templates/members/locator.png' );
+					$icon_url    = BP_PLATFORM_API . 'bp-core/profile-search/templates/members/locator.png';
 					$icon_title  = __( 'get current location', 'buddyboss' ); ?>
 
 					<input type="number" min="1" name="<?php echo $name . '[distance]'; ?>" value="<?php echo $value['distance']; ?>"/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?

### Changes proposed in this Pull Request:

Change the call for the locator.png so that it is loaded from its actual location in Platform. 

Fixes #1073

### How to test the changes in this Pull Request:

1. Install Version 4.1 of the BP xProfile Location plugin
2. In Platform > Profile Search, add a Location field and set search mode to distance
3. Go to the members directory
4. The locator.png should no longer be 404

BP xProfile Location: https://wordpress.org/plugins/bp-xprofile-location/
