### PR TITLE
1299 - Fixed the notification date

### DIFF
--- a/src/bp-forums/notifications.php
+++ b/src/bp-forums/notifications.php
@@ -201,7 +201,7 @@ function bbp_buddypress_add_notification( $reply_id = 0, $topic_id = 0, $forum_i
 		'item_id'          => $reply_id,
 		'component_name'   => bbp_get_component_name(),
 		'component_action' => 'bbp_new_reply',
-		'date_notified'    => get_post( $reply_id )->post_date,
+		'date_notified'    => bp_core_current_time(),
 	);
 
 	// Notify the topic author if not the current reply author

--- a/src/bp-forums/notifications.php
+++ b/src/bp-forums/notifications.php
@@ -203,7 +203,7 @@ function bbp_buddypress_add_notification( $reply_id = 0, $topic_id = 0, $forum_i
 		'item_id'          => $reply_id,
 		'component_name'   => bbp_get_component_name(),
 		'component_action' => 'bbp_new_reply',
-		'date_notified'    => bp_core_current_time(),
+		'date_notified'    => get_post( $reply_id )->post_date_gmt,
 	);
 
 	// Notify the topic author if not the current reply author


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1299 

### How to test the changes in this Pull Request:

1. Inside admin, Settings > General, set the timezone to UTC -4 or Los Angeles, or whatever timezone except UTC+0
2. Post a reply using a different account
3. Login to the account that started the discussion and you should see a notification
4. Click the notification bell located at the top right corner of the page and you'll see that the timestamp is incorrect.

### Proof Screenshots or Video
https://www.loom.com/share/cc27a971ee6243c49cedcfdb4be68b19

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

