### PR TITLE
Notification dropdown should basically show unread notifications ever…

### DIFF
--- a/src/bp-notifications/bp-notifications-template.php
+++ b/src/bp-notifications/bp-notifications-template.php
@@ -185,10 +185,11 @@ function bp_get_notifications_read_permalink( $user_id = 0 ) {
  */
 function bp_has_notifications( $args = '' ) {
 
+	$notification_read_flag = bp_parse_args( $args );
 	// Get the default is_new argument.
-	if ( bp_is_current_action( 'unread' ) ) {
+	if ( bp_is_current_action( 'unread' ) || isset( $notification_read_flag[ 'unread' ] ) ) {
 		$is_new = 1;
-	} elseif ( bp_is_current_action( 'read' ) ) {
+	} elseif ( bp_is_current_action( 'read' ) || isset( $notification_read_flag[ 'read' ] ) ) {
 		$is_new = 0;
 
 		// Not on a notifications page? default to fetch new notifications.


### PR DESCRIPTION
…ywhere

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/buddyboss/buddyboss-theme/issues/1096

### How to test the changes in this Pull Request:
  

1. Go to any notification read page
2. Click on notification drop down
3. It is showing read notification in drop down
4. It should show unread notification on drop down everywhere


### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
