### PR TITLE
Activate Page title issue when Rank Math Plugin is active

### DIFF
--- a/src/bp-core/compatibility/bp-rankmath-plugin-helpers.php
+++ b/src/bp-core/compatibility/bp-rankmath-plugin-helpers.php
@@ -87,6 +87,10 @@ class BP_RankMath_Title implements IPaper {
  */
 function bp_helper_rankmath_group_page_support( $title ) {
 
+	if ( bp_is_current_component( 'activate' ) || bp_is_current_component( 'register' ) ) {
+		return;
+	}
+
 	if (
 		bp_is_active( 'groups' ) && ! empty( buddypress()->groups->current_group )
 		|| bp_is_user()


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #919 .

### How to test the changes in this Pull Request:

1. Go to 'Activate Rank Math plugin '
2.  Go to the user Register page and activate page that has activation key in the slug.
3. See error

### Proof Screenshots or Video
**Before:** 
- Register: http://prntscr.com/tfaiq4
- Activate: http://prntscr.com/tfaj48

**After:** 
- Register: http://prntscr.com/tfajo6
- Activate: http://prntscr.com/tfajsz

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->