### PR TITLE
#1107 Private Network - Public Content not showing in settings when you have a dynamic/Memcached cache enable

### DIFF
--- a/src/bp-core/admin/settings/bp-admin-setting-general.php
+++ b/src/bp-core/admin/settings/bp-admin-setting-general.php
@@ -98,8 +98,8 @@ class BP_Admin_Setting_General extends BP_Admin_Setting_tab {
 
 		// Private Network Settings.
 		$this->add_field( 'bp-enable-private-network', __( 'Private Network', 'buddyboss' ), 'bp_admin_setting_callback_private_network', 'intval' );
-		$enable_private_network = bp_get_option( 'bp-enable-private-network' );
-		if ( '0' === $enable_private_network ) {
+		$enable_private_network = bp_enable_private_network();
+		if ( ! $enable_private_network ) {
 			$this->add_field( 'bp-enable-private-network-public-content', __( 'Public Content', 'buddyboss' ), 'bp_admin_setting_callback_private_network_public_content' );
 		}
 		$this->add_field( 'bp-privacy-tutorial', '', 'bp_privacy_tutorial' );

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -1133,7 +1133,7 @@ function bp_private_network_template_redirect() {
 
 	if ( ! is_user_logged_in() ) {
 
-		$enable_private_network = bp_get_option( 'bp-enable-private-network' );
+		$enable_private_network = bp_enable_private_network();
 
 		$page_ids            = bp_core_get_directory_page_ids();
 		$terms               = false;
@@ -1143,7 +1143,7 @@ function bp_private_network_template_redirect() {
 		$id                  = ( ! empty( $id ) ) ? $id : 0;
 		$activate            = ( bp_is_activation_page() && ( '' !== bp_get_current_activation_key() || isset( $_GET['activated'] ) ) ) ? true : false;
 
-		if ( '0' === $enable_private_network ) {
+		if ( ! $enable_private_network ) {
 
 			if ( apply_filters( 'bp_private_network_pre_check', false ) ) {
 				return;
@@ -1426,9 +1426,9 @@ function bp_remove_wc_lostpassword_url( $default_url = '' ) {
 
 	if ( ! is_user_logged_in() ) {
 
-		$enable_private_network = bp_get_option( 'bp-enable-private-network' );
+		$enable_private_network = bp_enable_private_network();
 
-		if ( '0' === $enable_private_network ) {
+		if ( ! $enable_private_network ) {
 
 			$args = array( 'action' => 'lostpassword' );
 			if ( ! empty( $redirect ) ) {
@@ -1460,9 +1460,9 @@ function bp_core_change_privacy_policy_link_on_private_network( $link, $privacy_
 
 	if ( ! is_user_logged_in() ) {
 
-		$enable_private_network = bp_get_option( 'bp-enable-private-network' );
+		$enable_private_network = bp_enable_private_network();
 
-		if ( '0' === $enable_private_network ) {
+		if ( ! $enable_private_network ) {
 
 			$privacy_policy_url = get_privacy_policy_url();
 			$policy_page_id     = (int) get_option( 'wp_page_for_privacy_policy' );

--- a/src/bp-core/bp-core-options.php
+++ b/src/bp-core/bp-core-options.php
@@ -776,6 +776,13 @@ function bp_disable_account_deletion( $default = false ) {
  *              false.
  */
 function bp_enable_private_network( $default = false ) {
+	global $bp;
+
+	if ( isset( $bp ) && isset( $bp->site_options ) && is_array( $bp->site_options ) && isset( $bp->site_options['bp-enable-private-network'] ) ) {
+		$val = (bool) $bp->site_options['bp-enable-private-network'];
+	} else {
+		$val = (bool) bp_get_option( 'bp-enable-private-network', $default );
+	}
 
 	/**
 	 * Filters whether private network for site is enabled.
@@ -784,7 +791,7 @@ function bp_enable_private_network( $default = false ) {
 	 *
 	 * @param bool $value Whether private network for site is enabled.
 	 */
-	return apply_filters( 'bp_enable_private_network', (bool) bp_get_option( 'bp-enable-private-network', $default ) );
+	return apply_filters( 'bp_enable_private_network', $val );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1107  .


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
