### PR TITLE
added a visual setting for max upload size for media and documents

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4848,3 +4848,48 @@ function bp_core_hide_display_name_field( $field_id = 0 ) {
 	 */
 	return ( bool ) apply_filters( 'bp_core_hide_display_name_field', $retval, $field_id );
 }
+
+/**
+ * Return the file upload max size in bytes.
+ *
+ * @return mixed|void
+ *
+ * @since BuddyBoss 1.4.8
+ */
+function bp_core_upload_max_size() {
+
+	static $max_size = - 1;
+
+	if ( $max_size < 0 ) {
+		// Start with post_max_size.
+		$size = @ini_get( 'post_max_size' );
+		$unit = preg_replace( '/[^bkmgtpezy]/i', '', $size ); // Remove the non-unit characters from the size.
+		$size = preg_replace( '/[^0-9\.]/', '', $size ); // Remove the non-numeric characters from the size.
+		if ( $unit ) {
+			$post_max_size = round( $size * pow( 1024, stripos( 'bkmgtpezy', $unit[0] ) ) );
+		} else {
+			$post_max_size = round( $size );
+		}
+
+		if ( $post_max_size > 0 ) {
+			$max_size = $post_max_size;
+		}
+
+		// If upload_max_size is less, then reduce. Except if upload_max_size is
+		// zero, which indicates no limit.
+		$size = @ini_get( 'upload_max_filesize' );
+		$unit = preg_replace( '/[^bkmgtpezy]/i', '', $size ); // Remove the non-unit characters from the size.
+		$size = preg_replace( '/[^0-9\.]/', '', $size ); // Remove the non-numeric characters from the size.
+		if ( $unit ) {
+			$upload_max = round( $size * pow( 1024, stripos( 'bkmgtpezy', $unit[0] ) ) );
+		} else {
+			$upload_max = round( $size );
+		}
+		if ( $upload_max > 0 && $upload_max < $max_size ) {
+			$max_size = $upload_max;
+		}
+	}
+
+	return apply_filters( 'bp_core_upload_max_size', $max_size );
+
+}

