### PR TITLE
Elementor plugin not working when we set BP pages as front page

### DIFF
--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -154,7 +154,7 @@ function bp_core_set_uri_globals() {
 	 */
 	if ( 'page' == get_option( 'show_on_front' ) && get_option( 'page_on_front' ) && empty( $bp_uri ) && empty( $_GET['p'] ) && empty( $_GET['page_id'] ) && empty( $_GET['cat'] ) ) {
 		$post = get_post( get_option( 'page_on_front' ) );
-		if ( ! empty( $post ) ) {
+		if ( ! empty( $post ) && apply_filters( 'bp_core_set_uri_show_on_front', true ) ) {
 			$bp_uri[0] = $post->post_name;
 		}
 	}

--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -478,3 +478,31 @@ function bp_settings_remove_wc_lostpassword_url() {
 }
 add_action( 'bp_before_member_settings_template', 'bp_settings_remove_wc_lostpassword_url' );
 add_action( 'login_form_login', 'bp_settings_remove_wc_lostpassword_url' );
+
+/**
+ * Fix elementor editor issue while bp page set as front.
+ *
+ * @since BuddyBoss 1.4.9
+ *
+ * @param boolean $bool Boolean to return
+ *
+ * @return boolean
+ */
+function bp_core_set_uri_elementor_show_on_front( $bool ) {
+	if (
+		isset( $_REQUEST['elementor-preview'] )
+		|| (
+			is_admin() &&
+			isset( $_REQUEST['action'] )
+			&& (
+				'elementor' === $_REQUEST['action']
+				|| 'elementor_ajax' === $_REQUEST['action']
+			)
+		)
+	) {
+		return false;
+	}
+
+	return $bool;
+}
+add_filter( 'bp_core_set_uri_show_on_front', 'bp_core_set_uri_elementor_show_on_front', 10, 3 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1317 
Fixes #375
Fixes #380
Fixes #767

### How to test the changes in this Pull Request:

1. Go to Admin-> Settings-> Reading
2. Set Your homepage displays as a static page as Activity Feed
3. See error: https://www.loom.com/share/861f2d2a4b6047f88ff0598e20245d03

### Proof Screenshots or Video
http://prntscr.com/txjk84

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
