### PR TITLE
Warning: DOMDocument::loadHTML(): htmlParseEntityRef: expecting ';' in Entity, Error when Popup Builder Plugin install with #1152

### DIFF
--- a/src/bp-integrations/compatibility/bp-compatibility-integration.php
+++ b/src/bp-integrations/compatibility/bp-compatibility-integration.php
@@ -53,7 +53,7 @@ class BP_Compatibility_Integration extends BP_Integration {
 		$htmlDom = new DOMDocument;
 
 		// Parse the HTML of the page using DOMDocument::loadHTML
-		$htmlDom->loadHTML($link['settings']);
+		@$htmlDom->loadHTML($link['settings']);
 
 		// Extract the links from the HTML.
 		$links = $htmlDom->getElementsByTagName('a');

--- a/src/bp-integrations/compatibility/bp-compatibility-integration.php
+++ b/src/bp-integrations/compatibility/bp-compatibility-integration.php
@@ -53,21 +53,21 @@ class BP_Compatibility_Integration extends BP_Integration {
 		$htmlDom = new DOMDocument;
 
 		// Parse the HTML of the page using DOMDocument::loadHTML
-		@$htmlDom->loadHTML($link['settings']);
+		$htmlDom->loadHTML( htmlentities( $link['settings'] ) );
 
 		// Extract the links from the HTML.
-		$links = $htmlDom->getElementsByTagName('a');
+		$links = $htmlDom->getElementsByTagName( 'a' );
 
 		$extractedLinks = array();
 
-		if ( !empty( $links ) ) {
+		if ( ! empty( $links ) ) {
 			foreach ( $links as $link_obj ) {
-				$extractedLinks[] = $link_obj->getAttribute('href');
+				$extractedLinks[] = $link_obj->getAttribute( 'href' );
 			}
 		}
 
 		if (
-			!empty( $extractedLinks )
+			! empty( $extractedLinks )
 			&& in_array( bp_get_admin_url( add_query_arg( array( 'page' => 'bp-settings' ), 'admin.php' ) ), $extractedLinks )
 		) {
 			// Add a few links to the existing links array.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1152.

### Changelog entry

> Added @ at the line `$htmlDom->loadHTML($link['settings']);` on file `wp-content/plugins/buddyboss-platform/src/bp-integrations/compatibility/bp-compatibility-integration.php`
