### PR TITLE
Only Me option not working on Photo upload ( anyone can see that photo & also without login )

### DIFF
--- a/src/bp-members/bp-members-filters.php
+++ b/src/bp-members/bp-members-filters.php
@@ -184,9 +184,21 @@ function bp_members_filter_media_personal_scope( $retval = array(), $filter = ar
 			: bp_loggedin_user_id();
 	}
 
-	$privacy = array( 'public', 'loggedin', 'onlyme' );
-	if ( bp_is_active( 'friends' ) ) {
-		$privacy[] = 'friends';
+	$privacy = array( 'public', 'loggedin' );
+
+	if ( (int) $user_id === (int) bp_loggedin_user_id() ) {
+		$privacy[] = 'onlyme';
+	}
+
+	if ( bp_is_active( 'friends' ) && bp_is_profile_media_support_enabled() ) {
+		if ( (int) $user_id === (int) bp_loggedin_user_id() ) {
+			$privacy[] = 'friends';
+		} else {
+			$friends = friends_get_friend_user_ids( $user_id );
+			if ( ! empty( $friends ) && in_array( (int) bp_loggedin_user_id(), $friends, true ) ) {
+				$privacy[] = 'friends';
+			}
+		}
 	}
 
 	$retval = array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1211

### How to test the changes in this Pull Request:

1. Go to Activity Feed section
2. Click on the Upload photo icon and upload a photo
3. set the visible mod to only me.
4. See it with an incognito mode or log in with other users you can see the photo.

### Proof Screenshots or Video
Current User: 
http://prntscr.com/tmm9oq
http://prntscr.com/tmm9an

Other users profile: 
http://prntscr.com/tmmarm

Without logged in:
http://prntscr.com/tmm9x7

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
