### PR TITLE
Fixed hardcoded group id in registration page

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/xprofile/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/xprofile/template-tags.php
@@ -66,7 +66,7 @@ function bp_nouveau_xprofile_edit_visibilty() {
 function bp_nouveau_base_account_has_xprofile() {
 	return (bool) bp_has_profile(
 		array(
-			'profile_group_id' => 1,
+			'profile_group_id' => bp_xprofile_base_group_id(),
 			'fetch_field_data' => false,
 		)
 	);


### PR DESCRIPTION
### All Submissions:
Client is using the defualt BuddyBoss Registration: https://prnt.sc/ugwzve but Profile fields: https://prnt.sc/ugwxqo are not showing on the registration page.

Fixed hardcoded group id.

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
