### PR TITLE
#1692 - Fix Private group documents display issue

### DIFF
--- a/src/bp-groups/bp-groups-filters.php
+++ b/src/bp-groups/bp-groups-filters.php
@@ -665,7 +665,7 @@ function bp_groups_filter_document_scope( $retval = array(), $filter = array() )
 	}
 
 	if ( empty( $group_ids ) ) {
-		$group_ids = array( 'groups' => array() );
+		$group_ids = array( 'groups' => array( 0 ) );
 	}
 
 	if ( bp_is_group() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### How to test the changes in this Pull Request:

1. Remove all the public groups from the site and keep only private groups.
2. Go the main document directory page and it will show all the private groups documents even if you are not a part of that group.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
