### PR TITLE
Private messages are deleted as soon as you click on the send button

### DIFF
--- a/src/bp-messages/classes/class-bp-messages-message.php
+++ b/src/bp-messages/classes/class-bp-messages-message.php
@@ -192,6 +192,11 @@ class BP_Messages_Message {
 
 		messages_remove_callback_values();
 
+		// Removed message meta while sending a new message.
+		if ( ! empty( $this->id ) && ! is_wp_error( $this->id ) ) {
+			bp_messages_delete_meta( $this->id );
+		}
+
 		/**
 		 * Fires after the current message item has been saved.
 		 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #968

### How to test the changes in this Pull Request:

1. Go to profile > messages
2. Compose a message and send
3. See error

**It's happening on that DB where messages are deleted but meta still existed.**

### Proof Screenshots or Video
http://somup.com/cYjb2X6C9V

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
