### PR TITLE
#1144 Fix Group documents breadcrumb does not work when the documents page slug is not documents

### DIFF
--- a/src/bp-document/bp-document-functions.php
+++ b/src/bp-document/bp-document-functions.php
@@ -1936,10 +1936,10 @@ function bp_document_folder_bradcrumb( $folder_id ) {
 			$link     = '';
 			$group_id = (int) $element['group_id'];
 			if ( 0 === $group_id ) {
-				$link = bp_displayed_user_domain() . bp_get_document_root_slug() . '/folders/' . $element['id'];
+				$link = bp_displayed_user_domain() . bp_get_document_slug() . '/folders/' . $element['id'];
 			} else {
 				$group = groups_get_group( array( 'group_id' => $group_id ) );
-				$link  = bp_get_group_permalink( $group ) . bp_get_document_root_slug() . '/folders/' . $element['id'];
+				$link  = bp_get_group_permalink( $group ) . bp_get_document_slug() . '/folders/' . $element['id'];
 			}
 			$html .= '<li> <a href=" ' . $link . ' ">' . stripslashes( $element['title'] ) . '</a></li>';
 		}


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1144  

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
