### PR TITLE
adds action for 'This is not a BuddyPress page, so just return.'

### DIFF
--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -271,6 +271,7 @@ function bp_core_set_uri_globals() {
 
 	// This is not a BuddyPress page, so just return.
 	if ( empty( $matches ) ) {
+		do_action( 'bp_not_a_page' );
 		return false;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:
adds an action hook that fires when it is determined that "This is not a BuddyPress page"

Fixes #1617 

### How to test the changes in this Pull Request:

It's just a hook; no behavior is changed.


### Changelog entry

Adds an action hook 'bp_not_a_page' that fires when BP determines that it is not on a BP page.
