### PR TITLE
Profile completion widget not updating while having a repeater fields

### DIFF
--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -2098,9 +2098,10 @@ function bp_xprofile_get_user_progress( $group_ids, $photo_types ) {
 	// Get Groups and Group fields with Loggedin user data.
 	$profile_groups = bp_xprofile_get_groups(
 		array(
-			'fetch_fields'     => true,
-			'fetch_field_data' => true,
-			'user_id'          => $user_id,
+			'fetch_fields'                   => true,
+			'fetch_field_data'               => true,
+			'user_id'                        => $user_id,
+			'repeater_show_main_fields_only' => false,
 		)
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1348 

### How to test the changes in this Pull Request:

1. Having a repeater field and filled all: http://prntscr.com/tz05r8
2. See the widget shows only 2 filled out of 3: http://prntscr.com/tz06xa

### Proof Screenshots or Video
http://somup.com/cYjIIC6Al9

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

