### PR TITLE
Fix - static wp-admin check removed

### DIFF
--- a/src/bp-loader.php
+++ b/src/bp-loader.php
@@ -134,7 +134,7 @@ if ( empty( $is_bp_active ) && empty( $is_bb_active ) && empty( $bp_incompatible
 		// Do not add the "bbpress/bbpress.php" & "buddypress/bp-loader.php" on "/wp-admin/plugins.php" page otherwise it will show the plugin file not exists error.
 
 		$admin_url    = ( is_multisite() ) ? network_admin_url() : admin_url();
-		$site_url	  = ( is_multisite() ) ? network_site_url() : site_url();
+		$site_url     = ( is_multisite() ) ? network_site_url() : site_url();
 		$root_path    = str_replace( $site_url, '', $admin_url );
 		$plugins_path = $root_path . 'plugins.php';
 		$ajax_path    = $root_path . 'admin-ajax.php';

--- a/src/bp-loader.php
+++ b/src/bp-loader.php
@@ -133,8 +133,8 @@ if ( empty( $is_bp_active ) && empty( $is_bb_active ) && empty( $bp_incompatible
 
 		// Do not add the "bbpress/bbpress.php" & "buddypress/bp-loader.php" on "/wp-admin/plugins.php" page otherwise it will show the plugin file not exists error.
 
-		$admin_url    = ( is_multisite() ) ? network_admin_url() : admin_url();
-		$site_url     = ( is_multisite() ) ? network_site_url() : site_url();
+		$admin_url    = ( $bp_is_multisite ) ? network_admin_url() : admin_url();
+		$site_url     = ( $bp_is_multisite ) ? network_site_url() : site_url();
 		$root_path    = str_replace( $site_url, '', $admin_url );
 		$plugins_path = $root_path . 'plugins.php';
 		$ajax_path    = $root_path . 'admin-ajax.php';

--- a/src/bp-loader.php
+++ b/src/bp-loader.php
@@ -133,8 +133,9 @@ if ( empty( $is_bp_active ) && empty( $is_bb_active ) && empty( $bp_incompatible
 
 		// Do not add the "bbpress/bbpress.php" & "buddypress/bp-loader.php" on "/wp-admin/plugins.php" page otherwise it will show the plugin file not exists error.
 
-		$admin_url    = admin_url();
-		$root_path    = str_replace( site_url(), '', $admin_url );
+		$admin_url    = ( is_multisite() ) ? network_admin_url() : admin_url();
+		$site_url	  = ( is_multisite() ) ? network_site_url() : site_url();
+		$root_path    = str_replace( $site_url, '', $admin_url );
 		$plugins_path = $root_path . 'plugins.php';
 		$ajax_path    = $root_path . 'admin-ajax.php';
 

--- a/src/bp-loader.php
+++ b/src/bp-loader.php
@@ -133,8 +133,8 @@ if ( empty( $is_bp_active ) && empty( $is_bb_active ) && empty( $bp_incompatible
 
 		// Do not add the "bbpress/bbpress.php" & "buddypress/bp-loader.php" on "/wp-admin/plugins.php" page otherwise it will show the plugin file not exists error.
 
-		$admin_url    = ( $bp_is_multisite ) ? network_admin_url() : admin_url();
-		$site_url     = ( $bp_is_multisite ) ? network_site_url() : site_url();
+		$admin_url    = admin_url();
+		$site_url     = site_url();
 		$root_path    = str_replace( $site_url, '', $admin_url );
 		$plugins_path = $root_path . 'plugins.php';
 		$ajax_path    = $root_path . 'admin-ajax.php';

--- a/src/bp-loader.php
+++ b/src/bp-loader.php
@@ -133,8 +133,10 @@ if ( empty( $is_bp_active ) && empty( $is_bb_active ) && empty( $bp_incompatible
 
 		// Do not add the "bbpress/bbpress.php" & "buddypress/bp-loader.php" on "/wp-admin/plugins.php" page otherwise it will show the plugin file not exists error.
 
-		$plugins_path = '/wp-admin/plugins.php';
-		$ajax_path    = '/wp-admin/admin-ajax.php';
+		$admin_url    = admin_url();
+		$root_path    = str_replace( site_url(), '', $admin_url );
+		$plugins_path = $root_path . 'plugins.php';
+		$ajax_path    = $root_path . 'admin-ajax.php';
 
 		// Hide My WP plugin compatibility
 		if ( class_exists( 'HideMyWP' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Fixes #ISSUE_NUMBER .

### Issue
Concern: WPS Hide Issue - Error in the plugin page is being received when the default admin URL is changed through the plugin WP Hide & Security Enhancer.

As per the user

"The problem is located at bp-loader.php file ( version 1.5.0 ) , at lines 194-195:

strpos( $_SERVER['REQUEST_URI'], $plugins_path ) !== false
strpos( $_SERVER['REQUEST_URI'], $ajax_path ) !== false

So on your side, you hard-code the urls:
$plugins_path = '/wp-admin/plugins.php';
$ajax_path = '/wp-admin/admin-ajax.php';

So when changing the default admin url from wp-admin to something else, the above comparison will fail.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
