### PR TITLE
Update bp-core-avatars.php

### DIFF
--- a/src/bp-core/bp-core-avatars.php
+++ b/src/bp-core/bp-core-avatars.php
@@ -199,7 +199,7 @@ function bp_core_fetch_avatar( $args = '' ) {
 	$bp = buddypress();
 
 	// If avatars are disabled for the root site, obey that request and bail.
-	if ( ! $bp->avatar->show_avatars ) {
+	if ( ! $bp->avatar || ! $bp->avatar->show_avatars ) {
 		return;
 	}
 


### PR DESCRIPTION
See [https://github.com/buddyboss/buddyboss-platform/issues/1104](https://github.com/buddyboss/buddyboss-platform/issues/1104)
Same as the BP patch
https://buddypress.trac.wordpress.org/ticket/8177
Prevent errors when get_avatar() is used before BP Globals are set
