### PR TITLE
1251 - Fixed the issue with notification mark read when visiting the …

### DIFF
--- a/src/bp-activity/bp-activity-notifications.php
+++ b/src/bp-activity/bp-activity-notifications.php
@@ -294,6 +294,42 @@ function bp_activity_remove_screen_notifications_single_activity_permalink( $act
 add_action( 'bp_activity_screen_single_activity_permalink', 'bp_activity_remove_screen_notifications_single_activity_permalink' );
 
 /**
+ * Mark notification read when user visit sing post page permalink
+ *
+ * @since BuddyPress 2.0.0
+ */
+function bp_activity_remove_screen_notifications_sing_post() {
+	global $post;
+
+	if ( ! is_user_logged_in() || empty( $post->post_type ) || ! bp_is_post_type_feed_enable( $post->post_type ) || ! is_singular( $post->post_type ) ) {
+		return;
+	}
+
+	$comment_id = 0;
+	// For replies to a parent update.
+	if ( ! empty( $_GET['rid'] ) ) {
+		$comment_id = (int) $_GET['rid'];
+
+		// For replies to an activity comment.
+	} elseif ( ! empty( $_GET['crid'] ) ) {
+		$comment_id = (int) $_GET['crid'];
+	}
+
+	// Mark individual activity reply notification as read.
+	if ( ! empty( $comment_id ) ) {
+		BP_Notifications_Notification::update(
+			array(
+				'is_new' => false,
+			),
+			array(
+				'user_id' => bp_loggedin_user_id(),
+				'id'      => $comment_id,
+			)
+		);
+	}
+}
+
+/**
  * Mark non-mention notifications as read when user visits our read permalink.
  *
  * In particular, 'update_reply' and 'comment_reply' notifications are handled

--- a/src/bp-activity/bp-activity-notifications.php
+++ b/src/bp-activity/bp-activity-notifications.php
@@ -298,21 +298,24 @@ add_action( 'bp_activity_screen_single_activity_permalink', 'bp_activity_remove_
  *
  * @since BuddyPress 2.0.0
  */
-function bp_activity_remove_screen_notifications_sing_post() {
+function bp_activity_mark_blog_post_notification_read() {
 	global $post;
 
 	if ( ! is_user_logged_in() || empty( $post->post_type ) || ! bp_is_post_type_feed_enable( $post->post_type ) || ! is_singular( $post->post_type ) ) {
 		return;
 	}
 
+	$rid        = filter_input( INPUT_GET, 'rid', FILTER_VALIDATE_INT );
+	$crid       = filter_input( INPUT_GET, 'crid', FILTER_VALIDATE_INT );
 	$comment_id = 0;
+
 	// For replies to a parent update.
-	if ( ! empty( $_GET['rid'] ) ) {
-		$comment_id = (int) $_GET['rid'];
+	if ( ! empty( $rid ) ) {
+		$comment_id = $rid;
 
 		// For replies to an activity comment.
 	} elseif ( ! empty( $_GET['crid'] ) ) {
-		$comment_id = (int) $_GET['crid'];
+		$comment_id = $crid;
 	}
 
 	// Mark individual activity reply notification as read.

--- a/src/bp-core/bp-core-actions.php
+++ b/src/bp-core/bp-core-actions.php
@@ -42,7 +42,7 @@ add_action( 'wp_enqueue_scripts', 'bp_enqueue_scripts', 10 );
 add_action( 'enqueue_embed_scripts', 'bp_enqueue_embed_scripts', 10 );
 add_action( 'admin_bar_menu', 'bp_setup_admin_bar', 20 ); // After WP core.
 add_action( 'template_redirect', 'bp_template_redirect', 10 );
-add_action( 'template_redirect', 'bp_activity_remove_screen_notifications_sing_post', 10 );
+add_action( 'template_redirect', 'bp_activity_mark_blog_post_notification_read', 10 );
 add_action( 'widgets_init', 'bp_widgets_init', 10 );
 add_action( 'generate_rewrite_rules', 'bp_generate_rewrite_rules', 10 );
 

--- a/src/bp-core/bp-core-actions.php
+++ b/src/bp-core/bp-core-actions.php
@@ -42,6 +42,7 @@ add_action( 'wp_enqueue_scripts', 'bp_enqueue_scripts', 10 );
 add_action( 'enqueue_embed_scripts', 'bp_enqueue_embed_scripts', 10 );
 add_action( 'admin_bar_menu', 'bp_setup_admin_bar', 20 ); // After WP core.
 add_action( 'template_redirect', 'bp_template_redirect', 10 );
+add_action( 'template_redirect', 'bp_activity_remove_screen_notifications_sing_post', 10 );
 add_action( 'widgets_init', 'bp_widgets_init', 10 );
 add_action( 'generate_rewrite_rules', 'bp_generate_rewrite_rules', 10 );
 


### PR DESCRIPTION
…notification ilnk

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1251.

### How to test the changes in this Pull Request:

1. Create a custom post type
2. Make sure to enable it on BuddyBoss > Settings > Activity > Custom Post Types
3. Add new item for the CPT you just created
4. Go to the activity feed, try to mention someone or comment using another account
5. Using the mentioned account, notice that the notification is not being marked as read after viewing it. For reference, please see, https://i.ibb.co/JsxCRtd/mentioned.png
6. Lastly, go to the creator's account and notice the the notification when some commented on your CPT activity will not marked as read too, for reference, please see https://i.ibb.co/fx7fszy/commented.png.

### Proof Screenshots or Video
https://www.loom.com/share/ffe257d80a8c41378114f2f3cf090a4a
<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
