### PR TITLE
No 'Read more' for blog posts activity on Activity feed. 

### DIFF
--- a/src/bp-activity/bp-activity-filters.php
+++ b/src/bp-activity/bp-activity-filters.php
@@ -534,7 +534,7 @@ function bp_activity_make_nofollow_filter_callback( $matches ) {
  * @param array  $args {
  *     Optional parameters. See $options argument of {@link bp_create_excerpt()}
  *     for all available parameters.
- * }
+ * }.
  * @return string $excerpt The truncated text.
  */
 function bp_activity_truncate_entry( $text, $args = array() ) {
@@ -578,8 +578,10 @@ function bp_activity_truncate_entry( $text, $args = array() ) {
 	 * been truncated), add the "Read More" link. Note that bp_create_excerpt() is stripping
 	 * shortcodes, so we have strip them from the $text before the comparison.
 	 */
-	if ( 'new_blog_post' === $activities_template->activity->type ) {
-		$excerpt = sprintf( '%1$s<span class="activity-blog-post-link"><a href="%2$s" rel="nofollow">%3$s</a></span>', $excerpt, get_the_permalink( $activities_template->activity->secondary_item_id ), $append_text );
+	if ( in_array( $activities_template->activity->type, array( 'new_blog_post', 'new_blog_comment' ), true ) ) {
+		$excerpt_link = 'new_blog_post' === $activities_template->activity->type ? get_the_permalink( $activities_template->activity->secondary_item_id ) : bp_get_activity_thread_permalink();
+
+		$excerpt = sprintf( '%1$s<span class="activity-blog-post-link"><a href="%2$s" rel="nofollow">%3$s</a></span>', $excerpt, $excerpt_link, $append_text );
 	} elseif ( strlen( $excerpt ) <= strlen( strip_shortcodes( $text ) ) && false !== strrpos( $excerpt, __( '&hellip;', 'buddyboss' ) ) ) {
 		$id = ! empty( $activities_template->activity->current_comment->id ) ? 'acomment-read-more-' . $activities_template->activity->current_comment->id : 'activity-read-more-' . bp_get_activity_id();
 

--- a/src/bp-activity/bp-activity-filters.php
+++ b/src/bp-activity/bp-activity-filters.php
@@ -110,7 +110,7 @@ add_filter( 'bp_get_total_favorite_count_for_user', 'bp_core_number_format' );
 add_filter( 'bp_get_total_mention_count_for_user', 'bp_core_number_format' );
 
 add_filter( 'bp_activity_get_embed_excerpt', 'bp_activity_embed_excerpt_onclick_location_filter', 9 );
-//add_filter( 'bp_after_has_activities_parse_args', 'bp_activity_display_all_types_on_just_me' );
+// add_filter( 'bp_after_has_activities_parse_args', 'bp_activity_display_all_types_on_just_me' );
 
 add_filter( 'bp_get_activity_content_body', 'bp_activity_link_preview', 20, 2 );
 add_action( 'bp_has_activities', 'bp_activity_has_activity_filter', 10, 2 );
@@ -290,7 +290,7 @@ function bp_activity_update_comment_privacy( $activity ) {
 		)
 	);
 
-	if ( ! empty( $activity_comments ) && !empty( $activity_comments['activities'] ) && isset( $activity_comments['activities'][0]->children )) {
+	if ( ! empty( $activity_comments ) && ! empty( $activity_comments['activities'] ) && isset( $activity_comments['activities'][0]->children ) ) {
 		$children = $activity_comments['activities'][0]->children;
 		if ( ! empty( $children ) ) {
 			foreach ( $children as $comment ) {
@@ -306,14 +306,14 @@ function bp_activity_update_comment_privacy( $activity ) {
  * @since BuddyBoss 1.4.0
  *
  * @param BP_Activity_Activity $comment Activity comment object
- * @param string $privacy Parent Activity privacy
+ * @param string               $privacy Parent Activity privacy
  */
 function bp_activity_comment_privacy_update( $comment, $privacy ) {
-	$comment_activity = new BP_Activity_Activity( $comment->id );
+	$comment_activity          = new BP_Activity_Activity( $comment->id );
 	$comment_activity->privacy = $privacy;
 	$comment_activity->save();
 
-	if ( !empty( $comment->children ) ) {
+	if ( ! empty( $comment->children ) ) {
 		foreach ( $comment->children as $child_comment ) {
 			bp_activity_comment_privacy_update( $child_comment, $privacy );
 		}
@@ -549,7 +549,7 @@ function bp_activity_truncate_entry( $text, $args = array() ) {
 	 */
 	$maybe_truncate_text = apply_filters(
 		'bp_activity_maybe_truncate_entry',
-		isset( $activities_template->activity->type ) && ! in_array( $activities_template->activity->type, array( 'new_blog_post' ), true )
+		isset( $activities_template->activity->type ) && ! in_array( $activities_template->activity->type, array(), true )
 	);
 
 	// The full text of the activity update should always show on the single activity screen.
@@ -578,7 +578,9 @@ function bp_activity_truncate_entry( $text, $args = array() ) {
 	 * been truncated), add the "Read More" link. Note that bp_create_excerpt() is stripping
 	 * shortcodes, so we have strip them from the $text before the comparison.
 	 */
-	if ( strlen( $excerpt ) <= strlen( strip_shortcodes( $text ) ) && false !== strrpos( $excerpt, __( '&hellip;', 'buddyboss' ) ) ) {
+	if ( 'new_blog_post' === $activities_template->activity->type ) {
+		$excerpt = sprintf( '%1$s<span class="activity-blog-post-link"><a href="%2$s" rel="nofollow">%3$s</a></span>', $excerpt, get_the_permalink( $activities_template->activity->secondary_item_id ), $append_text );
+	} elseif ( strlen( $excerpt ) <= strlen( strip_shortcodes( $text ) ) && false !== strrpos( $excerpt, __( '&hellip;', 'buddyboss' ) ) ) {
 		$id = ! empty( $activities_template->activity->current_comment->id ) ? 'acomment-read-more-' . $activities_template->activity->current_comment->id : 'activity-read-more-' . bp_get_activity_id();
 
 		$excerpt = sprintf( '%1$s<span class="activity-read-more" id="%2$s"><a href="%3$s" rel="nofollow">%4$s</a></span>', $excerpt, $id, bp_get_activity_thread_permalink(), $append_text );
@@ -637,10 +639,10 @@ function bp_activity_link_preview( $content, $activity ) {
 		$content  .= '<div class="activity-link-preview-image">';
 		$content  .= '<a href="' . esc_url( $preview_data['url'] ) . '" target="_blank"><img src="' . esc_url( $image_url ) . '" /></a>';
 		$content  .= '</div>';
-	} else if ( ! empty( $preview_data['image_url'] ) ) {
-		$content  .= '<div class="activity-link-preview-image">';
-		$content  .= '<a href="' . esc_url( $preview_data['url'] ) . '" target="_blank"><img src="' . esc_url( $preview_data['image_url'] ) . '" /></a>';
-		$content  .= '</div>';
+	} elseif ( ! empty( $preview_data['image_url'] ) ) {
+		$content .= '<div class="activity-link-preview-image">';
+		$content .= '<a href="' . esc_url( $preview_data['url'] ) . '" target="_blank"><img src="' . esc_url( $preview_data['image_url'] ) . '" /></a>';
+		$content .= '</div>';
 	}
 	$content .= '<div class="activity-link-preview-excerpt"><p>' . $description . '</p></div>';
 	$content .= '</div>';
@@ -715,7 +717,7 @@ function bp_activity_display_all_types_on_just_me( $args ) {
 	}
 
 	if ( bp_is_user() && 'all' === $args['scope'] && empty( bp_current_action() ) ) {
-		$scope = array( 'just-me' );
+		$scope         = array( 'just-me' );
 		$args['scope'] = implode( ',', $scope );
 		return $args;
 	}
@@ -960,9 +962,9 @@ function bp_activity_filter_just_me_scope( $retval = array(), $filter = array() 
 
 		// Overrides.
 		'override' => array(
-			//'display_comments' => bp_show_streamed_activity_comment() ? 'stream' : 'threaded',
-			'filter'           => array( 'user_id' => 0 ),
-			'show_hidden'      => true,
+			// 'display_comments' => bp_show_streamed_activity_comment() ? 'stream' : 'threaded',
+			'filter'      => array( 'user_id' => 0 ),
+			'show_hidden' => true,
 		),
 	);
 
@@ -996,7 +998,7 @@ function bp_activity_filter_public_scope( $retval = array(), $filter = array() )
 		array(
 			'column' => 'hide_sitewide',
 			'value'  => 0,
-		)
+		),
 	);
 
 	return $retval;
@@ -1038,10 +1040,9 @@ function bp_activity_filter_favorites_scope( $retval = array(), $filter = array(
 		);
 	}
 
-
 	$friends_filter = array();
-	$onlyme_filter = array();
-	$privacy = array( 'public' );
+	$onlyme_filter  = array();
+	$privacy        = array( 'public' );
 	if ( is_user_logged_in() ) {
 		$privacy[] = 'loggedin';
 
@@ -1054,7 +1055,7 @@ function bp_activity_filter_favorites_scope( $retval = array(), $filter = array(
 
 			if ( $user_id === bp_loggedin_user_id() ) {
 				$friends[] = bp_loggedin_user_id();
-				$friends = array_unique( $friends );
+				$friends   = array_unique( $friends );
 			}
 
 			if ( ! empty( $friends ) ) {
@@ -1075,7 +1076,7 @@ function bp_activity_filter_favorites_scope( $retval = array(), $filter = array(
 						'compare' => 'IN',
 						'value'   => (array) $favs,
 					),
-					$show_hidden
+					$show_hidden,
 				);
 			}
 		}
@@ -1098,9 +1099,9 @@ function bp_activity_filter_favorites_scope( $retval = array(), $filter = array(
 					'compare' => 'IN',
 					'value'   => (array) $favs,
 				),
-				$show_hidden
+				$show_hidden,
 			);
-			$privacy[] = 'loggedin';
+			$privacy[]     = 'loggedin';
 		}
 	}
 
@@ -1114,7 +1115,7 @@ function bp_activity_filter_favorites_scope( $retval = array(), $filter = array(
 		array(
 			'column'  => 'privacy',
 			'compare' => 'IN',
-			'value'   => $privacy
+			'value'   => $privacy,
 		),
 		$show_hidden,
 	);
@@ -1134,8 +1135,8 @@ function bp_activity_filter_favorites_scope( $retval = array(), $filter = array(
 			$onlyme_filter,
 			// Overrides.
 			'override' => array(
-				'filter'           => array( 'user_id' => 0 ),
-				'show_hidden'      => true,
+				'filter'      => array( 'user_id' => 0 ),
+				'show_hidden' => true,
 			),
 		);
 	}
@@ -1170,10 +1171,10 @@ function bp_activity_filter_mentions_scope( $retval = array(), $filter = array()
 			: bp_loggedin_user_id();
 	}
 
-	$privacy = array( 'public' );
-	$friends = array();
+	$privacy     = array( 'public' );
+	$friends     = array();
 	$show_hidden = array();
-	$user_groups  = array();
+	$user_groups = array();
 
 	if ( is_user_logged_in() ) {
 		$privacy[] = 'loggedin';
@@ -1287,11 +1288,11 @@ function bp_activity_filter_mentions_scope( $retval = array(), $filter = array()
 		),
 		// Overrides.
 		'override' => array(
-			//'display_comments' => bp_show_streamed_activity_comment() ? 'stream' : 'threaded',
-			'filter'           => array( 'user_id' => 0 ),
-			'show_hidden'      => true,
+			// 'display_comments' => bp_show_streamed_activity_comment() ? 'stream' : 'threaded',
+			'filter'      => array( 'user_id' => 0 ),
+			'show_hidden' => true,
 		),
-		$privacy_scope
+		$privacy_scope,
 	);
 
 	return $retval;
@@ -1612,7 +1613,6 @@ function bp_activity_has_media_activity_filter( $has_activities, $activities ) {
 
 						unset( $activities->activities[ $key ] );
 					}
-
 				}
 			}
 		}
@@ -1650,14 +1650,14 @@ function bp_activity_media_add( $media ) {
 					$comment_activity = new BP_Activity_Activity( $comment->item_id );
 					if ( ! empty( $comment_activity->component ) && buddypress()->groups->id === $comment_activity->component ) {
 						$media->group_id = $comment_activity->item_id;
-						$media->privacy = 'grouponly';
+						$media->privacy  = 'grouponly';
 					}
 				}
 			}
 
 			$args = array(
-				'hide_sitewide'     => true,
-				'privacy'           => 'media'
+				'hide_sitewide' => true,
+				'privacy'       => 'media',
 			);
 
 			// Create activity only if not created previously.
@@ -1673,7 +1673,7 @@ function bp_activity_media_add( $media ) {
 
 			if ( $activity_id ) {
 
-				//save media activity id in media
+				// save media activity id in media
 				$media->activity_id = $activity_id;
 				$media->save();
 
@@ -1685,22 +1685,22 @@ function bp_activity_media_add( $media ) {
 
 				if ( $parent_activity_id ) {
 
-					$media_activity = new BP_Activity_Activity( $activity_id );
+					$media_activity                    = new BP_Activity_Activity( $activity_id );
 					$media_activity->secondary_item_id = $parent_activity_id;
 					$media_activity->save();
 
-					//save parent activity id in attachment meta
+					// save parent activity id in attachment meta
 					update_post_meta( $media->attachment_id, 'bp_media_parent_activity_id', $parent_activity_id );
 				}
 			}
 		} else {
 			if ( $parent_activity_id ) {
 
-				//save media activity id in media
+				// save media activity id in media
 				$media->activity_id = $parent_activity_id;
 				$media->save();
 
-				//save parent activity id in attachment meta
+				// save parent activity id in attachment meta
 				update_post_meta( $media->attachment_id, 'bp_media_parent_activity_id', $parent_activity_id );
 			}
 		}
@@ -1732,7 +1732,6 @@ function bp_activity_create_parent_media_activity( $media_ids ) {
 			 * @param string $value Activity message being posted.
 			 *
 			 * @since BuddyPress 1.2.0
-			 *
 			 */
 			$content = apply_filters( 'bp_activity_post_update_content', $bp_media_upload_activity_content );
 		}
@@ -1741,12 +1740,17 @@ function bp_activity_create_parent_media_activity( $media_ids ) {
 		$album_id = false;
 
 		if ( bp_is_active( 'groups' ) && ! empty( $group_id ) && $group_id > 0 ) {
-			$activity_id = groups_post_update( array( 'content' => $content, 'group_id' => $group_id ) );
+			$activity_id = groups_post_update(
+				array(
+					'content'  => $content,
+					'group_id' => $group_id,
+				)
+			);
 		} else {
 			$activity_id = bp_activity_post_update( array( 'content' => $content ) );
 		}
 
-		//save media meta for activity
+		// save media meta for activity
 		if ( ! empty( $activity_id ) ) {
 			$privacy = 'public';
 
@@ -1762,12 +1766,12 @@ function bp_activity_create_parent_media_activity( $media_ids ) {
 				}
 
 				if ( 1 === $bp_media_upload_count ) {
-					//save media activity id in media
+					// save media activity id in media
 					$media->activity_id = $activity_id;
 					$media->save();
 				}
 
-				//save parent activity id in attachment meta
+				// save parent activity id in attachment meta
 				update_post_meta( $media->attachment_id, 'bp_media_parent_activity_id', $activity_id );
 			}
 
@@ -1798,7 +1802,6 @@ function bp_activity_create_parent_media_activity( $media_ids ) {
  *
  * @return mixed
  * @since BuddyBoss 1.5.0
- *
  */
 function bp_activity_edit_update_media( $media_ids ) {
 	global $bp_activity_edit, $bp_activity_post_update_id;
@@ -1820,7 +1823,7 @@ function bp_activity_edit_update_media( $media_ids ) {
 					$old_media = new BP_Media( $old_media_id );
 					$args      = array(
 						'hide_sitewide' => true,
-						'privacy'       => 'media'
+						'privacy'       => 'media',
 					);
 
 					if ( ! empty( $old_media->group_id ) && bp_is_active( 'groups' ) ) {
@@ -1849,13 +1852,13 @@ function bp_activity_edit_update_media( $media_ids ) {
 						// save attachment meta for activity.
 						update_post_meta( $old_media->attachment_id, 'bp_media_activity_id', $activity_id );
 
-						//save parent activity id in attachment meta.
+						// save parent activity id in attachment meta.
 						update_post_meta( $old_media->attachment_id, 'bp_media_parent_activity_id', $bp_activity_post_update_id );
 					}
 				}
 
 				// old media count is greater than 1 and new media uploaded count is only 1 now.
-			} else if ( 1 < count( $old_media_ids ) && 1 === count( $media_ids ) ) {
+			} elseif ( 1 < count( $old_media_ids ) && 1 === count( $media_ids ) ) {
 				$new_media_id = $media_ids[0];
 
 				// check if new media is in old media uploaded, if yes then delete that media's media activity first.
@@ -1868,16 +1871,16 @@ function bp_activity_edit_update_media( $media_ids ) {
 					bp_activity_delete( array( 'id' => $media_activity_id ) );
 					add_action( 'bp_activity_after_delete', 'bp_media_delete_activity_media' );
 
-					//save parent activity id in media.
+					// save parent activity id in media.
 					$new_media->activity_id = $bp_activity_post_update_id;
 					$new_media->save();
 
-					//save parent activity id in attachment meta.
+					// save parent activity id in attachment meta.
 					update_post_meta( $new_media->attachment_id, 'bp_media_parent_activity_id', $bp_activity_post_update_id );
 				}
 
 				// old media and new media count is same and old media and new media are different.
-			} else if ( 1 === count( $old_media_ids ) && 1 === count( $media_ids ) ) {
+			} elseif ( 1 === count( $old_media_ids ) && 1 === count( $media_ids ) ) {
 				$new_media_id = $media_ids[0];
 
 				// check if new media is not in old media uploaded and.
@@ -1931,7 +1934,6 @@ function bp_activity_new_at_mention_permalink( $link, $item_id, $secondary_item_
 			$id   = current( $notification )->id;
 			$link = add_query_arg( 'crid', (int) $id, bp_activity_get_permalink( $activity_obj->id ) );
 		}
-
 	}
 
 	return $link;
@@ -1962,7 +1964,7 @@ function bp_activity_document_add( $document ) {
 					$comment_activity = new BP_Activity_Activity( $comment->item_id );
 					if ( ! empty( $comment_activity->component ) && buddypress()->groups->id === $comment_activity->component ) {
 						$document->group_id = $comment_activity->item_id;
-						$document->privacy = 'grouponly';
+						$document->privacy  = 'grouponly';
 					}
 				}
 			}
@@ -1997,7 +1999,7 @@ function bp_activity_document_add( $document ) {
 
 				if ( ! empty( $parent_activity_id ) ) {
 
-					$document_activity = new BP_Activity_Activity( $activity_id );
+					$document_activity                    = new BP_Activity_Activity( $activity_id );
 					$document_activity->secondary_item_id = $parent_activity_id;
 					$document_activity->save();
 
@@ -2008,11 +2010,11 @@ function bp_activity_document_add( $document ) {
 		} else {
 			if ( $parent_activity_id ) {
 
-				//save document activity id
+				// save document activity id
 				$document->activity_id = $parent_activity_id;
 				$document->save();
 
-				//save parent activity id in attachment meta
+				// save parent activity id in attachment meta
 				update_post_meta( $document->attachment_id, 'bp_document_parent_activity_id', $parent_activity_id );
 			}
 		}
@@ -2026,7 +2028,6 @@ function bp_activity_document_add( $document ) {
  *
  * @return mixed
  * @since BuddyBoss 1.2.0
- *
  */
 function bp_activity_create_parent_document_activity( $document_ids ) {
 	global $bp_document_upload_count, $bp_activity_post_update, $bp_document_upload_activity_content, $bp_activity_post_update_id, $bp_activity_edit;
@@ -2044,7 +2045,6 @@ function bp_activity_create_parent_document_activity( $document_ids ) {
 			 * @param string $value Activity message being posted.
 			 *
 			 * @since BuddyPress 1.2.0
-			 *
 			 */
 			$content = apply_filters( 'bp_activity_post_update_content', $bp_document_upload_activity_content );
 		}
@@ -2053,12 +2053,17 @@ function bp_activity_create_parent_document_activity( $document_ids ) {
 		$folder_id = false;
 
 		if ( bp_is_active( 'groups' ) && ! empty( $group_id ) && $group_id > 0 ) {
-			$activity_id = groups_post_update( array( 'content' => $content, 'group_id' => $group_id ) );
+			$activity_id = groups_post_update(
+				array(
+					'content'  => $content,
+					'group_id' => $group_id,
+				)
+			);
 		} else {
 			$activity_id = bp_activity_post_update( array( 'content' => $content ) );
 		}
 
-		//save document meta for activity.
+		// save document meta for activity.
 		if ( ! empty( $activity_id ) ) {
 			$privacy = 'public';
 
@@ -2074,13 +2079,13 @@ function bp_activity_create_parent_document_activity( $document_ids ) {
 				}
 
 				if ( 1 === $bp_document_upload_count ) {
-					//save media activity id in media
-					$document->activity_id  = $activity_id;
-					$document->group_id     = $group_id;
+					// save media activity id in media
+					$document->activity_id = $activity_id;
+					$document->group_id    = $group_id;
 					$document->save();
 				}
 
-				//save parent activity id in attachment meta.
+				// save parent activity id in attachment meta.
 				update_post_meta( $document->attachment_id, 'bp_document_parent_activity_id', $activity_id );
 			}
 
@@ -2111,7 +2116,6 @@ function bp_activity_create_parent_document_activity( $document_ids ) {
  *
  * @return mixed
  * @since BuddyBoss 1.5.0
- *
  */
 function bp_activity_edit_update_document( $document_ids ) {
 	global $bp_activity_edit, $bp_activity_post_update_id;
@@ -2133,7 +2137,7 @@ function bp_activity_edit_update_document( $document_ids ) {
 					$old_document = new BP_Document( $old_document_id );
 					$args         = array(
 						'hide_sitewide' => true,
-						'privacy'       => 'document'
+						'privacy'       => 'document',
 					);
 
 					if ( ! empty( $old_document->group_id ) && bp_is_active( 'groups' ) ) {
@@ -2162,13 +2166,13 @@ function bp_activity_edit_update_document( $document_ids ) {
 						// save attachment meta for activity.
 						update_post_meta( $old_document->attachment_id, 'bp_document_activity_id', $activity_id );
 
-						//save parent activity id in attachment meta.
+						// save parent activity id in attachment meta.
 						update_post_meta( $old_document->attachment_id, 'bp_document_parent_activity_id', $bp_activity_post_update_id );
 					}
 				}
 
 				// old document count is greater than 1 and new document uploaded count is only 1 now.
-			} else if ( 1 < count( $old_document_ids ) && 1 === count( $document_ids ) ) {
+			} elseif ( 1 < count( $old_document_ids ) && 1 === count( $document_ids ) ) {
 				$new_document_id = $document_ids[0];
 
 				// check if new document is in old document uploaded, if yes then delete that document's document activity first.
@@ -2181,16 +2185,16 @@ function bp_activity_edit_update_document( $document_ids ) {
 					bp_activity_delete( array( 'id' => $document_activity_id ) );
 					add_action( 'bp_activity_after_delete', 'bp_document_delete_activity_document' );
 
-					//save parent activity id in document.
+					// save parent activity id in document.
 					$new_document->activity_id = $bp_activity_post_update_id;
 					$new_document->save();
 
-					//save parent activity id in attachment meta.
+					// save parent activity id in attachment meta.
 					update_post_meta( $new_document->attachment_id, 'bp_document_parent_activity_id', $bp_activity_post_update_id );
 				}
 
 				// old document and new document count is same and old document and new document are different.
-			} else if ( 1 === count( $old_document_ids ) && 1 === count( $document_ids ) ) {
+			} elseif ( 1 === count( $old_document_ids ) && 1 === count( $document_ids ) ) {
 				$new_document_id = $document_ids[0];
 
 				// check if new document is not in old document uploaded and.
@@ -2232,7 +2236,6 @@ function bp_nouveau_remove_edit_activity_entry_buttons( $buttons, $activity_id )
 		if ( in_array( $activity->privacy, array( 'document', 'media' ), 1 ) ) {
 			unset( $buttons['activity_edit'] );
 		}
-
 	}
 
 	return $buttons;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

Fixes #1524 #1420 

### How to test the changes in this Pull Request:

1. Enable the 'Blog Posts' for Activity feed.
2. Publish a new post.
3. Go to activity feed.
4. See error

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
