### PR TITLE
Profile Fieldset tabs are being cached

### DIFF
--- a/src/bp-xprofile/bp-xprofile-cache.php
+++ b/src/bp-xprofile/bp-xprofile-cache.php
@@ -288,8 +288,3 @@ add_action( 'xprofile_field_before_save', 'bp_xprofile_reset_fields_by_name_cach
 
 // List actions to clear super cached pages on, if super cache is installed.
 add_action( 'xprofile_updated_profile', 'bp_core_clear_cache' );
-
-function testtttttttt() {
-	wp_cache_delete( 'all', 'bp_xprofile_groups' );
-}
-add_action( 'xprofile_updated_profile', 'testtttttttt' );

--- a/src/bp-xprofile/bp-xprofile-cache.php
+++ b/src/bp-xprofile/bp-xprofile-cache.php
@@ -288,3 +288,8 @@ add_action( 'xprofile_field_before_save', 'bp_xprofile_reset_fields_by_name_cach
 
 // List actions to clear super cached pages on, if super cache is installed.
 add_action( 'xprofile_updated_profile', 'bp_core_clear_cache' );
+
+function testtttttttt() {
+	wp_cache_delete( 'all', 'bp_xprofile_groups' );
+}
+add_action( 'xprofile_updated_profile', 'testtttttttt' );

--- a/src/bp-xprofile/bp-xprofile-template.php
+++ b/src/bp-xprofile/bp-xprofile-template.php
@@ -175,7 +175,7 @@ function bp_get_field_css_class( $class = false ) {
 	// Add the field visibility level.
 	$css_classes[] = 'visibility-' . esc_attr( bp_get_the_profile_field_visibility_level() );
 
-	if ( $profile_template->current_field % 2 == 1 ) {
+	if ( 1 === $profile_template->current_field % 2 ) {
 		$css_classes[] = 'alt';
 	}
 
@@ -1056,11 +1056,28 @@ function bp_get_profile_field_data( $args = '' ) {
  * @return array $groups
  */
 function bp_profile_get_field_groups() {
+	$cache_key = 'all';
 
-	$groups = wp_cache_get( 'all', 'bp_xprofile_groups' );
+	// Get user id.
+	$user_id = bp_displayed_user_id() ? bp_displayed_user_id() : bp_loggedin_user_id();
+
+	// Get all member types for user.
+	$member_types = bp_get_member_type( $user_id, false );
+	if ( ! empty( $member_types ) ) {
+
+		// Prepare cache key for multiple member types.
+		if ( is_array( $member_types ) ) {
+			$member_types = md5( implode( '', $member_types ) );
+		}
+
+		// Cache key for member types.
+		$cache_key = $member_types;
+	}
+
+	$groups = wp_cache_get( $cache_key, 'bp_xprofile_groups' );
 	if ( false === $groups ) {
 		$groups = bp_xprofile_get_groups( array( 'fetch_fields' => true ) );
-		wp_cache_set( 'all', $groups, 'bp_xprofile_groups' );
+		wp_cache_set( $cache_key, $groups, 'bp_xprofile_groups' );
 	}
 
 	/**
@@ -1495,10 +1512,7 @@ function bp_profile_get_settings_visibility_select( $args = '' ) {
 				<?php echo $r['before_controls']; ?>
 
 				<label for="<?php echo esc_attr( 'field_' . $r['field_id'] ); ?>_visibility" class="<?php echo esc_attr( $r['label_class'] ); ?>">
-					<?php
-					 /* translators: accessibility text */
-					 _e( 'Select visibility', 'buddyboss' );
-					 ?>
+					<?php _e( 'Select visibility', 'buddyboss' ); /* translators: accessibility text */ ?>
 				</label>
 				<select class="<?php echo esc_attr( $r['class'] ); ?>" name="<?php echo esc_attr( 'field_' . $r['field_id'] ); ?>_visibility" id="<?php echo esc_attr( 'field_' . $r['field_id'] ); ?>_visibility">
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1595 

### How to test the changes in this Pull Request:

1. Enable object caching.
2. Create some profile types and assign them to different users.
3. Create multiple fieldsets with different availability for each profile type.
4. Try to log in using different users with different profile types.
5. See the results.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->