### PR TITLE
Joining a group leads to 404

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/groups/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/ajax.php
@@ -246,11 +246,12 @@ function bp_nouveau_ajax_joinleave_group() {
                 // Request is pending
                 $group->is_pending = '1';
 
-                $response = array(
-                    'contents' => bp_get_group_join_button( $group ),
-                    'is_group' => bp_is_group(),
-                    'type'     => 'success',
-                );
+	            $response = array(
+		            'contents'  => bp_get_group_join_button( $group ),
+		            'is_group'  => bp_is_group(),
+		            'type'      => 'success',
+		            'group_url' => ( bp_is_group() ? bp_get_group_permalink( $group ) : '' ),
+	            );
             }
             break;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #961

### How to test the changes in this Pull Request:

1. Create a Profile Type and assign it to a user
2. Create a Group Type, then set its "Profile Type Joining" with the Profile type you just created.
3. Create a new Group and set its Group Type to the one you just created.
4. Log in using the user with the profile type.
5. Go to the group page and you will be redirected to 404.

### Proof Screenshots or Video
http://somup.com/cYie1IQEQr
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
