### PR TITLE
PHP 7.* above & WordPress 5.5 Compatiblity

### DIFF
--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -3844,7 +3844,8 @@ function bp_activity_create_summary( $content, $activity ) {
 	if ( $use_media_type === 'embeds' ) {
 		$summary .= PHP_EOL . PHP_EOL . $extracted_media['url'];
 	} elseif ( $use_media_type === 'images' ) {
-		$summary .= sprintf( ' <img src="%s">', esc_url( $extracted_media['url'] ) );
+		$extracted_media_url = isset( $extracted_media['url'] ) ? $extracted_media['url'] : '';
+		$summary .= sprintf( ' <img src="%s">', esc_url( $extracted_media_url ) );
 	} elseif ( in_array( $use_media_type, array( 'audio', 'videos' ), true ) ) {
 		$summary .= PHP_EOL . PHP_EOL . $extracted_media['original'];  // Full shortcode.
 	}

--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -370,8 +370,10 @@ class BP_Activity_Activity {
 	public static function get( $args = array() ) {
 		global $wpdb;
 
+		$function_args = func_get_args();
+
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '1.6', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(
@@ -388,7 +390,7 @@ class BP_Activity_Activity {
 				10 => 'spam',
 			);
 
-			$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+			$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 		}
 
 		$bp = buddypress();
@@ -1493,6 +1495,8 @@ class BP_Activity_Activity {
 	public static function get_activity_comments( $activity_id, $left, $right, $spam = 'ham_only', $top_level_parent_id = 0 ) {
 		global $wpdb;
 
+		$function_args = func_get_args();
+
 		if ( empty( $top_level_parent_id ) ) {
 			$top_level_parent_id = $activity_id;
 		}
@@ -1540,7 +1544,7 @@ class BP_Activity_Activity {
 			 * @param BP_Activity_Activity $value     Magic method referring to currently called method.
 			 * @param array                $func_args Array of the method's argument list.
 			 */
-			if ( apply_filters( 'bp_use_legacy_activity_query', false, __METHOD__, func_get_args() ) ) {
+			if ( apply_filters( 'bp_use_legacy_activity_query', false, __METHOD__, $function_args ) ) {
 
 				/**
 				 * Filters the MySQL prepared statement for the legacy activity query.

--- a/src/bp-activity/classes/class-bp-activity-template.php
+++ b/src/bp-activity/classes/class-bp-activity-template.php
@@ -138,8 +138,10 @@ class BP_Activity_Template {
 	public function __construct( $args ) {
 		$bp = buddypress();
 
+		$function_args = func_get_args();
+
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '1.6', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(
@@ -158,7 +160,7 @@ class BP_Activity_Template {
 				12 => 'page_arg',
 			);
 
-			$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+			$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 		}
 
 		$defaults = array(

--- a/src/bp-core/bp-core-moderation.php
+++ b/src/bp-core/bp-core-moderation.php
@@ -189,7 +189,7 @@ function bp_core_check_for_moderation( $user_id = 0, $title = '', $content = '',
  * @since BuddyPress 1.6.0
  * @since BuddyPress 2.6.0 Added $error_type parameter.
  *
- * @todo Why don't we use wp_blacklist_check() for this?
+ * @todo Why don't we use wp_check_comment_disallowed_list() for this?
  *
  * @param int    $user_id    User ID.
  * @param string $title      The title of the content.
@@ -223,9 +223,13 @@ function bp_core_check_for_blacklist( $user_id = 0, $title = '', $content = '', 
 
 	/** Blacklist ************************************************************
 	 */
+	$disallowed_keys_option_name = 'blacklist_keys';
+	if ( function_exists( 'wp_check_comment_disallowed_list' ) ) {
+		$disallowed_keys_option_name = 'disallowed_keys';
+ 	}
 
 	// Get the moderation keys.
-	$blacklist = trim( get_option( 'blacklist_keys' ) );
+	$blacklist = trim( get_option( $disallowed_keys_option_name ) );
 
 	// Bail if blacklist is empty.
 	if ( empty( $blacklist ) ) {

--- a/src/bp-core/classes/class-bp-attachment-cover-image.php
+++ b/src/bp-core/classes/class-bp-attachment-cover-image.php
@@ -76,11 +76,11 @@ class BP_Attachment_Cover_Image extends BP_Attachment {
 		}
 
 		// File size is too big.
-		if ( $file['size'] > $this->original_max_filesize ) {
+		if ( isset( $file['size'] ) && ( $file['size'] > $this->original_max_filesize ) ) {
 			$file['error'] = 11;
 
 			// File is of invalid type.
-		} elseif ( ! bp_attachments_check_filetype( $file['tmp_name'], $file['name'], bp_attachments_get_allowed_mimes( 'cover_image' ) ) ) {
+		} elseif ( isset( $file['tmp_name'] ) && isset( $file['name'] ) && ! bp_attachments_check_filetype( $file['tmp_name'], $file['name'], bp_attachments_get_allowed_mimes( 'cover_image' ) ) ) {
 			$file['error'] = 12;
 		}
 

--- a/src/bp-core/classes/class-bp-core-oembed-extension.php
+++ b/src/bp-core/classes/class-bp-core-oembed-extension.php
@@ -232,9 +232,10 @@ abstract class BP_Core_oEmbed_Extension {
 			"/embed/{$this->slug_endpoint}",
 			array(
 				array(
-					'methods'  => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'get_item' ),
-					'args'     => $args,
+					'methods'               => WP_REST_Server::READABLE,
+					'callback'              => array( $this, 'get_item' ),
+					'permission_callback'   => '__return_true',
+					'args'                  => $args,
 				),
 			)
 		);

--- a/src/bp-core/classes/class-bp-media-extractor.php
+++ b/src/bp-core/classes/class-bp-media-extractor.php
@@ -840,10 +840,15 @@ class BP_Media_Extractor {
 				// Extract the data we need from each image in this gallery.
 				foreach ( $images as $image_id ) {
 					$image  = wp_get_attachment_image_src( $image_id, $image_size );
+
+					$image_url    = isset( $image[0] ) ? $image[0] : '';
+					$image_width  = isset( $image[1] ) ? $image[1] : '';
+				    $image_height = isset( $image[2] ) ? $image[2] : '';
+
 					$data[] = array(
-						'url'        => $image[0],
-						'width'      => $image[1],
-						'height'     => $image[2],
+						'url'        => $image_url,
+						'width'      => $image_width,
+						'height'     => $image_height,
 
 						'gallery_id' => 1 + $gallery_id,
 					);

--- a/src/bp-core/classes/class-bp-phpmailer.php
+++ b/src/bp-core/classes/class-bp-phpmailer.php
@@ -2,10 +2,11 @@
 /**
  * Core component classes.
  *
- * @package BuddyBoss\Core
+ * @package BuddyPress
+ * @subpackage Core
  */
 
-// Exit if accessed directly
+// Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -25,6 +26,7 @@ class BP_PHPMailer implements BP_Email_Delivery {
 	 */
 	public function bp_email( BP_Email $email ) {
 		static $phpmailer = null;
+		$phpmailer_is_6_0 = false;
 
 		/**
 		 * Filter PHPMailer object to use.
@@ -37,13 +39,30 @@ class BP_PHPMailer implements BP_Email_Delivery {
 		 */
 		$phpmailer = apply_filters( 'bp_phpmailer_object', $phpmailer );
 
-		if ( ! ( $phpmailer instanceof PHPMailer ) ) {
-			if ( ! class_exists( 'PHPMailer' ) ) {
-				require_once ABSPATH . WPINC . '/class-phpmailer.php';
-				require_once ABSPATH . WPINC . '/class-smtp.php';
-			}
+		/**
+		 * WordPress 5.5 deprecated version 5.2 of PHPMailer
+		 * and is now using version 6.0 of PHPMailer.
+		 */
+		if ( file_exists( ABSPATH . WPINC . '/PHPMailer/PHPMailer.php' ) ) {
+			if ( ! ( $phpmailer instanceof PHPMailer\PHPMailer\PHPMailer ) ) {
+				if ( ! class_exists( 'PHPMailer\\PHPMailer\\PHPMailer' ) ) {
+					require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+					require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
+					require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
+				}
 
-			$phpmailer = new PHPMailer( true );
+				$phpmailer        = new PHPMailer\PHPMailer\PHPMailer( true );
+				$phpmailer_is_6_0 = true;
+			}
+		} else {
+			if ( ! ( $phpmailer instanceof PHPMailer ) ) {
+				if ( ! class_exists( 'PHPMailer' ) ) {
+					require_once ABSPATH . WPINC . '/class-phpmailer.php';
+					require_once ABSPATH . WPINC . '/class-smtp.php';
+				}
+
+				$phpmailer = new PHPMailer( true );
+			}
 		}
 
 		/*
@@ -59,16 +78,18 @@ class BP_PHPMailer implements BP_Email_Delivery {
 		/*
 		 * Set up.
 		 */
-
 		$phpmailer->IsMail();
 		$phpmailer->CharSet = bp_get_option( 'blog_charset' );
 
 		/*
 		 * Content.
 		 */
-
 		$phpmailer->Subject = $email->get_subject( 'replace-tokens' );
-		$content_plaintext  = PHPMailer::normalizeBreaks( $email->get_content_plaintext( 'replace-tokens' ) );
+		if ( $phpmailer_is_6_0 ) {
+			$content_plaintext = PHPMailer\PHPMailer\PHPMailer::normalizeBreaks( $email->get_content_plaintext( 'replace-tokens' ) );
+		} else {
+			$content_plaintext = PHPMailer::normalizeBreaks( $email->get_content_plaintext( 'replace-tokens' ) );
+		}
 
 		if ( $email->get( 'content_type' ) === 'html' ) {
 			$phpmailer->msgHTML( $email->get_template( 'add-content' ) );
@@ -80,38 +101,79 @@ class BP_PHPMailer implements BP_Email_Delivery {
 		}
 
 		$recipient = $email->get_from();
-		try {
-			$phpmailer->SetFrom( $recipient->get_address(), $recipient->get_name(), false );
-		} catch ( phpmailerException $e ) {
+		if ( $phpmailer_is_6_0 ) {
+			try {
+				$phpmailer->setFrom( $recipient->get_address(), $recipient->get_name(), false );
+			} catch ( PHPMailer\PHPMailer\Exception $e ) {
+			}
+		} else {
+			try {
+				$phpmailer->SetFrom( $recipient->get_address(), $recipient->get_name(), false );
+			} catch ( phpmailerException $e ) {
+			}
 		}
 
 		$recipient = $email->get_reply_to();
-		try {
-			$phpmailer->addReplyTo( $recipient->get_address(), $recipient->get_name() );
-		} catch ( phpmailerException $e ) {
+		if ( $phpmailer_is_6_0 ) {
+			try {
+				$phpmailer->addReplyTo( $recipient->get_address(), $recipient->get_name() );
+			} catch ( PHPMailer\PHPMailer\Exception $e ) {
+			}
+		} else {
+			try {
+				$phpmailer->addReplyTo( $recipient->get_address(), $recipient->get_name() );
+			} catch ( phpmailerException $e ) {
+			}
 		}
 
 		$recipients = $email->get_to();
-		foreach ( $recipients as $recipient ) {
-			try {
-				$phpmailer->AddAddress( $recipient->get_address(), $recipient->get_name() );
-			} catch ( phpmailerException $e ) {
+		if ( $phpmailer_is_6_0 ) {
+			foreach ( $recipients as $recipient ) {
+				try {
+					$phpmailer->AddAddress( $recipient->get_address(), $recipient->get_name() );
+				} catch ( PHPMailer\PHPMailer\Exception $e ) {
+				}
+			}
+		} else {
+			foreach ( $recipients as $recipient ) {
+				try {
+					$phpmailer->AddAddress( $recipient->get_address(), $recipient->get_name() );
+				} catch ( phpmailerException $e ) {
+				}
 			}
 		}
 
 		$recipients = $email->get_cc();
-		foreach ( $recipients as $recipient ) {
-			try {
-				$phpmailer->AddCc( $recipient->get_address(), $recipient->get_name() );
-			} catch ( phpmailerException $e ) {
+		if ( $phpmailer_is_6_0 ) {
+			foreach ( $recipients as $recipient ) {
+				try {
+					$phpmailer->AddCc( $recipient->get_address(), $recipient->get_name() );
+				} catch ( PHPMailer\PHPMailer\Exception $e ) {
+				}
+			}
+		} else {
+			foreach ( $recipients as $recipient ) {
+				try {
+					$phpmailer->AddCc( $recipient->get_address(), $recipient->get_name() );
+				} catch ( phpmailerException $e ) {
+				}
 			}
 		}
 
 		$recipients = $email->get_bcc();
-		foreach ( $recipients as $recipient ) {
-			try {
-				$phpmailer->AddBcc( $recipient->get_address(), $recipient->get_name() );
-			} catch ( phpmailerException $e ) {
+		if ( $phpmailer_is_6_0 ) {
+			foreach ( $recipients as $recipient ) {
+				try {
+					$phpmailer->AddBcc( $recipient->get_address(), $recipient->get_name() );
+				} catch ( PHPMailer\PHPMailer\Exception $e ) {
+				}
+			}
+		} else {
+			foreach ( $recipients as $recipient ) {
+				try {
+					$phpmailer->AddBcc( $recipient->get_address(), $recipient->get_name() );
+				} catch ( phpmailerException $e ) {
+				}
 			}
 		}
 
@@ -132,13 +194,20 @@ class BP_PHPMailer implements BP_Email_Delivery {
 		/** This filter is documented in wp-includes/pluggable.php */
 		do_action_ref_array( 'phpmailer_init', array( &$phpmailer ) );
 
-		try {
-			return $phpmailer->Send();
-		} catch ( phpmailerException $e ) {
-			return new WP_Error( $e->getCode(), $e->getMessage(), $email );
+		if ( $phpmailer_is_6_0 ) {
+			try {
+				return $phpmailer->Send();
+			} catch ( PHPMailer\PHPMailer\Exception $e ) {
+				return new WP_Error( $e->getCode(), $e->getMessage(), $email );
+			}
+		} else {
+			try {
+				return $phpmailer->Send();
+			} catch ( phpmailerException $e ) {
+				return new WP_Error( $e->getCode(), $e->getMessage(), $email );
+			}
 		}
 	}
-
 
 	/*
 	 * Utility/helper functions.

--- a/src/bp-core/classes/class-bp-user-query.php
+++ b/src/bp-core/classes/class-bp-user-query.php
@@ -706,7 +706,7 @@ class BP_User_Query {
 
 		// Set a last_activity value for each user, even if it's empty.
 		foreach ( $this->results as $user_id => $user ) {
-			$user_last_activity                       = ! empty( $last_activities[ $user_id ]['date_recorded'] ) ? $last_activities[ $user_id ]['date_recorded'] : '';
+			$user_last_activity = isset( $last_activities[ $user_id ]['date_recorded'] ) ? $last_activities[ $user_id ]['date_recorded'] : '';
 			$this->results[ $user_id ]->last_activity = $user_last_activity;
 		}
 

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -248,8 +248,10 @@ function groups_create_group( $args = '' ) {
  */
 function groups_edit_base_group_details( $args = array() ) {
 
+	$function_args = func_get_args();
+
 	// Backward compatibility with old method of passing arguments.
-	if ( ! is_array( $args ) || func_num_args() > 1 ) {
+	if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 		_deprecated_argument( __METHOD__, '2.9.0', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 		$old_args_keys = array(
@@ -259,7 +261,7 @@ function groups_edit_base_group_details( $args = array() ) {
 			3 => 'notify_members',
 		);
 
-		$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+		$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 	}
 
 	$r = bp_parse_args(
@@ -751,8 +753,10 @@ function groups_get_group_mods( $group_id ) {
  */
 function groups_get_group_members( $args = array() ) {
 
+	$function_args = func_get_args();
+
 	// Backward compatibility with old method of passing arguments.
-	if ( ! is_array( $args ) || func_num_args() > 1 ) {
+	if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 		_deprecated_argument( __METHOD__, '2.0.0', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 		$old_args_keys = array(
@@ -765,7 +769,7 @@ function groups_get_group_members( $args = array() ) {
 			6 => 'group_role',
 		);
 
-		$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+		$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 	}
 
 	$r = bp_parse_args(
@@ -785,7 +789,7 @@ function groups_get_group_members( $args = array() ) {
 	);
 
 	// For legacy users. Use of BP_Groups_Member::get_all_for_group() is deprecated.
-	if ( apply_filters( 'bp_use_legacy_group_member_query', false, __FUNCTION__, func_get_args() ) ) {
+	if ( apply_filters( 'bp_use_legacy_group_member_query', false, __FUNCTION__, $function_args ) ) {
 		$retval = BP_Groups_Member::get_all_for_group( $r['group_id'], $r['per_page'], $r['page'], $r['exclude_admins_mods'], $r['exclude_banned'], $r['exclude'] );
 	} else {
 
@@ -3125,6 +3129,12 @@ function bp_groups_remove_group_type( $group_id, $group_type ) {
 	if ( empty( $group_type ) || ! bp_groups_get_group_type_object( $group_type ) ) {
 		return false;
 	}
+
+	// No need to continue if the group doesn't have the type.
+	$existing_types = bp_groups_get_group_type( $group_id, false );
+ 	if ( ! in_array( $group_type, $existing_types, true ) ) {
+		return false;
+ 	}
 
 	$deleted = bp_remove_object_terms( $group_id, $group_type, 'bp_group_type' );
 

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -2007,8 +2007,11 @@ function groups_delete_invite( $user_id, $group_id, $inviter_id = false ) {
  * }
  */
 function groups_send_invites( $args = array() ) {
+
+	$function_args = func_get_args();
+
 	// Backward compatibility with old method of passing arguments.
-	if ( ! is_array( $args ) || func_num_args() > 1 ) {
+	if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 		_deprecated_argument( __METHOD__, '1.3.5', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 		$old_args_keys = array(
@@ -2016,7 +2019,7 @@ function groups_send_invites( $args = array() ) {
 			1 => 'group_id',
 		);
 
-		$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+		$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 	}
 
 	$r = bp_parse_args( $args, array(
@@ -2351,8 +2354,11 @@ function groups_remove_member( $user_id, $group_id ) {
  * @return bool True on success, false on failure.
  */
 function groups_send_membership_request( $args = array() ) {
+
+	$function_args = func_get_args();
+
 	// Backward compatibility with old method of passing arguments.
-	if ( ! is_array( $args ) || func_num_args() > 1 ) {
+	if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 		_deprecated_argument( __METHOD__, '1.3.5', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 		$old_args_keys = array(
@@ -2360,7 +2366,7 @@ function groups_send_membership_request( $args = array() ) {
 			1 => 'group_id',
 		);
 
-		$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+		$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 	}
 
 	$r = bp_parse_args( $args, array(

--- a/src/bp-groups/classes/class-bp-groups-group-members-template.php
+++ b/src/bp-groups/classes/class-bp-groups-group-members-template.php
@@ -94,8 +94,10 @@ class BP_Groups_Group_Members_Template {
 	 */
 	public function __construct( $args = array() ) {
 
+		$function_args = func_get_args();
+
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '2.0.0', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(
@@ -108,7 +110,7 @@ class BP_Groups_Group_Members_Template {
 				6 => 'group_role',
 			);
 
-			$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+			$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 		}
 
 		$r = bp_parse_args(

--- a/src/bp-groups/classes/class-bp-groups-group.php
+++ b/src/bp-groups/classes/class-bp-groups-group.php
@@ -1074,8 +1074,10 @@ class BP_Groups_Group {
 	public static function get( $args = array() ) {
 		global $wpdb;
 
+		$function_args = func_get_args();
+
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '1.7', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(
@@ -1090,7 +1092,7 @@ class BP_Groups_Group {
 				8 => 'show_hidden',
 			);
 
-			$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+			$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 		}
 
 		$defaults = array(

--- a/src/bp-groups/classes/class-bp-groups-invite-template.php
+++ b/src/bp-groups/classes/class-bp-groups-invite-template.php
@@ -79,8 +79,10 @@ class BP_Groups_Invite_Template {
 	 */
 	public function __construct( $args = array() ) {
 
+		$function_args = func_get_args();
+
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '2.0.0', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(
@@ -88,7 +90,7 @@ class BP_Groups_Invite_Template {
 				1 => 'group_id',
 			);
 
-			$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+			$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 		}
 
 		$r = bp_parse_args(

--- a/src/bp-groups/classes/class-bp-groups-membership-requests-template.php
+++ b/src/bp-groups/classes/class-bp-groups-membership-requests-template.php
@@ -86,8 +86,10 @@ class BP_Groups_Membership_Requests_Template {
 	 */
 	public function __construct( $args = array() ) {
 
+		$function_args = func_get_args();
+
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '2.0.0', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(

--- a/src/bp-groups/classes/class-bp-groups-template.php
+++ b/src/bp-groups/classes/class-bp-groups-template.php
@@ -129,8 +129,10 @@ class BP_Groups_Template {
 	 */
 	function __construct( $args = array() ) {
 
+		$function_args = func_get_args();
+
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '1.7', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(

--- a/src/bp-integrations/learndash/buddypress/components/BpGroupReports.php
+++ b/src/bp-integrations/learndash/buddypress/components/BpGroupReports.php
@@ -120,7 +120,8 @@ class BpGroupReports extends BP_Group_Extension {
 
 		foreach ( bp_ld_sync( 'settings' )->get( 'reports.access', array() ) as $type ) {
 			$function = "groups_is_user_{$type}";
-			if ( function_exists( $function ) && call_user_func_array( $function, array( bp_loggedin_user_id(), $currentGroup->id ) ) ) {
+			$callback = call_user_func_array( $function, array( bp_loggedin_user_id(), $currentGroup->id ) );
+			if ( function_exists( $function ) && $callback ) {
 				return true;
 			}
 		}

--- a/src/bp-integrations/learndash/core/Requirements.php
+++ b/src/bp-integrations/learndash/core/Requirements.php
@@ -49,7 +49,8 @@ class Requirements
 	public function checkForRequirements()
 	{
 		foreach ($this->requirements as $name => $data) {
-			if (! call_user_func_array('call_user_func_array', $data['callback'])) {
+			$callback = call_user_func_array('call_user_func_array', $data['callback']);
+			if (! $callback ) {
 				continue;
 			}
 

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -2004,7 +2004,7 @@ function bp_core_activate_signup( $key ) {
 		// Set up data to pass to the legacy filter.
 		$user = array(
 			'user_id'  => $user_id,
-			'password' => $signup->meta['password'],
+			'password' => isset( $signup->meta['password'] ) ? $signup->meta['password'] : '',
 			'meta'     => $signup->meta,
 		);
 
@@ -2786,6 +2786,12 @@ function bp_set_member_type( $user_id, $member_type, $append = false ) {
 function bp_remove_member_type( $user_id, $member_type ) {
 	// Bail if no valid profile type was passed.
 	if ( empty( $member_type ) || ! bp_get_member_type_object( $member_type ) ) {
+		return false;
+	}
+
+	// No need to continue if the member doesn't have the type.
+	$existing_types = bp_get_member_type( $user_id, false );
+	if ( ! in_array( $member_type, $existing_types, true ) ) {
 		return false;
 	}
 

--- a/src/bp-messages/classes/class-bp-messages-box-template.php
+++ b/src/bp-messages/classes/class-bp-messages-box-template.php
@@ -107,8 +107,10 @@ class BP_Messages_Box_Template {
 	 */
 	public function __construct( $args = array() ) {
 
+		$function_args = func_get_args();
+
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '2.2.0', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(
@@ -121,7 +123,7 @@ class BP_Messages_Box_Template {
 				6 => 'page_arg',
 			);
 
-			$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+			$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 		}
 
 		$r = wp_parse_args(
@@ -173,8 +175,8 @@ class BP_Messages_Box_Template {
 				)
 			);
 
-			$this->threads            = ( $threads ) ? $threads['threads'] : false;
-			$this->total_thread_count = ( $threads ) ? $threads['total'] : 0;
+			$this->threads            = isset( $threads['threads'] ) ? $threads['threads'] : array();
+			$this->total_thread_count = isset( $threads['total'] ) ? $threads['total'] : 0;
 		}
 
 		if ( ! $this->threads ) {

--- a/src/bp-messages/classes/class-bp-messages-thread.php
+++ b/src/bp-messages/classes/class-bp-messages-thread.php
@@ -751,10 +751,11 @@ class BP_Messages_Thread {
 	public static function get_current_threads_for_user( $args = array() ) {
 		global $wpdb;
 
-		$bp = buddypress();
+		$bp             = buddypress();
+		$function_args  = func_get_args();
 
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '2.2.0', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(
@@ -766,7 +767,7 @@ class BP_Messages_Thread {
 				5 => 'search_terms',
 			);
 
-			$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+			$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 		}
 
 		$r = bp_parse_args(

--- a/src/bp-xprofile/classes/class-bp-xprofile-data-template.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-data-template.php
@@ -125,8 +125,10 @@ class BP_XProfile_Data_Template {
 	 */
 	public function __construct( $args = '' ) {
 
+		$function_args = func_get_args();
+
 		// Backward compatibility with old method of passing arguments.
-		if ( ! is_array( $args ) || func_num_args() > 1 ) {
+		if ( ! is_array( $args ) || count( $function_args ) > 1 ) {
 			_deprecated_argument( __METHOD__, '2.3.0', sprintf( __( 'Arguments passed to %1$s should be in an associative array. See the inline documentation at %2$s for more details.', 'buddyboss' ), __METHOD__, __FILE__ ) );
 
 			$old_args_keys = array(
@@ -142,7 +144,7 @@ class BP_XProfile_Data_Template {
 				9 => 'update_meta_cache',
 			);
 
-			$args = bp_core_parse_args_array( $old_args_keys, func_get_args() );
+			$args = bp_core_parse_args_array( $old_args_keys, $function_args );
 		}
 
 		$r = wp_parse_args(

--- a/src/cli/features/bootstrap/utils.php
+++ b/src/cli/features/bootstrap/utils.php
@@ -209,11 +209,12 @@ function assoc_args_to_str( $assoc_args ) {
  * returns the final command, with the parameters escaped.
  */
 function esc_cmd( $cmd ) {
-	if ( func_num_args() < 2 ) {
-		trigger_error( 'esc_cmd() requires at least two arguments.', E_USER_WARNING );
-	}
 
 	$args = func_get_args();
+
+	if ( count( $args ) < 2 ) {
+		trigger_error( 'esc_cmd() requires at least two arguments.', E_USER_WARNING );
+	}
 
 	$cmd = array_shift( $args );
 

--- a/src/languages/buddyboss.pot
+++ b/src/languages/buddyboss.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BuddyBoss Platform 1.4.8\n"
 "Report-Msgid-Bugs-To: https://www.buddyboss.com/contact/\n"
-"POT-Creation-Date: 2020-08-10 01:10:39+00:00\n"
+"POT-Creation-Date: 2020-08-12 06:50:05+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -588,7 +588,7 @@ msgstr ""
 
 #: bp-activity/bp-activity-filters.php:1659
 #: bp-activity/bp-activity-filters.php:1861
-#: bp-groups/bp-groups-activity.php:179 bp-groups/bp-groups-functions.php:1657
+#: bp-groups/bp-groups-activity.php:179 bp-groups/bp-groups-functions.php:1661
 #: cli/components/activity.php:763
 msgid "%1$s posted an update in the group %2$s"
 msgstr ""
@@ -678,7 +678,7 @@ msgstr ""
 #: bp-core/classes/class-bp-admin.php:534
 #: bp-core/classes/class-bp-admin.php:535 bp-forums/admin/settings.php:1464
 #: bp-forums/admin/tools.php:29 bp-forums/admin/tools.php:1748
-#: bp-media/bp-media-filters.php:968
+#: bp-media/bp-media-filters.php:1040
 msgid "Tools"
 msgstr ""
 
@@ -752,11 +752,11 @@ msgstr ""
 msgid "Thumbnail"
 msgstr ""
 
-#: bp-activity/bp-activity-functions.php:5074
+#: bp-activity/bp-activity-functions.php:5075
 msgid "URL is not valid."
 msgstr ""
 
-#: bp-activity/bp-activity-functions.php:5082
+#: bp-activity/bp-activity-functions.php:5083
 #: bp-activity/classes/class-bp-rest-activity-link-preview-endpoint.php:101
 msgid "Sorry! preview is not available right now. Please try again later."
 msgstr ""
@@ -903,9 +903,9 @@ msgstr[1] ""
 #: bp-groups/bp-groups-template.php:4779 bp-groups/bp-groups-template.php:4821
 #: bp-groups/bp-groups-template.php:4865 bp-groups/bp-groups-template.php:6659
 #: bp-groups/classes/class-bp-groups-component.php:1059
-#: bp-groups/classes/class-bp-groups-invite-template.php:247
-#: bp-groups/classes/class-bp-groups-invite-template.php:260
-#: bp-groups/classes/class-bp-groups-invite-template.php:272
+#: bp-groups/classes/class-bp-groups-invite-template.php:249
+#: bp-groups/classes/class-bp-groups-invite-template.php:262
+#: bp-groups/classes/class-bp-groups-invite-template.php:274
 #: bp-media/classes/class-bp-media-component.php:376
 #: bp-members/bp-members-template.php:824
 #: bp-members/bp-members-template.php:1547
@@ -1030,19 +1030,19 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: bp-activity/classes/class-bp-activity-activity.php:375
-#: bp-activity/classes/class-bp-activity-template.php:143
-#: bp-groups/bp-groups-functions.php:253 bp-groups/bp-groups-functions.php:756
-#: bp-groups/bp-groups-functions.php:2008
-#: bp-groups/bp-groups-functions.php:2352
-#: bp-groups/classes/class-bp-groups-group-members-template.php:99
-#: bp-groups/classes/class-bp-groups-group.php:1079
-#: bp-groups/classes/class-bp-groups-invite-template.php:84
-#: bp-groups/classes/class-bp-groups-membership-requests-template.php:91
-#: bp-groups/classes/class-bp-groups-template.php:134
-#: bp-messages/classes/class-bp-messages-box-template.php:112
-#: bp-messages/classes/class-bp-messages-thread.php:758
-#: bp-xprofile/classes/class-bp-xprofile-data-template.php:130
+#: bp-activity/classes/class-bp-activity-activity.php:377
+#: bp-activity/classes/class-bp-activity-template.php:145
+#: bp-groups/bp-groups-functions.php:255 bp-groups/bp-groups-functions.php:760
+#: bp-groups/bp-groups-functions.php:2012
+#: bp-groups/bp-groups-functions.php:2356
+#: bp-groups/classes/class-bp-groups-group-members-template.php:101
+#: bp-groups/classes/class-bp-groups-group.php:1081
+#: bp-groups/classes/class-bp-groups-invite-template.php:86
+#: bp-groups/classes/class-bp-groups-membership-requests-template.php:93
+#: bp-groups/classes/class-bp-groups-template.php:136
+#: bp-messages/classes/class-bp-messages-box-template.php:114
+#: bp-messages/classes/class-bp-messages-thread.php:759
+#: bp-xprofile/classes/class-bp-xprofile-data-template.php:132
 msgid ""
 "Arguments passed to %1$s should be in an associative array. See the inline "
 "documentation at %2$s for more details."
@@ -1237,7 +1237,7 @@ msgstr ""
 #: bp-forums/classes/class-bp-forums-component.php:278
 #: bp-forums/classes/class-bp-forums-component.php:329
 #: bp-forums/common/widgets.php:728 bp-forums/forums/template.php:48
-#: bp-media/bp-media-filters.php:1019 bp-media/bp-media-settings.php:208
+#: bp-media/bp-media-filters.php:1091 bp-media/bp-media-settings.php:208
 #: bp-media/bp-media-settings.php:215 bp-media/bp-media-settings.php:222
 #: bp-media/bp-media-settings.php:229 bp-search/bp-search-functions.php:369
 #: bp-templates/bp-nouveau/includes/customizer.php:173
@@ -1288,28 +1288,28 @@ msgstr ""
 msgid "Embedded Activity Item"
 msgstr ""
 
-#: bp-activity/classes/class-bp-activity-template.php:299
+#: bp-activity/classes/class-bp-activity-template.php:301
 #: bp-blogs/classes/class-bp-blogs-template.php:152
 #: bp-document/classes/class-bp-document-folder-template.php:222
 #: bp-document/classes/class-bp-document-template.php:245
-#: bp-groups/classes/class-bp-groups-template.php:298
+#: bp-groups/classes/class-bp-groups-template.php:300
 #: bp-media/classes/class-bp-media-album-template.php:225
 #: bp-media/classes/class-bp-media-template.php:235
 #: bp-members/classes/class-bp-core-members-template.php:209
-#: bp-messages/classes/class-bp-messages-box-template.php:228
+#: bp-messages/classes/class-bp-messages-box-template.php:230
 #: bp-notifications/classes/class-bp-notifications-template.php:243
 msgid "&larr;"
 msgstr ""
 
-#: bp-activity/classes/class-bp-activity-template.php:300
+#: bp-activity/classes/class-bp-activity-template.php:302
 #: bp-blogs/classes/class-bp-blogs-template.php:153
 #: bp-document/classes/class-bp-document-folder-template.php:223
 #: bp-document/classes/class-bp-document-template.php:246
-#: bp-groups/classes/class-bp-groups-template.php:299
+#: bp-groups/classes/class-bp-groups-template.php:301
 #: bp-media/classes/class-bp-media-album-template.php:226
 #: bp-media/classes/class-bp-media-template.php:236
 #: bp-members/classes/class-bp-core-members-template.php:210
-#: bp-messages/classes/class-bp-messages-box-template.php:229
+#: bp-messages/classes/class-bp-messages-box-template.php:231
 #: bp-notifications/classes/class-bp-notifications-template.php:244
 msgid "&rarr;"
 msgstr ""
@@ -1883,7 +1883,7 @@ msgstr ""
 #: bp-blogs/bp-blogs-template.php:646
 #: bp-core/classes/class-bp-core-user.php:204
 #: bp-groups/bp-groups-widgets.php:81
-#: bp-groups/classes/class-bp-groups-invite-template.php:280
+#: bp-groups/classes/class-bp-groups-invite-template.php:282
 #: bp-groups/classes/class-bp-groups-widget.php:159
 #: bp-members/bp-members-template.php:1016
 #: bp-members/bp-members-template.php:1690
@@ -2548,8 +2548,8 @@ msgid "Shortcode"
 msgstr ""
 
 #: bp-core/admin/bp-core-admin-functions.php:1664
-#: bp-members/bp-members-functions.php:3057
-#: bp-members/bp-members-functions.php:3539
+#: bp-members/bp-members-functions.php:3063
+#: bp-members/bp-members-functions.php:3545
 #: bp-members/classes/class-bp-members-admin.php:969
 #: bp-members/classes/class-bp-members-admin.php:2671
 #: bp-templates/bp-nouveau/buddypress/members/single/invites/send-invites.php:22
@@ -2578,7 +2578,7 @@ msgid "e.g. Student"
 msgstr ""
 
 #: bp-core/admin/bp-core-admin-functions.php:1713
-#: bp-members/bp-members-functions.php:3542
+#: bp-members/bp-members-functions.php:3548
 msgid "Members Directory"
 msgstr ""
 
@@ -2647,7 +2647,7 @@ msgid ""
 msgstr ""
 
 #: bp-core/admin/bp-core-admin-functions.php:1992
-#: bp-groups/bp-groups-admin.php:2249 bp-members/bp-members-functions.php:3793
+#: bp-groups/bp-groups-admin.php:2249 bp-members/bp-members-functions.php:3799
 msgid "Copy to clipboard"
 msgstr ""
 
@@ -2706,7 +2706,7 @@ msgid ""
 msgstr ""
 
 #: bp-core/admin/bp-core-admin-functions.php:2366
-#: bp-media/bp-media-filters.php:1060
+#: bp-media/bp-media-filters.php:1132
 msgid "Run Migration"
 msgstr ""
 
@@ -2744,8 +2744,8 @@ msgstr ""
 #: bp-core/admin/settings/bp-admin-setting-groups.php:60
 #: bp-core/deprecated/buddyboss/1.1.8.php:233
 #: bp-core/deprecated/buddyboss/1.1.8.php:236
-#: bp-groups/bp-groups-admin.php:2536 bp-groups/bp-groups-functions.php:3402
-#: bp-groups/bp-groups-functions.php:3405
+#: bp-groups/bp-groups-admin.php:2536 bp-groups/bp-groups-functions.php:3412
+#: bp-groups/bp-groups-functions.php:3415
 msgid "Group Types"
 msgstr ""
 
@@ -3225,8 +3225,8 @@ msgstr ""
 
 #: bp-core/admin/bp-core-admin-slugs.php:53 bp-core/bp-core-functions.php:783
 #: bp-document/bp-document-filters.php:69
-#: bp-document/bp-document-functions.php:1900
-#: bp-document/bp-document-functions.php:1903
+#: bp-document/bp-document-functions.php:2090
+#: bp-document/bp-document-functions.php:2093
 #: bp-document/classes/class-bp-document-component.php:69
 #: bp-document/classes/class-bp-document-component.php:260
 #: bp-document/classes/class-bp-document-component.php:262
@@ -3270,9 +3270,9 @@ msgstr ""
 #: bp-core/bp-core-template.php:561 bp-core/bp-core-update.php:763
 #: bp-core/classes/class-bp-email-tokens.php:394 bp-forums/admin/topics.php:679
 #: bp-groups/bp-groups-admin.php:1396 bp-groups/bp-groups-admin.php:2052
-#: bp-groups/bp-groups-functions.php:3912
-#: bp-groups/bp-groups-functions.php:3931
-#: bp-groups/bp-groups-functions.php:3948 bp-groups/bp-groups-template.php:5418
+#: bp-groups/bp-groups-functions.php:3922
+#: bp-groups/bp-groups-functions.php:3941
+#: bp-groups/bp-groups-functions.php:3958 bp-groups/bp-groups-template.php:5418
 #: bp-groups/classes/class-bp-groups-component.php:631
 #: bp-groups/classes/class-bp-groups-component.php:913
 #: bp-groups/classes/class-bp-groups-list-table.php:439
@@ -3298,7 +3298,7 @@ msgstr ""
 #: bp-core/admin/settings/bp-admin-setting-friends.php:21
 #: bp-core/gdpr/class-bp-friendship-export.php:58
 #: bp-document/classes/class-bp-document.php:720
-#: bp-document/classes/class-bp-document.php:1380
+#: bp-document/classes/class-bp-document.php:1379
 #: bp-friends/bp-friends-activity.php:110
 #: bp-friends/bp-friends-activity.php:119
 #: bp-friends/bp-friends-notifications.php:261
@@ -3358,7 +3358,7 @@ msgstr ""
 #: bp-forums/templates/default/bbpress/loop-forums.php:19
 #: bp-forums/templates/default/bbpress/loop-topics.php:18
 #: bp-forums/topics/template.php:48 bp-forums/topics/template.php:49
-#: bp-media/bp-media-filters.php:1025
+#: bp-media/bp-media-filters.php:1097
 #: bp-templates/bp-nouveau/includes/groups/classes.php:300
 msgid "Discussions"
 msgstr ""
@@ -3375,7 +3375,7 @@ msgstr ""
 #: bp-forums/templates/default/bbpress/loop-replies.php:31
 #: bp-forums/templates/default/bbpress/loop-replies.php:72
 #: bp-forums/templates/default/bbpress/loop-topics.php:19
-#: bp-media/bp-media-filters.php:1031
+#: bp-media/bp-media-filters.php:1103
 msgid "Replies"
 msgstr ""
 
@@ -3513,7 +3513,7 @@ msgstr ""
 #: bp-forums/admin/tools.php:1577 bp-forums/admin/tools.php:1579
 #: bp-forums/admin/tools.php:1653 bp-forums/admin/tools.php:1655
 #: bp-forums/admin/tools.php:1727 bp-forums/admin/tools.php:1729
-#: bp-forums/core/capabilities.php:608 bp-media/bp-media-filters.php:1421
+#: bp-forums/core/capabilities.php:608 bp-media/bp-media-filters.php:1493
 msgid "Complete!"
 msgstr ""
 
@@ -3849,7 +3849,7 @@ msgid "Allowed Profile Type"
 msgstr ""
 
 #: bp-core/admin/settings/bp-admin-setting-media.php:22
-#: bp-media/bp-media-filters.php:1013
+#: bp-media/bp-media-filters.php:1085
 msgid "Media"
 msgstr ""
 
@@ -3917,8 +3917,8 @@ msgstr ""
 
 #: bp-core/admin/settings/bp-admin-setting-xprofile.php:129
 #: bp-core/admin/settings/bp-admin-setting-xprofile.php:132
-#: bp-members/bp-members-functions.php:3049
-#: bp-members/bp-members-functions.php:3052
+#: bp-members/bp-members-functions.php:3055
+#: bp-members/bp-members-functions.php:3058
 #: bp-xprofile/bp-xprofile-admin.php:1114
 #: bp-xprofile/bp-xprofile-admin.php:1165
 #: bp-xprofile/classes/class-bp-xprofile-field.php:1602
@@ -4852,7 +4852,7 @@ msgstr ""
 
 #: bp-core/bp-core-functions.php:2531
 #: bp-core/deprecated/buddyboss/1.1.8.php:235
-#: bp-groups/bp-groups-functions.php:3404
+#: bp-groups/bp-groups-functions.php:3414
 #: bp-groups/bp-groups-notifications.php:1229
 #: bp-groups/classes/class-bp-groups-component.php:104
 #: bp-groups/classes/class-bp-groups-theme-compat.php:183
@@ -5796,7 +5796,7 @@ msgstr ""
 msgid "You have posted too many links"
 msgstr ""
 
-#: bp-core/bp-core-moderation.php:175 bp-core/bp-core-moderation.php:289
+#: bp-core/bp-core-moderation.php:175 bp-core/bp-core-moderation.php:293
 msgid "You have posted an inappropriate word."
 msgstr ""
 
@@ -6538,31 +6538,31 @@ msgid "The uploaded file exceeds the maximum allowed file size of: %s"
 msgstr ""
 
 #: bp-core/classes/class-bp-attachment.php:161
-#: bp-document/bp-document-functions.php:1379
+#: bp-document/bp-document-functions.php:1383
 #: bp-media/bp-media-functions.php:116
 msgid "The uploaded file was only partially uploaded."
 msgstr ""
 
 #: bp-core/classes/class-bp-attachment.php:162
-#: bp-document/bp-document-functions.php:1380
+#: bp-document/bp-document-functions.php:1384
 #: bp-media/bp-media-functions.php:117
 msgid "No file was uploaded."
 msgstr ""
 
 #: bp-core/classes/class-bp-attachment.php:164
-#: bp-document/bp-document-functions.php:1382
+#: bp-document/bp-document-functions.php:1386
 #: bp-media/bp-media-functions.php:119
 msgid "Missing a temporary folder."
 msgstr ""
 
 #: bp-core/classes/class-bp-attachment.php:165
-#: bp-document/bp-document-functions.php:1383
+#: bp-document/bp-document-functions.php:1387
 #: bp-media/bp-media-functions.php:120
 msgid "Failed to write file to disk."
 msgstr ""
 
 #: bp-core/classes/class-bp-attachment.php:166
-#: bp-document/bp-document-functions.php:1384
+#: bp-document/bp-document-functions.php:1388
 #: bp-media/bp-media-functions.php:121
 msgid "File upload stopped by extension."
 msgstr ""
@@ -6771,7 +6771,7 @@ msgid "Display post featured image?"
 msgstr ""
 
 #: bp-core/classes/class-bp-core-user.php:218
-#: bp-groups/classes/class-bp-groups-invite-template.php:284
+#: bp-groups/classes/class-bp-groups-invite-template.php:286
 msgid "%d group"
 msgid_plural "%d groups"
 msgstr[0] ""
@@ -7422,34 +7422,34 @@ msgstr ""
 
 #: bp-core/deprecated/buddyboss/1.1.8.php:232
 #: bp-core/deprecated/buddyboss/1.1.8.php:237
-#: bp-groups/bp-groups-functions.php:3401
-#: bp-groups/bp-groups-functions.php:3406
+#: bp-groups/bp-groups-functions.php:3411
+#: bp-groups/bp-groups-functions.php:3416
 msgid "New Group Type"
 msgstr ""
 
 #: bp-core/deprecated/buddyboss/1.1.8.php:234
-#: bp-groups/bp-groups-functions.php:3403
+#: bp-groups/bp-groups-functions.php:3413
 msgid "Edit Group Type"
 msgstr ""
 
 #: bp-core/deprecated/buddyboss/1.1.8.php:238
-#: bp-groups/bp-groups-functions.php:3407
+#: bp-groups/bp-groups-functions.php:3417
 msgid "No Group Types found"
 msgstr ""
 
 #: bp-core/deprecated/buddyboss/1.1.8.php:239
-#: bp-groups/bp-groups-functions.php:3408
+#: bp-groups/bp-groups-functions.php:3418
 msgid "No Group Types found in trash"
 msgstr ""
 
 #: bp-core/deprecated/buddyboss/1.1.8.php:240
-#: bp-groups/bp-groups-functions.php:3409
+#: bp-groups/bp-groups-functions.php:3419
 msgid "Search Group Types"
 msgstr ""
 
 #: bp-core/deprecated/buddyboss/1.1.8.php:241 bp-groups/bp-groups-admin.php:175
 #: bp-groups/bp-groups-admin.php:1951 bp-groups/bp-groups-admin.php:2264
-#: bp-groups/bp-groups-functions.php:3410
+#: bp-groups/bp-groups-functions.php:3420
 #: bp-groups/classes/class-bp-groups-list-table.php:744
 #: bp-groups/classes/class-bp-rest-group-settings-endpoint.php:764
 #: bp-templates/bp-nouveau/buddypress/groups/single/admin/group-settings.php:244
@@ -8055,7 +8055,7 @@ msgid "Field"
 msgstr ""
 
 #: bp-core/profile-search/bps-admin.php:84 bp-groups/bp-groups-admin.php:2265
-#: bp-members/bp-members-functions.php:3540
+#: bp-members/bp-members-functions.php:3546
 msgid "Label"
 msgstr ""
 
@@ -8390,7 +8390,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: bp-document/bp-document-filters.php:1012 bp-media/bp-media-filters.php:1513
+#: bp-document/bp-document-filters.php:1012 bp-media/bp-media-filters.php:1585
 msgid "File not found"
 msgstr ""
 
@@ -8416,85 +8416,85 @@ msgid_plural "%s documents"
 msgstr[0] ""
 msgstr[1] ""
 
-#: bp-document/bp-document-filters.php:1590 bp-media/bp-media-filters.php:1908
+#: bp-document/bp-document-filters.php:1590 bp-media/bp-media-filters.php:1980
 msgid "<a href=\"%1$s\" target=\"_blank\">%2$s uploaded</a>"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1323
+#: bp-document/bp-document-functions.php:1327
 msgid "Please login in order to upload file document."
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1378
+#: bp-document/bp-document-functions.php:1382
 #: bp-media/bp-media-functions.php:115
 msgid "The uploaded file exceeds "
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1403
+#: bp-document/bp-document-functions.php:1407
 msgid "Error while uploading document."
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1738
+#: bp-document/bp-document-functions.php:1918
 msgid "Default"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1742
+#: bp-document/bp-document-functions.php:1923
 msgid "Archive"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1746
+#: bp-document/bp-document-functions.php:1928
 msgid "Audio"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1750
+#: bp-document/bp-document-functions.php:1933
 msgid "Code"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1754
+#: bp-document/bp-document-functions.php:1938
 msgid "Design"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1758
+#: bp-document/bp-document-functions.php:1943
 #: bp-templates/bp-nouveau/buddypress/common/js-templates/activity/parts/bp-activity-link-preview.php:26
 msgid "Image"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1762
+#: bp-document/bp-document-functions.php:1948
 msgid "Presentation"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1766
+#: bp-document/bp-document-functions.php:1953
 msgid "Spreadsheet"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1770
+#: bp-document/bp-document-functions.php:1958
 msgid "Text"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1774
+#: bp-document/bp-document-functions.php:1963
 msgid "Video"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:1907
+#: bp-document/bp-document-functions.php:2097
 msgid "..."
 msgstr ""
 
-#: bp-document/bp-document-functions.php:2171
+#: bp-document/bp-document-functions.php:2357
 msgid "The document name is empty!"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:2174
+#: bp-document/bp-document-functions.php:2360
 msgid "Bad characters or invalid document name!"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:2177
+#: bp-document/bp-document-functions.php:2363
 msgid "A file with that name already exists in the containing folder!"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:2180
+#: bp-document/bp-document-functions.php:2366
 msgid "The document containing directory is not writable!"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:2210
+#: bp-document/bp-document-functions.php:2396
 msgid "File renaming error!"
 msgstr ""
 
@@ -8512,10 +8512,10 @@ msgstr ""
 msgid "My Documents"
 msgstr ""
 
-#: bp-document/classes/class-bp-document-folder.php:518
+#: bp-document/classes/class-bp-document-folder.php:524
 #: bp-document/classes/class-bp-document-privacy.php:58
 #: bp-document/classes/class-bp-document.php:710
-#: bp-document/classes/class-bp-document.php:1370
+#: bp-document/classes/class-bp-document.php:1369
 #: bp-integrations/learndash/bp-admin-learndash-tab.php:154
 #: bp-media/classes/class-bp-media-privacy.php:59
 msgid "Group Members"
@@ -12097,10 +12097,10 @@ msgid ""
 msgstr ""
 
 #: bp-forums/common/locale.php:43 bp-groups/bp-groups-admin.php:1451
-#: bp-groups/bp-groups-functions.php:1288
-#: bp-groups/bp-groups-functions.php:3914
-#: bp-groups/bp-groups-functions.php:3933
-#: bp-groups/bp-groups-functions.php:3950
+#: bp-groups/bp-groups-functions.php:1292
+#: bp-groups/bp-groups-functions.php:3924
+#: bp-groups/bp-groups-functions.php:3943
+#: bp-groups/bp-groups-functions.php:3960
 #: bp-integrations/learndash/bp-admin-learndash-tab.php:343
 #: bp-integrations/learndash/bp-admin-learndash-tab.php:359
 #. translators: user role
@@ -12108,10 +12108,10 @@ msgid "Organizer"
 msgstr ""
 
 #: bp-forums/common/locale.php:46 bp-forums/replies/functions.php:2439
-#: bp-groups/bp-groups-admin.php:1452 bp-groups/bp-groups-functions.php:1296
-#: bp-groups/bp-groups-functions.php:3916
-#: bp-groups/bp-groups-functions.php:3935
-#: bp-groups/bp-groups-functions.php:3952
+#: bp-groups/bp-groups-admin.php:1452 bp-groups/bp-groups-functions.php:1300
+#: bp-groups/bp-groups-functions.php:3926
+#: bp-groups/bp-groups-functions.php:3945
+#: bp-groups/bp-groups-functions.php:3962
 #: bp-integrations/learndash/bp-admin-learndash-tab.php:344
 #: bp-integrations/learndash/bp-admin-learndash-tab.php:360
 #. translators: user role
@@ -12858,13 +12858,13 @@ msgid "Replies: %s"
 msgstr ""
 
 #: bp-forums/replies/functions.php:2405 bp-forums/users/template.php:517
-#: bp-groups/bp-groups-admin.php:1453 bp-groups/bp-groups-functions.php:1304
-#: bp-groups/bp-groups-functions.php:3918
-#: bp-groups/bp-groups-functions.php:3937
-#: bp-groups/bp-groups-functions.php:3954
+#: bp-groups/bp-groups-admin.php:1453 bp-groups/bp-groups-functions.php:1308
+#: bp-groups/bp-groups-functions.php:3928
+#: bp-groups/bp-groups-functions.php:3947
+#: bp-groups/bp-groups-functions.php:3964
 #: bp-integrations/learndash/bp-admin-learndash-tab.php:345
 #: bp-integrations/learndash/bp-admin-learndash-tab.php:361
-#: bp-members/bp-members-functions.php:3815
+#: bp-members/bp-members-functions.php:3821
 #: bp-members/classes/class-bp-members-admin.php:951
 msgid "Member"
 msgstr ""
@@ -12876,7 +12876,7 @@ msgstr ""
 #: bp-forums/replies/functions.php:2430 bp-members/bp-members-functions.php:540
 #: bp-messages/bp-messages-template.php:1791
 #: bp-messages/bp-messages-template.php:2056
-#: bp-messages/classes/class-bp-messages-thread.php:1334
+#: bp-messages/classes/class-bp-messages-thread.php:1335
 msgid "Deleted User"
 msgstr ""
 
@@ -14490,7 +14490,7 @@ msgid "You joined the group!"
 msgstr ""
 
 #: bp-groups/actions/leave-group.php:40 bp-groups/bp-groups-admin.php:647
-#: bp-groups/bp-groups-functions.php:570
+#: bp-groups/bp-groups-functions.php:572
 msgid "This group must have at least one organizer."
 msgstr ""
 
@@ -14738,9 +14738,9 @@ msgstr ""
 #: bp-groups/bp-groups-admin.php:1206 bp-groups/bp-groups-admin.php:1227
 #: bp-groups/bp-groups-admin.php:1239 bp-groups/bp-groups-admin.php:1251
 #: bp-groups/bp-groups-admin.php:1263 bp-groups/bp-groups-admin.php:1390
-#: bp-groups/bp-groups-admin.php:1996 bp-groups/bp-groups-functions.php:3908
-#: bp-groups/bp-groups-functions.php:3927
-#: bp-groups/bp-groups-functions.php:3944
+#: bp-groups/bp-groups-admin.php:1996 bp-groups/bp-groups-functions.php:3918
+#: bp-groups/bp-groups-functions.php:3937
+#: bp-groups/bp-groups-functions.php:3954
 #: bp-integrations/learndash/bp-admin-learndash-tab.php:512
 msgid "Organizers"
 msgstr ""
@@ -14827,9 +14827,9 @@ msgid "Enter a comma-separated list of user logins."
 msgstr ""
 
 #: bp-groups/bp-groups-admin.php:1393 bp-groups/bp-groups-admin.php:2024
-#: bp-groups/bp-groups-functions.php:3910
-#: bp-groups/bp-groups-functions.php:3929
-#: bp-groups/bp-groups-functions.php:3946
+#: bp-groups/bp-groups-functions.php:3920
+#: bp-groups/bp-groups-functions.php:3939
+#: bp-groups/bp-groups-functions.php:3956
 #: bp-integrations/learndash/bp-admin-learndash-tab.php:513
 msgid "Moderators"
 msgstr ""
@@ -14851,7 +14851,7 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
-#: bp-groups/bp-groups-admin.php:1455 bp-groups/bp-groups-functions.php:1312
+#: bp-groups/bp-groups-admin.php:1455 bp-groups/bp-groups-functions.php:1316
 msgid "Banned"
 msgstr ""
 
@@ -14999,14 +14999,14 @@ msgid "Groups Filter"
 msgstr ""
 
 #: bp-groups/bp-groups-admin.php:2293 bp-groups/bp-groups-admin.php:2304
-#: bp-members/bp-members-functions.php:3568
-#: bp-members/bp-members-functions.php:3579
+#: bp-members/bp-members-functions.php:3574
+#: bp-members/bp-members-functions.php:3585
 msgid "Show"
 msgstr ""
 
 #: bp-groups/bp-groups-admin.php:2295 bp-groups/bp-groups-admin.php:2302
-#: bp-members/bp-members-functions.php:3570
-#: bp-members/bp-members-functions.php:3577
+#: bp-members/bp-members-functions.php:3576
+#: bp-members/bp-members-functions.php:3583
 msgid "Hide"
 msgstr ""
 
@@ -15031,23 +15031,23 @@ msgstr ""
 msgid "Group Organizer"
 msgstr ""
 
-#: bp-groups/bp-groups-functions.php:579
+#: bp-groups/bp-groups-functions.php:581
 msgid "You successfully left the group."
 msgstr ""
 
-#: bp-groups/bp-groups-functions.php:2443
-#: bp-groups/bp-groups-functions.php:2476
-#: bp-groups/bp-groups-functions.php:2513
+#: bp-groups/bp-groups-functions.php:2447
+#: bp-groups/bp-groups-functions.php:2480
+#: bp-groups/bp-groups-functions.php:2517
 msgid ""
 "Argument `membership_id` passed to %1$s  is deprecated. See the inline "
 "documentation at %2$s for more details."
 msgstr ""
 
-#: bp-groups/bp-groups-functions.php:2865
+#: bp-groups/bp-groups-functions.php:2869
 msgid "Group type already exists."
 msgstr ""
 
-#: bp-groups/bp-groups-functions.php:2896
+#: bp-groups/bp-groups-functions.php:2900
 msgid "You may not register a group type with this name."
 msgstr ""
 
@@ -15432,7 +15432,7 @@ msgid "Pending Invites"
 msgstr ""
 
 #: bp-groups/classes/class-bp-groups-component.php:784
-#: bp-media/bp-media-filters.php:1007
+#: bp-media/bp-media-filters.php:1079
 #: bp-media/classes/class-bp-media-component.php:295
 #: bp-templates/bp-nouveau/buddypress/media/albums.php:12
 #: bp-templates/bp-nouveau/includes/groups/classes.php:289
@@ -17671,43 +17671,43 @@ msgid ""
 "bbPress to re-enable BuddyBoss Platform."
 msgstr ""
 
-#: bp-media/bp-media-filters.php:910 bp-media/bp-media-filters.php:926
-#: bp-media/bp-media-filters.php:927 bp-media/bp-media-filters.php:980
-#: bp-media/bp-media-filters.php:1107
+#: bp-media/bp-media-filters.php:982 bp-media/bp-media-filters.php:998
+#: bp-media/bp-media-filters.php:999 bp-media/bp-media-filters.php:1052
+#: bp-media/bp-media-filters.php:1179
 msgid "Import Media"
 msgstr ""
 
-#: bp-media/bp-media-filters.php:985
+#: bp-media/bp-media-filters.php:1057
 msgid ""
 "BuddyBoss Media plugin database tables do not exist, meaning you have "
 "nothing to import."
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1002
+#: bp-media/bp-media-filters.php:1074
 msgid "Your database is being updated in the background."
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1004
+#: bp-media/bp-media-filters.php:1076
 msgid "Migration in progress"
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1009 bp-media/bp-media-filters.php:1015
-#: bp-media/bp-media-filters.php:1021 bp-media/bp-media-filters.php:1027
-#: bp-media/bp-media-filters.php:1033
+#: bp-media/bp-media-filters.php:1081 bp-media/bp-media-filters.php:1087
+#: bp-media/bp-media-filters.php:1093 bp-media/bp-media-filters.php:1099
+#: bp-media/bp-media-filters.php:1105
 msgid "out of"
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1043 bp-media/bp-media-filters.php:1054
+#: bp-media/bp-media-filters.php:1115 bp-media/bp-media-filters.php:1126
 msgid "Re-Run Migration"
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1050 bp-media/bp-media-functions.php:2129
+#: bp-media/bp-media-filters.php:1122 bp-media/bp-media-functions.php:2129
 msgid ""
 "BuddyBoss Media data update is complete! Any previously uploaded member "
 "photos should display in their profiles now."
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1059
+#: bp-media/bp-media-filters.php:1131
 msgid ""
 "Import your existing members photo uploads, if you were previously using <a "
 "href=\"https://www.buddyboss.com/product/buddyboss-media/\">BuddyBoss "
@@ -17715,7 +17715,7 @@ msgid ""
 "old photos into the new Media component."
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1105
+#: bp-media/bp-media-filters.php:1177
 msgid ""
 "We have found some media uploaded from the <strong>BuddyBoss "
 "Media</strong></strong> plugin, which is not compatible with BuddyBoss "
@@ -17724,35 +17724,35 @@ msgid ""
 "are still using it."
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1312
+#: bp-media/bp-media-filters.php:1384
 msgid "Repair media on the site."
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1317
+#: bp-media/bp-media-filters.php:1389
 msgid "Repair forum media privacy"
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1371
+#: bp-media/bp-media-filters.php:1443
 msgid "%s media updated successfully."
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1381
+#: bp-media/bp-media-filters.php:1453
 msgid "Media update complete!"
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1409
+#: bp-media/bp-media-filters.php:1481
 msgid "%s Forums media privacy updated successfully."
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1417
+#: bp-media/bp-media-filters.php:1489
 msgid "Forums media privacy updated %s"
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1530
+#: bp-media/bp-media-filters.php:1602
 msgid "Go to media"
 msgstr ""
 
-#: bp-media/bp-media-filters.php:1903
+#: bp-media/bp-media-filters.php:1975
 #: bp-templates/bp-nouveau/buddypress/media/album-entry.php:20
 #: bp-templates/bp-nouveau/buddypress/media/single-album.php:33
 msgid "%s photo"
@@ -18445,82 +18445,82 @@ msgstr ""
 msgid "You may not register a profile type with this name."
 msgstr ""
 
-#: bp-members/bp-members-functions.php:2945
+#: bp-members/bp-members-functions.php:2951
 msgid "BuddyBoss profile type"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3048
-#: bp-members/bp-members-functions.php:3053
+#: bp-members/bp-members-functions.php:3054
+#: bp-members/bp-members-functions.php:3059
 msgid "New Profile Type"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3050
+#: bp-members/bp-members-functions.php:3056
 msgid "Edit Profile Type"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3051
-#: bp-members/bp-members-functions.php:3543
+#: bp-members/bp-members-functions.php:3057
+#: bp-members/bp-members-functions.php:3549
 #: bp-members/classes/class-bp-members-admin.php:2188
 #: bp-members/classes/class-bp-members-admin.php:2210
 msgid "Users"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3054
+#: bp-members/bp-members-functions.php:3060
 msgid "No Profile Types found"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3055
+#: bp-members/bp-members-functions.php:3061
 msgid "No Profile Types found in trash"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3056
+#: bp-members/bp-members-functions.php:3062
 msgid "Search Profile Types"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3541
+#: bp-members/bp-members-functions.php:3547
 msgid "Members Filter"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3788
+#: bp-members/bp-members-functions.php:3794
 msgid ""
 "You have {total_users} members with this profile type, are you sure you "
 "would like to trash it?"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3789
+#: bp-members/bp-members-functions.php:3795
 msgid ""
 "You have {total_users} members with this profile type, are you sure you "
 "would like to delete it?"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3790
+#: bp-members/bp-members-functions.php:3796
 msgid ""
 "You have members with these profile types, are you sure you would like to "
 "trash it?"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3791
+#: bp-members/bp-members-functions.php:3797
 msgid ""
 "You have members with these profile types, are you sure you would like to "
 "delete it?"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3792
+#: bp-members/bp-members-functions.php:3798
 msgid "Copied"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3855
-#: bp-members/bp-members-functions.php:3863
-#: bp-members/bp-members-functions.php:3871
-#: bp-members/bp-members-functions.php:3876
+#: bp-members/bp-members-functions.php:3861
+#: bp-members/bp-members-functions.php:3869
+#: bp-members/bp-members-functions.php:3877
+#: bp-members/bp-members-functions.php:3882
 msgid "their"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3867
+#: bp-members/bp-members-functions.php:3873
 msgid "his"
 msgstr ""
 
-#: bp-members/bp-members-functions.php:3869
+#: bp-members/bp-members-functions.php:3875
 msgid "her"
 msgstr ""
 
@@ -19845,7 +19845,7 @@ msgstr ""
 msgid "Display Sitewide Notices posted by the site administrator"
 msgstr ""
 
-#: bp-messages/classes/class-bp-messages-thread.php:1325
+#: bp-messages/classes/class-bp-messages-thread.php:1326
 msgid "%s Recipients"
 msgstr ""
 
@@ -24982,32 +24982,32 @@ msgctxt "member latest update in member directory"
 msgid "- &quot;%s&quot;"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:3258
+#: bp-document/bp-document-functions.php:3444
 #. translators: Memory unit for terabyte.
 msgctxt "memory unit"
 msgid "TB"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:3260
+#: bp-document/bp-document-functions.php:3446
 #. translators: Memory unit for gigabyte.
 msgctxt "memory unit"
 msgid "GB"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:3262
+#: bp-document/bp-document-functions.php:3448
 #. translators: Memory unit for megabyte.
 msgctxt "memory unit"
 msgid "MB"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:3264
+#: bp-document/bp-document-functions.php:3450
 #. translators: Memory unit for kilobyte.
 msgctxt "memory unit"
 msgid "KB"
 msgstr ""
 
-#: bp-document/bp-document-functions.php:3266
-#: bp-document/bp-document-functions.php:3271
+#: bp-document/bp-document-functions.php:3452
+#: bp-document/bp-document-functions.php:3457
 #. translators: Memory unit for byte.
 msgctxt "memory unit"
 msgid "B"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #973 .

### How to test the changes in this Pull Request:

1.
2.
3.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

1. `blacklist_keys` option name has been deprecated in WP 5.5

      > As a result, our PHPunit tests are failing each time there are run against WordPress trunk due to the deprecated notice.
The attached patch is fixing the issue making sure to use the new option name (disallowed_keys) if the site's installed WordPress version is >= WP 5.5.

2. oembed/1.0/embed/activity is missing the required permission_callback

      > Just found this doing_it_wrong notice added in WordPress 5.5. As this route is used to embed activity content into a Post, we simply need to use the __return_true function as the permission callback.

3. Ensure compatibility with PHPMailer v6.0

      > There is a major update in the PHPMailer library in core. This is scheduled to be released with WP 5.5 due in a few weeks. More details on the Make Core blog post: https://make.wordpress.org/core/2020/07/01/external-library-updates-in-wordpress-5-5-call-for-testing/

4. PHP 7.4 "trying to access..." errors

      > See corresponding ticket and explanation in Core Trac: https://core.trac.wordpress.org/ticket/47704

5. func_get_args() should be cast to variable before being modified

      > The behavior of func_get_args() was changed in PHP 7.0, so that it reflects the current value of function params, rather than the values originally passed. In cases where we use func_get_args(), intending to reference the original values, we should cast to a variable early in the function. See https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameter-modified
