### PR TITLE
Profile and Group Cover Image scaling

### DIFF
--- a/src/bp-core/bp-core-attachments.php
+++ b/src/bp-core/bp-core-attachments.php
@@ -1255,8 +1255,6 @@ function bp_attachments_cover_image_generate_file( $args = array(), $cover_image
 		return false;
 	}
 
-	error_log( print_r( $dimensions, 1 ) );
-
 	// Resize the image so that it fit with the cover photo dimensions.
 	$cover_image  = $cover_image_class->fit( $args['file'], $dimensions );
 	$is_too_small = false;

--- a/src/bp-core/bp-core-attachments.php
+++ b/src/bp-core/bp-core-attachments.php
@@ -1255,6 +1255,8 @@ function bp_attachments_cover_image_generate_file( $args = array(), $cover_image
 		return false;
 	}
 
+	error_log( print_r( $dimensions, 1 ) );
+
 	// Resize the image so that it fit with the cover photo dimensions.
 	$cover_image  = $cover_image_class->fit( $args['file'], $dimensions );
 	$is_too_small = false;

--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -1419,10 +1419,10 @@ add_filter( 'bp_pages', 'bp_pages_terms_and_privacy_exclude' );
  * @since BuddyBoss 1.5.1
  */
 function bp_core_get_cover_image_dimensions( $wh, $settings, $component ) {
-	if ( did_action( 'wp_ajax_bp_cover_image_upload' ) && ( 'xprofile' === $component || 'groups' === $component ) ) {
+	if ( 'xprofile' === $component || 'groups' === $component ) {
 		return array(
-			'width'  => 99999,
-			'height' => 99999,
+			'width'  => 1950,
+			'height' => 450,
 		);
 	}
 

--- a/src/bp-core/classes/class-bp-attachment-cover-image.php
+++ b/src/bp-core/classes/class-bp-attachment-cover-image.php
@@ -117,16 +117,33 @@ class BP_Attachment_Cover_Image extends BP_Attachment {
 		// Get image size.
 		$cover_data = parent::get_image_data( $file );
 
+		$image_width  = $cover_data['width'];
+		$image_height = $cover_data['height'];
+
+		$max_width = ( ! empty( $image_width ) && !empty( $image_height ) && $image_height > $dimensions['height'] ? ( $image_width * $dimensions['height'] ) / $image_height : 0 );
+		$max_height = ( ! empty( $image_width ) && !empty( $image_height ) && $image_width > $dimensions['width'] ? ( $image_height * $dimensions['width'] ) / $image_width : 0 );
+
 		// Init the edit args.
 		$edit_args = array();
 
 		// Do we need to resize the image?
-		if ( ( isset( $cover_data['width'] ) && $cover_data['width'] > $dimensions['width'] ) ||
-		( isset( $cover_data['height'] ) && $cover_data['height'] > $dimensions['height'] ) ) {
+		if (
+			isset( $cover_data['width'] )
+			&& $cover_data['width'] > $dimensions['width']
+			&& $max_height >= $dimensions['height']
+		) {
 			$edit_args = array(
 				'max_w' => $dimensions['width'],
+				'crop'  => false,
+			);
+		} else if (
+			isset( $cover_data['height'] )
+			&& $cover_data['height'] > $dimensions['height']
+			&& $max_width >= $dimensions['width']
+		) {
+			$edit_args = array(
 				'max_h' => $dimensions['height'],
-				'crop'  => true,
+				'crop'  => false,
 			);
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1536 

### How to test the changes in this Pull Request:

1. Go to profile > Cover Photo
2. Formed cover image upload as per the sizes below. 
IF image size upload is: 2700 x 900
Then cropped version will be 1950 x 650 (Proportionally)
IF image size upload is: 5000 x 900
Then cropped version will be 2500 x 450 (Proportionally)
2000x2000 will become 1950x1950
5000x200 no scaling possible
1200x1000 no scaling possible

### Proof Screenshots or Video
Original : http://prntscr.com/unnri5
Uploade: http://prntscr.com/unnrpf
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
