### PR TITLE
Fix update activity

### DIFF
--- a/src/bp-document/bp-document-filters.php
+++ b/src/bp-document/bp-document-filters.php
@@ -273,7 +273,7 @@ function bp_document_update_activity_document_meta( $content, $user_id, $activit
 				$old_document_ids = explode( ',', $old_document_ids );
 				if ( ! empty( $old_document_ids ) ) {
 					foreach ( $old_document_ids as $document_id ) {
-						bp_document_delete( array( 'id' => $document_id ) );
+						bp_document_delete( array( 'id' => $document_id ), 'activity' );
 					}
 				}
 				bp_activity_delete_meta( $activity_id, 'bp_document_ids' );

--- a/src/bp-document/bp-document-filters.php
+++ b/src/bp-document/bp-document-filters.php
@@ -273,7 +273,7 @@ function bp_document_update_activity_document_meta( $content, $user_id, $activit
 				$old_document_ids = explode( ',', $old_document_ids );
 				if ( ! empty( $old_document_ids ) ) {
 					foreach ( $old_document_ids as $document_id ) {
-						bp_document_delete( array( 'id' => $document_id ), 'activity' );
+						bp_document_delete( array( 'id' => $document_id ) );
 					}
 				}
 				bp_activity_delete_meta( $activity_id, 'bp_document_ids' );
@@ -314,6 +314,10 @@ function bp_document_update_activity_document_meta( $content, $user_id, $activit
 			$old_document_ids = bp_activity_get_meta( $activity_id, 'bp_document_ids', true );
 			$old_document_ids = explode( ',', $old_document_ids );
 			if ( ! empty( $old_document_ids ) ) {
+
+				// This is hack to update/delete parent activity if new media added in edit.
+				bp_activity_update_meta( $activity_id, 'bp_document_ids', implode( ',', array_unique( array_merge( $document_ids, $old_document_ids ) ) ) );
+
 				foreach ( $old_document_ids as $document_id ) {
 					if ( ! in_array( $document_id, $document_ids ) ) {
 						bp_document_delete( array( 'id' => $document_id ) );
@@ -711,7 +715,7 @@ function bp_document_user_messages_delete_attached_document( $thread_id, $messag
  * @param array|object $post              Request object.
  *
  * @return bool
- * 
+ *
  * @since BuddyBoss 1.5.1
  */
 function bp_document_message_validated_content( $validated_content, $content, $post ) {

--- a/src/bp-document/classes/class-bp-document.php
+++ b/src/bp-document/classes/class-bp-document.php
@@ -1741,7 +1741,7 @@ class BP_Document {
 
 					// Deleting an activity.
 					} else {
-						if ( bp_activity_delete( array(
+						if ( 'activity' !== $from && bp_activity_delete( array(
 								'id'      => $activity->id,
 								'user_id' => $activity->user_id,
 							) ) ) {

--- a/src/bp-document/classes/class-bp-document.php
+++ b/src/bp-document/classes/class-bp-document.php
@@ -1715,7 +1715,7 @@ class BP_Document {
 					}
 				}
 
-				if ( empty( $from ) || 'activity' === $from ) {
+				if ( empty( $from ) ) {
 					wp_delete_attachment( $attachment_id, true );
 				}
 			}
@@ -1741,15 +1741,12 @@ class BP_Document {
 
 					// Deleting an activity.
 					} else {
-						// Do not delete the activity if action did via edit.
-						if ( bp_is_active( 'activity' ) && 'activity' !== $from ) {
-							if ( bp_activity_delete( array(
-									'id'      => $activity->id,
-									'user_id' => $activity->user_id,
-								) ) ) {
-								/** This action is documented in bp-activity/bp-activity-actions.php */
-								do_action( 'bp_activity_action_delete_activity', $activity->id, $activity->user_id );
-							}
+						if ( bp_activity_delete( array(
+								'id'      => $activity->id,
+								'user_id' => $activity->user_id,
+							) ) ) {
+							/** This action is documented in bp-activity/bp-activity-actions.php */
+							do_action( 'bp_activity_action_delete_activity', $activity->id, $activity->user_id );
 						}
 					}
 				}

--- a/src/bp-media/bp-media-filters.php
+++ b/src/bp-media/bp-media-filters.php
@@ -322,7 +322,7 @@ function bp_media_update_activity_media_meta( $content, $user_id, $activity_id )
 				$old_media_ids = explode( ',', $old_media_ids );
 				if ( ! empty( $old_media_ids ) ) {
 					foreach ( $old_media_ids as $media_id ) {
-						bp_media_delete( array( 'id' => $media_id ) );
+						bp_media_delete( array( 'id' => $media_id ), 'activity' );
 					}
 				}
 				bp_activity_delete_meta( $activity_id, 'bp_media_ids' );

--- a/src/bp-media/bp-media-filters.php
+++ b/src/bp-media/bp-media-filters.php
@@ -322,7 +322,7 @@ function bp_media_update_activity_media_meta( $content, $user_id, $activity_id )
 				$old_media_ids = explode( ',', $old_media_ids );
 				if ( ! empty( $old_media_ids ) ) {
 					foreach ( $old_media_ids as $media_id ) {
-						bp_media_delete( array( 'id' => $media_id ), 'activity' );
+						bp_media_delete( array( 'id' => $media_id ) );
 					}
 				}
 				bp_activity_delete_meta( $activity_id, 'bp_media_ids' );
@@ -358,11 +358,17 @@ function bp_media_update_activity_media_meta( $content, $user_id, $activity_id )
 
     //save media meta for activity.
     if ( ! empty( $activity_id ) ) {
+
     	// Delete media if not exists in current media ids
     	if ( isset( $_POST['edit'] ) ) {
 		    $old_media_ids = bp_activity_get_meta( $activity_id, 'bp_media_ids', true );
 		    $old_media_ids = explode( ',', $old_media_ids );
+
 		    if ( ! empty( $old_media_ids ) ) {
+
+		    	// This is hack to update/delete parent activity if new media added in edit.
+				bp_activity_update_meta( $activity_id, 'bp_media_ids', implode( ',', array_unique( array_merge( $media_ids, $old_media_ids ) ) ) );
+
 		    	foreach ( $old_media_ids as $media_id ) {
 
 		    		if ( ! in_array( $media_id, $media_ids ) ) {
@@ -371,7 +377,9 @@ function bp_media_update_activity_media_meta( $content, $user_id, $activity_id )
 			    }
 		    }
 	    }
-        bp_activity_update_meta( $activity_id, 'bp_media_ids', implode( ',', $media_ids ) );
+
+    	// update new media ids here in the activity meta.
+		bp_activity_update_meta( $activity_id, 'bp_media_ids', implode( ',', $media_ids ) );
     }
 }
 
@@ -917,7 +925,7 @@ function bp_media_messages_save_gif_data( &$message ) {
  * @param array|object $post              Request object.
  *
  * @return bool
- * 
+ *
  * @since BuddyBoss 1.5.1
  */
 function bp_media_message_validated_content( $validated_content, $content, $post ) {
@@ -936,7 +944,7 @@ function bp_media_message_validated_content( $validated_content, $content, $post
  * @param array|object $post              Request object.
  *
  * @return bool
- * 
+ *
  * @since BuddyBoss 1.5.1
  */
 function bp_media_gif_message_validated_content( $validated_content, $content, $post ) {

--- a/src/bp-media/classes/class-bp-media.php
+++ b/src/bp-media/classes/class-bp-media.php
@@ -1007,7 +1007,7 @@ class BP_Media {
 					}
 				}
 
-				if ( empty( $from ) || 'activity' === $from ) {
+				if ( empty( $from ) ) {
 					wp_delete_attachment( $attachment_id, true );
 				}
 			}
@@ -1033,15 +1033,12 @@ class BP_Media {
 
 					// Deleting an activity.
 					} else {
-						// Do not delete the activity if action did via edit.
-						if ( bp_is_active( 'activity' ) && 'activity' !== $from ) {
-							if ( bp_activity_delete( array(
-									'id'      => $activity->id,
-									'user_id' => $activity->user_id,
-								) ) ) {
-								/** This action is documented in bp-activity/bp-activity-actions.php */
-								do_action( 'bp_activity_action_delete_activity', $activity->id, $activity->user_id );
-							}
+						if ( bp_activity_delete( array(
+								'id'      => $activity->id,
+								'user_id' => $activity->user_id,
+							) ) ) {
+							/** This action is documented in bp-activity/bp-activity-actions.php */
+							do_action( 'bp_activity_action_delete_activity', $activity->id, $activity->user_id );
 						}
 					}
 				}

--- a/src/bp-media/classes/class-bp-media.php
+++ b/src/bp-media/classes/class-bp-media.php
@@ -1033,7 +1033,7 @@ class BP_Media {
 
 					// Deleting an activity.
 					} else {
-						if ( bp_activity_delete( array(
+						if ( 'activity' !== $from && bp_activity_delete( array(
 								'id'      => $activity->id,
 								'user_id' => $activity->user_id,
 							) ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

when deleting all media or document in activity, adding only 1 media or document and then update activity, deletes the activity. now it will not delete the activity and keeps it with 1 media or document. fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
