### PR TITLE
When Forums page is set as a child page, this breaks the Forums page in Profile > Forums tabs

### DIFF
--- a/src/bp-core/admin/bp-core-admin-components.php
+++ b/src/bp-core/admin/bp-core-admin-components.php
@@ -500,7 +500,7 @@ function bp_core_admin_components_settings_handler() {
 			$page_id = wp_insert_post( $new_page );
 
 			bp_update_option( '_bbp_root_slug_custom_slug', $page_id );
-			$slug = get_post_field( 'post_name', $page_id );
+			$slug    = get_page_uri( $page_id );
 			bp_update_option( '_bbp_root_slug', $slug );
 		}
 	}
@@ -610,7 +610,7 @@ function bp_core_admin_components_activation_handler() {
 			$page_id = wp_insert_post( $new_page );
 
 			bp_update_option( '_bbp_root_slug_custom_slug', $page_id );
-			$slug = get_post_field( 'post_name', $page_id );
+			$slug    = get_page_uri( $page_id );
 			bp_update_option( '_bbp_root_slug', $slug );
 		}
 	}

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -2511,7 +2511,7 @@ function bp_core_admin_create_background_page() {
 
 		// If forums page then change the BBPress root slug _bbp_root_slug and flush the redirect rule.
 		if ( 'new_forums_page' === $_POST['page'] ) {
-			$slug = get_post_field( 'post_name', $page_id );
+			$slug    = get_page_uri( $page_id );
 			bp_update_option( '_bbp_root_slug', $slug );
 			flush_rewrite_rules( true );
 		}
@@ -2954,7 +2954,7 @@ function bp_change_forum_slug_quickedit_save_page( $post_id, $post ) {
 	$forum_page_id = (int) bp_get_option( '_bbp_root_slug_custom_slug' );
 
 	if ( $forum_page_id > 0 && $forum_page_id === $post_id ) {
-		$slug = get_post_field( 'post_name', $post_id );
+		$slug    = get_page_uri( $post_id );
 		if ( '' !== $slug ) {
 			bp_update_option( '_bbp_root_slug', $slug );
 			bp_update_option( 'rewrite_rules', '' );

--- a/src/bp-core/admin/bp-core-admin-pages.php
+++ b/src/bp-core/admin/bp-core-admin-pages.php
@@ -404,7 +404,7 @@ function bp_core_admin_maybe_save_pages_settings() {
 			if ( isset( $_POST['bp_pages'] ) && '' === $_POST['bp_pages']['new_forums_page'] ) {
 				bp_update_option( '_bbp_root_slug_custom_slug', '' );
 			} else {
-				$slug = get_post_field( 'post_name', (int) $_POST['bp_pages']['new_forums_page'] );
+				$slug    = get_page_uri( (int) $_POST['bp_pages']['new_forums_page'] );
 				bp_update_option( '_bbp_root_slug', $slug );
 				bp_update_option( '_bbp_root_slug_custom_slug', (int) $_POST['bp_pages']['new_forums_page'] );
 			}

--- a/src/bp-core/bp-core-update.php
+++ b/src/bp-core/bp-core-update.php
@@ -887,7 +887,7 @@ function bp_add_activation_redirect() {
 				$page_id = wp_insert_post( $new_page );
 
 				bp_update_option( '_bbp_root_slug_custom_slug', $page_id );
-				$slug = get_post_field( 'post_name', $page_id );
+				$slug    = get_page_uri( $page_id );
 
 				// Set BBPress root Slug
 				bp_update_option( '_bbp_root_slug', $slug );

--- a/src/bp-forums/classes/class-bp-forums-component.php
+++ b/src/bp-forums/classes/class-bp-forums-component.php
@@ -101,7 +101,7 @@ if ( ! class_exists( 'BBP_Forums_Component' ) ) :
 			// All arguments for forums component
 			$args = array(
 				'path'          => BP_PLUGIN_DIR,
-				'slug'          => bp_get_option( '_bbp_root_slug', BP_FORUMS_SLUG ),
+				'slug'          => BP_FORUMS_SLUG,
 				'root_slug'     => isset( $bp->pages->forums->slug ) ? $bp->pages->forums->slug : BP_FORUMS_SLUG,
 				'has_directory' => false,
 				'search_string' => __( 'Search Forums&hellip;', 'buddyboss' ),

--- a/src/bp-forums/core/options.php
+++ b/src/bp-forums/core/options.php
@@ -450,18 +450,7 @@ function bbp_settings_integration( $default = 0 ) {
  * @return string
  */
 function bbp_get_root_slug( $default = 'forums' ) {
-	$forum_page_id = get_option( '_bbp_root_slug_custom_slug', 0 );
-	$root_slug     = get_option( '_bbp_root_slug', $default );
-	if ( ! empty( $forum_page_id ) ) {
-		$default_slug = $root_slug;
-		$root_slug    = get_page_uri( $forum_page_id );
-		if ( $default_slug !== $root_slug ) {
-			update_option( '_bbp_root_slug', $root_slug );
-			flush_rewrite_rules( true );
-		}
-	}
-
-	return apply_filters( 'bbp_get_root_slug', $root_slug );
+	return apply_filters( 'bbp_get_root_slug', get_option( '_bbp_root_slug', $default ) );
 }
 
 /**
@@ -507,7 +496,7 @@ function bbp_maybe_get_root_slug() {
  * @return string
  */
 function bbp_get_forum_slug( $default = 'forum' ) {;
-	return apply_filters( 'bbp_get_root_slug', bbp_maybe_get_root_slug() . get_option( '_bbp_forum_slug', $default ) );
+	return apply_filters( 'bbp_get_forum_slug', bbp_maybe_get_root_slug() . get_option( '_bbp_forum_slug', $default ) );
 }
 
 /**

--- a/src/bp-members/classes/class-bp-rest-members-details-endpoint.php
+++ b/src/bp-members/classes/class-bp-rest-members-details-endpoint.php
@@ -1065,7 +1065,7 @@ class BP_REST_Members_Details_Endpoint extends WP_REST_Users_Controller {
 
 		if ( bp_is_active( 'forums' ) ) {
 			$user_domain = bp_loggedin_user_domain();
-			$forums_link = trailingslashit( $user_domain . bp_get_option( '_bbp_root_slug', BP_FORUMS_SLUG ) );
+			$forums_link = trailingslashit( $user_domain . BP_FORUMS_SLUG );
 
 			$item_forums = array(
 				'ID'       => 'forums',

--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -292,7 +292,7 @@ class BP_Nouveau extends BP_Theme_Compat {
 		$forum_page_id = (int) bp_get_option('_bbp_root_slug_custom_slug');
 
 		if ( $forum_page_id > 0  && $forum_page_id === $post_id ) {
-			$slug = get_post_field( 'post_name', $post_id );
+			$slug    = get_page_uri( $forum_page_id );
 			if ( '' !== $slug ) {
 				bp_update_option( '_bbp_root_slug', $slug );
 				bp_update_option( 'rewrite_rules', '' );
@@ -528,7 +528,7 @@ class BP_Nouveau extends BP_Theme_Compat {
 
 		wp_enqueue_script( 'bp-nouveau' );
 		wp_enqueue_script( 'guillotine-js' );
-		
+
 
 		if ( bp_is_register_page() || bp_is_user_settings_general() ) {
 			wp_enqueue_script( 'bp-nouveau-password-verify' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### How to test the changes in this Pull Request:

Steps to reproduce the behavior:
1. Set Forums page as Child page
2. In frontend, go to Profile view
3. Click on Forums tab
4. See error

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