--- a/src/bp-document/bp-document-functions.php
+++ b/src/bp-document/bp-document-functions.php
@@ -259,40 +259,8 @@ function bp_document_folder_add_meta( $folder_id, $meta_key, $meta_value, $uniqu
  * @return string
  * @since BuddyBoss 1.4.0
  */
-function bp_document_file_upload_max_size( $post_string = false, $type = 'bytes' ) {
-	static $max_size = - 1;
-
-	if ( $max_size < 0 ) {
-		// Start with post_max_size.
-		$size = @ini_get( 'post_max_size' );
-		$unit = preg_replace( '/[^bkmgtpezy]/i', '', $size ); // Remove the non-unit characters from the size.
-		$size = preg_replace( '/[^0-9\.]/', '', $size );      // Remove the non-numeric characters from the size.
-		if ( $unit ) {
-			$post_max_size = round( $size * pow( 1024, stripos( 'bkmgtpezy', $unit[0] ) ) );
-		} else {
-			$post_max_size = round( $size );
-		}
-
-		if ( $post_max_size > 0 ) {
-			$max_size = $post_max_size;
-		}
-
-		// If upload_max_size is less, then reduce. Except if upload_max_size is
-		// zero, which indicates no limit.
-		$size = @ini_get( 'upload_max_filesize' );
-		$unit = preg_replace( '/[^bkmgtpezy]/i', '', $size ); // Remove the non-unit characters from the size.
-		$size = preg_replace( '/[^0-9\.]/', '', $size );      // Remove the non-numeric characters from the size.
-		if ( $unit ) {
-			$upload_max = round( $size * pow( 1024, stripos( 'bkmgtpezy', $unit[0] ) ) );
-		} else {
-			$upload_max = round( $size );
-		}
-		if ( $upload_max > 0 && $upload_max < $max_size ) {
-			$max_size = $upload_max;
-		}
-	}
-
-	return apply_filters( 'bp_document_file_upload_max_size', bp_document_format_size_units( $max_size, $post_string, $type ) );
+function bp_document_file_upload_max_size() {
+	return apply_filters( 'bp_document_file_upload_max_size', bp_media_allowed_upload_document_size() );
 }
 
 /**
@@ -1399,8 +1367,7 @@ function bp_document_upload_handler( $file_id = 'file' ) {
 			'test_form'            => false,
 			'upload_error_strings' => array(
 				false,
-				__( 'The uploaded file exceeds ', 'buddyboss' ) . bp_document_file_upload_max_size( true ),
-				__( 'The uploaded file exceeds ', 'buddyboss' ) . bp_document_file_upload_max_size( true ),
+				__( 'The uploaded file exceeds ', 'buddyboss' ) . bp_document_file_upload_max_size(),
 				__( 'The uploaded file was only partially uploaded.', 'buddyboss' ),
 				__( 'No file was uploaded.', 'buddyboss' ),
 				'',

--- a/src/bp-media/bp-media-functions.php
+++ b/src/bp-media/bp-media-functions.php
@@ -112,8 +112,7 @@ function bp_media_upload_handler( $file_id = 'file' ) {
 			'test_form'            => false,
 			'upload_error_strings' => array(
 				false,
-				__( 'The uploaded file exceeds ', 'buddyboss' ) . bp_media_file_upload_max_size( true ),
-				__( 'The uploaded file exceeds ', 'buddyboss' ) . bp_media_file_upload_max_size( true ),
+				__( 'The uploaded file exceeds ', 'buddyboss' ) . bp_media_file_upload_max_size(),
 				__( 'The uploaded file was only partially uploaded.', 'buddyboss' ),
 				__( 'No file was uploaded.', 'buddyboss' ),
 				'',
@@ -184,40 +183,8 @@ function bp_media_compress_image( $source, $destination, $quality = 90 ) {
  *
  * @return string
  */
-function bp_media_file_upload_max_size( $post_string = false, $type = 'bytes' ) {
-	static $max_size = - 1;
-
-	if ( $max_size < 0 ) {
-		// Start with post_max_size.
-		$size = @ini_get( 'post_max_size' );
-		$unit = preg_replace( '/[^bkmgtpezy]/i', '', $size ); // Remove the non-unit characters from the size.
-		$size = preg_replace( '/[^0-9\.]/', '', $size ); // Remove the non-numeric characters from the size.
-		if ( $unit ) {
-			$post_max_size = round( $size * pow( 1024, stripos( 'bkmgtpezy', $unit[0] ) ) );
-		} else {
-			$post_max_size = round( $size );
-		}
-
-		if ( $post_max_size > 0 ) {
-			$max_size = $post_max_size;
-		}
-
-		// If upload_max_size is less, then reduce. Except if upload_max_size is
-		// zero, which indicates no limit.
-		$size = @ini_get( 'upload_max_filesize' );
-		$unit = preg_replace( '/[^bkmgtpezy]/i', '', $size ); // Remove the non-unit characters from the size.
-		$size = preg_replace( '/[^0-9\.]/', '', $size ); // Remove the non-numeric characters from the size.
-		if ( $unit ) {
-			$upload_max = round( $size * pow( 1024, stripos( 'bkmgtpezy', $unit[0] ) ) );
-		} else {
-			$upload_max = round( $size );
-		}
-		if ( $upload_max > 0 && $upload_max < $max_size ) {
-			$max_size = $upload_max;
-		}
-	}
-
-	return apply_filters( 'bp_media_file_upload_max_size', bp_media_format_size_units( $max_size, $post_string, $type ) );
+function bp_media_file_upload_max_size() {
+	return apply_filters( 'bp_media_file_upload_max_size', bp_media_allowed_upload_media_size() );
 }
 
 /**

--- a/src/bp-media/bp-media-settings.php
+++ b/src/bp-media/bp-media-settings.php
@@ -233,6 +233,20 @@ function bp_media_get_settings_fields() {
 		);
 	}
 
+	$fields['bp_media_settings_photos']['bp_media_allowed_size'] = array(
+		'title'             => __( 'Allowed Max File Size', 'buddyboss' ),
+		'callback'          => 'bp_media_settings_callback_media_allowed_size',
+		'sanitize_callback' => 'absint',
+		'args'              => array(),
+	);
+
+	$fields['bp_media_settings_documents']['bp_document_allowed_size'] = array(
+		'title'             => __( 'Allowed Max File Size', 'buddyboss' ),
+		'callback'          => 'bp_media_settings_callback_document_allowed_size',
+		'sanitize_callback' => 'absint',
+		'args'              => array(),
+	);
+
 	$fields['bp_media_settings_documents']['bp_media_extension_document_support'] = array(
 		'title'    => __( 'File Extensions', 'buddyboss' ),
 		'callback' => 'bp_media_settings_callback_extension_link',
@@ -1343,4 +1357,84 @@ function bp_document_settings_callback_extension_section() {
 	?>
 	<p><?php esc_html_e( 'Check which file extensions are allowed to be uploaded. Add custom extensions at the bottom of the table.', 'buddyboss' ); ?></p>
 	<?php
+}
+
+/**
+ * Setting > Media > Photos > Allowed Mac File Size
+ *
+ * @since BuddyBoss 1.4.8
+ */
+function bp_media_settings_callback_media_allowed_size() {
+	$max_size = bp_core_upload_max_size();
+
+	?>
+	<input type="number"
+		   name="bp_media_allowed_size"
+		   id="bp_media_allowed_size"
+		   value="<?php echo esc_attr( bp_media_allowed_upload_media_size() ); ?>"
+	/>
+	<p class="description">
+		<?php
+		printf(
+				'%1$s %2$s %3$s',
+				__( 'Your server allowed memory is ', 'buddyboss' ),
+				bp_media_format_size_units( $max_size, false, 'MB' ),
+				'MB.'
+		);
+		?>
+	</p>
+	<?php
+}
+
+/**
+ * Allowed upload file size for the media.
+ *
+ * @return int Allowed upload file size for the media.
+ * @since BuddyBoss 1.4.8
+ */
+function bp_media_allowed_upload_media_size() {
+
+	$max_size = bp_core_upload_max_size();
+	$default  =  bp_media_format_size_units( $max_size, false, 'MB' );
+	return (int) apply_filters( 'bp_media_allowed_upload_media_size', (int) get_option( 'bp_media_allowed_size', $default ) );
+}
+
+/**
+ * Setting > Media > Documents > Allowed Max File Size
+ *
+ * @since BuddyBoss 1.4.8
+ */
+function bp_media_settings_callback_document_allowed_size() {
+	$max_size = bp_core_upload_max_size();
+
+	?>
+	<input type="number"
+		   name="bp_document_allowed_size"
+		   id="bp_document_allowed_size"
+		   value="<?php echo esc_attr( bp_media_allowed_upload_document_size() ); ?>"
+	/>
+	<p class="description">
+		<?php
+		printf(
+				'%1$s %2$s %3$s',
+				__( 'Your server allowed memory is ', 'buddyboss' ),
+				bp_document_format_size_units( $max_size, false, 'MB' ),
+				'MB.'
+		);
+		?>
+	</p>
+	<?php
+}
+
+/**
+ * Allowed upload file size for the document.
+ *
+ * @return int Allowed upload file size for the document.
+ *
+ * @since BuddyBoss 1.4.8
+ */
+function bp_media_allowed_upload_document_size() {
+	$max_size = bp_core_upload_max_size();
+	$default  =  bp_document_format_size_units( $max_size, false, 'MB' );
+	return (int) apply_filters( 'bp_media_allowed_upload_document_size', (int) get_option( 'bp_document_allowed_size', $default ) );
 }

--- a/src/bp-templates/bp-nouveau/includes/document/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/document/functions.php
@@ -98,7 +98,7 @@ function bp_nouveau_document_localize_scripts( $params = array() ) {
 
 	$document_options = array(
 		'dictInvalidFileType'       => __( 'Please upload only the following file types: ', 'buddyboss' ) . '<br /><div class="bb-allowed-file-types">' . implode( ', ', array_unique( $extensions ) ) . '</div>',
-		'max_upload_size'           => bp_document_file_upload_max_size( false, 'MB' ),
+		'max_upload_size'           => bp_document_file_upload_max_size(),
 		'maxFiles'                  => apply_filters( 'bp_document_upload_chunk_limit', 10 ),
 		'mp3_preview_extension'     => implode( ',', bp_get_document_preview_music_extensions() )
 	);

--- a/src/bp-templates/bp-nouveau/includes/media/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/media/functions.php
@@ -89,7 +89,7 @@ function bp_nouveau_media_localize_scripts( $params = array() ) {
 
 	//initialize media vars because it is used globally
 	$params['media'] = array(
-		'max_upload_size'              => bp_media_file_upload_max_size( false, 'MB' ),
+		'max_upload_size'              => bp_media_file_upload_max_size(),
 		'profile_media'                 => bp_is_profile_media_support_enabled(),
 		'profile_album'                 => bp_is_profile_albums_support_enabled(),
 		'group_media'                  => bp_is_group_media_support_enabled(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Video explanation - https://www.loom.com/share/08363fd28b744d1fabad2028fa288bcb

### How to test the changes in this Pull Request:

1. Enable Photos and Documents in Media
2. Check the new setting to limit max file size
3. Try uploading photos and documents that are smaller/larger than that file size to test. If larger you should get the validation popup telling you it is not large enough.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
