### PR TITLE
Private messaging not working when Members component page is non-english

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/messages/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/functions.php
@@ -125,7 +125,7 @@ function bp_nouveau_messages_localize_scripts( $params = array() ) {
 			'one'  => __( '1 other', 'buddyboss' ),
 			'more' => __( '%d others', 'buddyboss' ),
 		),
-		'rootUrl'                    => wp_parse_url( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() ), PHP_URL_PATH ),
+		'rootUrl'                    => urldecode( wp_parse_url( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() ), PHP_URL_PATH ) ),
 		'hasThreads'                 => bp_has_message_threads( bp_ajax_querystring( 'messages' ) )
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1173 

### How to test the changes in this Pull Request:

1. Create a page and use non-English characters as title like "کاربران"
2. Set this page as a component page for Members https://nimb.ws/dIN5Da
3. Now go to your private messaging, notice it is not working. https://nimb.ws/RatOBE

### Proof Screenshots or Video
http://prntscr.com/tgumif

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->