### PR TITLE
Update bp-core-avatars.php

### DIFF
--- a/src/bp-core/bp-core-avatars.php
+++ b/src/bp-core/bp-core-avatars.php
@@ -199,7 +199,7 @@ function bp_core_fetch_avatar( $args = '' ) {
 	$bp = buddypress();
 
 	// If avatars are disabled for the root site, obey that request and bail.
-	if ( ! $bp->avatar->show_avatars ) {
+	if ( ! $bp->avatar || ! $bp->avatar->show_avatars ) {
 		return;
 	}
 

--- a/src/bp-core/bp-core-avatars.php
+++ b/src/bp-core/bp-core-avatars.php
@@ -199,7 +199,7 @@ function bp_core_fetch_avatar( $args = '' ) {
 	$bp = buddypress();
 
 	// If avatars are disabled for the root site, obey that request and bail.
-	if ( ! $bp->avatar || ! $bp->avatar->show_avatars ) {
+	if ( ! $bp->avatar->show_avatars ) {
 		return;
 	}
 

--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -1970,6 +1970,8 @@ function bp_xprofile_get_member_display_name( $user_id = null ) {
 			}
 			break;
 	}
+	
+	if ( ! isset( $display_name ) ) $display_name = '';
 
 	return apply_filters( 'bp_xprofile_get_member_display_name', trim( $display_name ), $user_id );
 }


### PR DESCRIPTION
Same as the BP patch
https://buddypress.trac.wordpress.org/ticket/8177
Prevent errors when get_avatar() is used before BP Globals are set

