### PR TITLE
Use the plugin_dir property instead of BP_PLUGIN_DIR constant

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -2332,6 +2332,7 @@ function bp_is_get_request() {
  * @return bool True on success, false on failure.
  */
 function bp_core_load_buddypress_textdomain() {
+	$bp = buddypress();
 	$domain = 'buddyboss';
 
 	/**
@@ -2355,7 +2356,7 @@ function bp_core_load_buddypress_textdomain() {
 		array(
 			trailingslashit( WP_LANG_DIR . '/' . $domain ),
 			trailingslashit( WP_LANG_DIR ),
-			trailingslashit( BP_PLUGIN_DIR . '/languages' ),
+			trailingslashit( $bp->plugin_dir . '/languages' ),
 		)
 	);
 


### PR DESCRIPTION
When using the development version of the plugin, the language textdomain isn't loaded because it searches for `/buddyboss-platform/languages`, whereas the actual language folder is located in `/buddyboss-platform/src/languages`

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?