### PR TITLE
Quotes in discussion title are messed up in backend and produce informal quotes in frontend #1035

### DIFF
--- a/src/bp-forums/topics/functions.php
+++ b/src/bp-forums/topics/functions.php
@@ -174,7 +174,7 @@ function bbp_new_topic_handler( $action = '' ) {
 	/** Discussion Title */
 
 	if ( ! empty( $_POST['bbp_topic_title'] ) ) {
-		$topic_title = esc_attr( strip_tags( $_POST['bbp_topic_title'] ) );
+		$topic_title = sanitize_text_field( strip_tags( $_POST['bbp_topic_title'] ) );
 	}
 
 	// Filter and sanitize.

--- a/src/bp-forums/topics/functions.php
+++ b/src/bp-forums/topics/functions.php
@@ -174,7 +174,7 @@ function bbp_new_topic_handler( $action = '' ) {
 	/** Discussion Title */
 
 	if ( ! empty( $_POST['bbp_topic_title'] ) ) {
-		$topic_title = sanitize_text_field( strip_tags( $_POST['bbp_topic_title'] ) );
+		$topic_title = sanitize_text_field( $_POST['bbp_topic_title'] );
 	}
 
 	// Filter and sanitize.


### PR DESCRIPTION
…mal quotes in frontend

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1035.

### How to test the changes in this Pull Request:

1. Checked backend issue, it exists, quotes converted to HTML entities.
2. replaced `esc_attr()` to `sanitize_text_field()` as `esc_attr()` used for show output of the value, we will insert the data to the database, so here, `sanitize_text_field()` we will use.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed: Quotes in discussion title are messed up in backend and produce informal quotes in frontend #1035. replaced `esc_attr()` to `sanitize_text_field()` as `esc_attr()` used for show output of the value, we will insert the data to the database, so here, `sanitize_text_field()` we will use.
