### PR TITLE
"reinstall emails" link brings me to "not allowed" page

### DIFF
--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -1297,16 +1297,13 @@ function bp_admin_email_maybe_add_translation_notice() {
 		return;
 	}
 
-	if ( bp_core_do_network_admin() ) {
-		$admin_page = 'admin.php';
-	} else {
-		$admin_page = 'tools.php';
-	}
-
 	bp_core_add_admin_notice(
 		sprintf(
 			__( 'Are these emails not written in your site\'s language? Go to <a href="%s">BuddyBoss Tools and try the "reinstall emails"</a> tool.', 'buddyboss' ),
-			esc_url( add_query_arg( 'page', 'bp-tools', bp_get_admin_url( $admin_page ) ) )
+			esc_url( add_query_arg( array(
+				'page' => 'bp-repair-community',
+				'tab'  => 'bp-repair-community',
+			), bp_get_admin_url( 'admin.php' ) ) )
 		),
 		'updated'
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #939 

### How to test the changes in this Pull Request:

1. Go to Setting and change the language to non-English.
1. Go to WP Admin -> BuddyBoss -> Emails
2. Click on "try the "reinstall emails" tool" link
3. The browser opens new window
4. See the error “Sorry, you are not allowed to access this page”

### Proof Screenshots or Video
http://prntscr.com/te42tv

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?