### PR TITLE
758 - Reopen fix for allow to send group message without checking connection

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/messages/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/ajax.php
@@ -1706,7 +1706,7 @@ function bp_nouveau_get_thread_messages( $thread_id, $post ) {
 		$message_type            = bp_messages_get_meta( $first_message->id, 'group_message_type', true ); // open - private
 		$message_from            = bp_messages_get_meta( $first_message->id, 'message_from', true ); // group
 
-		if ( 'group' === $message_from && bp_get_the_thread_id() === (int) $group_message_thread_id && 'all' === $message_users && 'open' === $message_type ) {
+		if ( 'group' === $message_from && bp_get_the_thread_id() === (int) $group_message_thread_id  && 'open' === $message_type ) {
 			$is_group_thread = 1;
 			unset($thread->feedback_error);
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #758 .

### How to test the changes in this Pull Request:

1. Go to WP Admin > BuddyBoss > Settings > Connection
2. Enable Require users to be connected before they can message each other
3. Go to Group > Send Messages in the front end.
4. Send group message and see the error if any member of the group is not connected.
5. Check for individual message send from the group and check the message that sends to all group member

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
