### PR TITLE
Time Stamp conflict with TranslatePress #1155

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -1316,7 +1316,7 @@ function bp_core_time_since( $older_date, $newer_date = false ) {
 			}
 
 			// No output, so happened right now.
-			if ( ! (int) trim( $output ) ) {
+			if ( ! (int) $count || ! (int) $count2 ) {
 				$output = $right_now_text;
 			}
 		}

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -1254,6 +1254,7 @@ function bp_core_time_since( $older_date, $newer_date = false ) {
 			$output = $right_now_text;
 
 		} else {
+			$output = '';
 
 			// Set output var.
 			switch ( $seconds ) {
@@ -1316,7 +1317,7 @@ function bp_core_time_since( $older_date, $newer_date = false ) {
 			}
 
 			// No output, so happened right now.
-			if ( ! (int) $count && ! (int) $count2 ) {
+			if ( ! (int) trim( $output ) ) {
 				$output = $right_now_text;
 			}
 		}

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -1316,7 +1316,7 @@ function bp_core_time_since( $older_date, $newer_date = false ) {
 			}
 
 			// No output, so happened right now.
-			if ( ! (int) $count || ! (int) $count2 ) {
+			if ( ! (int) $count && ! (int) $count2 ) {
 				$output = $right_now_text;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The issue was time stamp translating, when we typecast full translated ago time to (int), it will return 0 which is false, so `right now` text showing. at `bp_core_time_since()` `wp-content/plugins/buddyboss-platform/src/bp-core/bp-core-functions.php` line number `1319`, So I fixed it by typecasting `$count` and `$count2` which is raw time count and it will convert easily to an integer.





<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> The issue was time stamp translating, when we typecast full translated ago time to (int), it will return 0 which is false, so `right now` text showing. at `bp_core_time_since()` `wp-content/plugins/buddyboss-platform/src/bp-core/bp-core-functions.php` line number `1319`, So I fixed it by typecasting `$count` and `$count2` which is raw time count and it will convert easily to an integer.

