### PR TITLE
Activity photo comment not working on email notification

### DIFF
--- a/src/bp-activity/bp-activity-filters.php
+++ b/src/bp-activity/bp-activity-filters.php
@@ -501,7 +501,7 @@ function bp_activity_make_nofollow_filter_callback( $matches ) {
 	// Extract URL from href
 	preg_match_all( '#\bhttps?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#', $text, $match );
 
-	$url_host      = parse_url( $match[0][0], PHP_URL_HOST );
+	$url_host      = ( isset( $match[0] ) && isset( $match[0][0] ) ? parse_url( $match[0][0], PHP_URL_HOST ) : '' );
 	$base_url_host = parse_url( site_url(), PHP_URL_HOST );
 
 	// If site link then nothing to do.

--- a/src/bp-core/classes/class-bp-email-tokens.php
+++ b/src/bp-core/classes/class-bp-email-tokens.php
@@ -643,7 +643,22 @@ class BP_Email_Tokens {
 											<tr>
 												<td>
 													<div class="bb-content-body" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: <?php echo esc_attr( $settings['body_text_size'] . 'px' ); ?>; letter-spacing: -0.24px; line-height: <?php echo esc_attr( floor( $settings['body_text_size'] * 1.625 ) . 'px' ); ?>;">
-														<?php echo apply_filters_ref_array( 'bp_get_activity_content_body', array( $activity_comment->content, &$activity_comment ) ); ?>
+														<?php
+														/**
+														 * Display text before activity comment.
+														 */
+														do_action( 'bp_activity_before_email_content', $activity_comment );
+
+														if ( in_array( $activity_comment->content, array( '&nbsp;', '&#8203;' ) ) ) {
+															$activity_comment->content = '';
+														}
+														echo apply_filters_ref_array( 'bp_get_activity_content_body', array( $activity_comment->content, &$activity_comment ) );
+
+                                                        /**
+														 * Display text after activity comment.
+														 */
+														do_action( 'bp_activity_after_email_content', $activity_comment );
+														?>
 													</div>
 												</td>
 											</tr>

--- a/src/bp-document/bp-document-filters.php
+++ b/src/bp-document/bp-document-filters.php
@@ -59,6 +59,8 @@ add_filter( 'bp_repair_list', 'bp_document_add_admin_repair_items' );
 // Change label for global search.
 add_filter( 'bp_search_label_search_type', 'bp_document_search_label_search' );
 
+add_action( 'bp_activity_after_email_content', 'bp_document_activity_after_email_content' );
+
 function bp_document_search_label_search( $type ) {
 
 	if ( 'folders' === $type ) {
@@ -1566,3 +1568,29 @@ function bp_members_filter_folder_public_scope( $retval = array(), $filter = arr
 }
 
 add_filter( 'bp_document_set_folder_public_scope_args', 'bp_members_filter_folder_public_scope', 10, 2 );
+
+/**
+ * Added text on the email when replied on the activity.
+ *
+ * @since BuddyBoss 1.4.7
+ *
+ * @param BP_Activity_Activity $activity Activity Object.
+ */
+function bp_document_activity_after_email_content( $activity ) {
+	$document_ids = bp_activity_get_meta( $activity->id, 'bp_document_ids', true );
+
+	if ( ! empty( $document_ids ) ) {
+		$document_ids = explode( ',', $document_ids );
+		$document_text = sprintf(
+		        _n( '%s Document', '%s Documents', count( $document_ids) , 'buddyboss' ),
+                number_format_i18n( count( $document_ids ) )
+        );
+		$content   = sprintf(
+	    	/* translator: 1. Activity link, 2. Activity document count */
+			__( '<a href="%1$s" target="_blank">%2$s Uploaded.</a>', 'buddyboss' ),
+			bp_activity_get_permalink( $activity->id ),
+			$document_text
+		);
+		echo wpautop( $content );
+	}
+}

--- a/src/bp-document/bp-document-loader.php
+++ b/src/bp-document/bp-document-loader.php
@@ -19,4 +19,4 @@ defined( 'ABSPATH' ) || exit;
 function bp_setup_document() {
 	buddypress()->document = new BP_Document_Component();
 }
-add_action( 'bp_setup_components', 'bp_setup_document', 6 );
+add_action( 'bp_setup_components', 'bp_setup_document', 5 );

--- a/src/bp-media/bp-media-filters.php
+++ b/src/bp-media/bp-media-filters.php
@@ -57,6 +57,8 @@ add_filter( 'bp_repair_list', 'bp_media_add_admin_repair_items' );
 // Download Media.
 add_action( 'init', 'bp_media_download_url_file' );
 
+add_action( 'bp_activity_after_email_content', 'bp_media_activity_after_email_content' );
+
 /**
  * Add media theatre template for activity pages
  */
@@ -228,6 +230,7 @@ function bp_media_activity_comment_entry( $comment_id ) {
 		'include'  => $media_ids,
 		'order_by' => 'menu_order',
 		'sort'     => 'ASC',
+        'user_id'  => false,
 	);
 
 	if ( bp_is_active( 'groups' ) && buddypress()->groups->id === $activity->component ) {
@@ -1887,4 +1890,26 @@ function bp_media_parse_file_path( $file_path ) {
 			'remote_file' => $remote_file,
 			'file_path'   => $file_path,
 	);
+}
+
+/**
+ * Added text on the email when replied on the activity.
+ *
+ * @since BuddyBoss 1.4.7
+ *
+ * @param BP_Activity_Activity $activity Activity Object.
+ */
+function bp_media_activity_after_email_content( $activity ) {
+	$media_ids = bp_activity_get_meta( $activity->id, 'bp_media_ids', true );
+
+	if ( ! empty( $media_ids ) ) {
+		$media_ids = explode( ',', $media_ids );
+		$content   = sprintf(
+		    /* translator: 1. Activity link, 2. Activity media count */
+			__( '<a href="%1$s" target="_blank">%2$s Media Uploaded.</a>', 'buddyboss' ),
+			bp_activity_get_permalink( $activity->id ),
+			count( $media_ids )
+		);
+		echo wpautop( $content );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #982 

### How to test the changes in this Pull Request:

1. Post something in Activity
2. Log in as another user and comment a photo to the activity post
3. Check your email for notification
4. See error

### Proof Screenshots or Video
Added text with the count and link with that comment to see the photo and documents.
http://prntscr.com/tcjhpp
http://prntscr.com/tcjhzf

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

