### PR TITLE
Fix #1421

### DIFF
--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -2102,6 +2102,7 @@ function bp_xprofile_get_user_progress( $group_ids, $photo_types ) {
 			'fetch_field_data'               => true,
 			'user_id'                        => $user_id,
 			'repeater_show_main_fields_only' => false,
+			'fetch_social_network_fields'    => true,
 		)
 	);
 
@@ -2140,13 +2141,25 @@ function bp_xprofile_get_user_progress( $group_ids, $photo_types ) {
 				}
 			}
 
-			$field_data_value = maybe_unserialize( $group_single_field->data->value );
+			// For Social networks field check child field is completed or not
+			if  ( 'socialnetworks' == $group_single_field->type ){
+				$field_data_value = maybe_unserialize( $group_single_field->data->value );
+				$children = $group_single_field->type_obj->field_obj->get_children();
+				foreach ( $children as $child ){
+					if ( isset( $field_data_value[$child->name] ) &&  ! empty( $field_data_value[$child->name] ) ) {
+						++ $group_completed_fields;
+					}
+					++ $group_total_fields;
+				}
+			} else{
+				$field_data_value = maybe_unserialize( $group_single_field->data->value );
 
-			if ( ! empty( $field_data_value ) ) {
-				++ $group_completed_fields;
+				if ( ! empty( $field_data_value ) ) {
+					++ $group_completed_fields;
+				}
+
+				++ $group_total_fields;
 			}
-
-			++ $group_total_fields;
 		}
 
 		/* Prepare array to return group specific progress details */

--- a/src/bp-xprofile/classes/class-bp-xprofile-group.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-group.php
@@ -289,6 +289,7 @@ class BP_XProfile_Group {
 				'include_fields'                 => false,
 				'update_meta_cache'              => true,
 				'repeater_show_main_fields_only' => false,
+				'fetch_social_network_fields'    => false,
 			)
 		);
 
@@ -442,7 +443,7 @@ class BP_XProfile_Group {
 		}
 
 		// If social networks field found then remove from the $field_ids array.
-		if ( $social_networks_key > 0 ) {
+		if ( $social_networks_key > 0 && empty( $r['fetch_social_network_fields'] ) ) {
 			if ( ( $key = array_search( $social_networks_key, $field_ids ) ) !== false ) {
 				unset( $field_ids[ $key ] );
 			}


### PR DESCRIPTION
social network field support on Profile completion widget

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. In admin create a Profile field
2. After creating a profile field, add a field to it with a type Social Networks.
3. In Appearance > Widgets > (BB) Profile Completion, check the field you've just created with the Social Networks type.

### Proof Screenshots or Video

<img width="769" alt="Screenshot 2020-09-10 at 1 36 44 PM" src="https://user-images.githubusercontent.com/2979084/92698995-ae070500-f36a-11ea-86a9-12f3ad71c312.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Social Network profile field issue fixed with profile complete widget 
