### PR TITLE
BP Integration tab errors and notices with tabs

### DIFF
--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -864,7 +864,18 @@ function bp_core_get_admin_integration_active_tab() {
 function bp_core_get_admin_integration_active_tab_object() {
 	global $bp_admin_integration_tabs;
 
-	return $bp_admin_integration_tabs[ bp_core_get_admin_integration_active_tab() ];
+	$active_tab = bp_core_get_admin_integration_active_tab();
+	if ( isset( $bp_admin_integration_tabs[ $active_tab ] ) ) {
+		return $bp_admin_integration_tabs[ $active_tab ];
+	}
+
+	if ( ! empty( $bp_admin_integration_tabs ) ) {
+		$tabs = array_keys( $bp_admin_integration_tabs );
+
+		return $bp_admin_integration_tabs[ $tabs[0] ];
+	}
+
+	return false;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the notices when integration tab is not available and not set in the global variable.
