### PR TITLE
Cloudflare site link preview issue fixed

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4790,7 +4790,9 @@ function bp_core_parse_url( $url ) {
 	} else {
 
 		// safely get URL and response body.
-		$response = wp_safe_remote_get( $url );
+		$response = wp_safe_remote_get( $url, array(
+			'user-agent' => '' // Default value being blocked by Cloudflare
+		));
 		$body     = wp_remote_retrieve_body( $response );
 
 		// if response is not empty


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

1) The problem is Cloudflare blocks the WordPress default user agent. The solution got from https://wordpress.org/support/topic/preview-not-working-with-medium-https/ plugin.

2) Another reason for preview not generate is request timeout to get site details. The default timeout time is 5 Sec. If added url site take time to send data then it'll not create preview and you will get error "Sorry! preview is not available right now. Please try again later" 

### How to test the changes in this Pull Request:

https://www.loom.com/share/f913ce7ef0f94f50a2c0ab5f2f2eac38

Links: https://elemental.medium.com/a-supercomputer-analyzed-covid-19-and-an-interesting-new-theory-has-emerged-31cb8eba9d63

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
