### PR TITLE
fix - When comment threading limit is reached there should still be a…

### DIFF
--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -3046,22 +3046,22 @@ function bp_activity_can_comment_reply( $comment = false ) {
 		$comment = bp_activity_current_comment();
 	}
 
-	if ( ! empty( $comment ) ) {
-
-		// Fall back on current comment in activity loop.
-		$comment_depth = isset( $comment->depth )
-			? intval( $comment->depth )
-			: bp_activity_get_comment_depth( $comment );
-
-		// Threading is turned on, so check the depth.
-		if ( get_option( 'thread_comments' ) ) {
-			$can_comment = (bool) ( $comment_depth < get_option( 'thread_comments_depth' ) );
-
-			// No threading for comment replies if no threading for comments.
-		} else {
-			$can_comment = false;
-		}
-	}
+//	if ( ! empty( $comment ) ) {
+//
+//		// Fall back on current comment in activity loop.
+//		$comment_depth = isset( $comment->depth )
+//			? intval( $comment->depth )
+//			: bp_activity_get_comment_depth( $comment );
+//
+//		// Threading is turned on, so check the depth.
+//		if ( get_option( 'thread_comments' ) ) {
+//			$can_comment = (bool) ( $comment_depth < get_option( 'thread_comments_depth' ) );
+//
+//			// No threading for comment replies if no threading for comments.
+//		} else {
+//			$can_comment = false;
+//		}
+//	}
 
 	/**
 	 * Filters whether a comment can be made on an activity reply item.

--- a/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -968,9 +968,9 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 		 * If post comment / Activity comment sync is on, it's safer
 		 * to unset the comment button just before returning it.
 		 */
-//		if ( ! bp_activity_can_comment_reply( bp_activity_current_comment() ) ) {
-//			unset( $return['activity_comment_reply'] );
-//		}
+		if ( ! bp_activity_can_comment_reply( bp_activity_current_comment() ) ) {
+			unset( $return['activity_comment_reply'] );
+		}
 
 		/**
 		 * If there was an activity of the user before one af another


### PR DESCRIPTION
… reply button but the comments should not indent

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Comment on activity of any kind or type
2. It should allow commenting and replying on every level

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
