### PR TITLE
PROD-899 Added  notification when someone like a post /  activity #1721

### DIFF
--- a/src/bp-activity/bp-activity-notifications.php
+++ b/src/bp-activity/bp-activity-notifications.php
@@ -88,6 +88,21 @@ function bp_activity_format_notifications( $action, $item_id, $secondary_item_id
 				$text = sprintf( __( '%1$s replied to one of your activity comments', 'buddyboss' ), $user_fullname );
 			}
 			break;
+
+		case 'mark_activity_favorite':
+			$link   = bp_get_notifications_permalink();
+			$title  = __( 'New Activity comment reply', 'buddyboss' );
+			$amount = 'single';
+
+			if ( (int) $total_items > 1 ) {
+				$link   = add_query_arg( 'type', $action, $link );
+				$text   = sprintf( __( 'You have %1$d new comment replies', 'buddyboss' ), (int) $total_items );
+				$amount = 'multiple';
+			} else {
+				$link = add_query_arg( 'crid', (int) $id, bp_activity_get_permalink( $activity_id ) );
+				$text = sprintf( __( '%1$s replied to one of your activity comments', 'buddyboss' ), $user_fullname );
+			}
+			break;
 	}
 
 	if ( 'string' == $format ) {
@@ -185,6 +200,21 @@ function bp_activity_at_mention_add_notification( $activity, $subject, $message,
 	);
 }
 add_action( 'bp_activity_sent_mention_email', 'bp_activity_at_mention_add_notification', 10, 5 );
+
+
+function bp_activity_like_add_notification( $activity ) {
+	bp_notifications_add_notification(
+			array(
+					'user_id'           => $activity->user_id,
+					'item_id'           => $activity->id,
+					'secondary_item_id' => bp_loggedin_user_id(),
+					'component_name'    => buddypress()->activity->id,
+					'component_action'  => 'mark_activity_favorite',
+					'date_notified'     => bp_core_current_time(),
+					'is_new'            => 1,
+			)
+	);
+}
 
 /**
  * Notify a member one of their activity received a reply.

--- a/src/bp-activity/bp-activity-notifications.php
+++ b/src/bp-activity/bp-activity-notifications.php
@@ -90,18 +90,9 @@ function bp_activity_format_notifications( $action, $item_id, $secondary_item_id
 			break;
 
 		case 'mark_activity_favorite':
-			$link   = bp_get_notifications_permalink();
-			$title  = __( 'New Activity comment reply', 'buddyboss' );
 			$amount = 'single';
-
-			if ( (int) $total_items > 1 ) {
-				$link   = add_query_arg( 'type', $action, $link );
-				$text   = sprintf( __( 'You have %1$d new comment replies', 'buddyboss' ), (int) $total_items );
-				$amount = 'multiple';
-			} else {
-				$link = add_query_arg( 'crid', (int) $id, bp_activity_get_permalink( $activity_id ) );
-				$text = sprintf( __( '%1$s replied to one of your activity comments', 'buddyboss' ), $user_fullname );
-			}
+			$link =  bp_activity_get_permalink( $activity_id );
+			$text = sprintf( __( '%1$s likes your post', 'buddyboss' ), $user_fullname );
 			break;
 	}
 
@@ -201,6 +192,13 @@ function bp_activity_at_mention_add_notification( $activity, $subject, $message,
 }
 add_action( 'bp_activity_sent_mention_email', 'bp_activity_at_mention_add_notification', 10, 5 );
 
+/**
+ * Notify a member when someone like their post / activity.
+ *
+ * @since BuddyBoss 1.5.6
+ *
+ * @param object $activity           Activity object.
+ */
 
 function bp_activity_like_add_notification( $activity ) {
 	bp_notifications_add_notification(

--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -132,6 +132,9 @@ function bp_nouveau_ajax_mark_activity_favorite() {
 			}
 		}
 
+		$activity     = new BP_Activity_Activity( $_POST['id'] );
+		bp_activity_like_add_notification( $activity );
+
 		wp_send_json_success( $response );
 	} else {
 		wp_send_json_error();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added  notification when someone like a post/activity

Fixes #1721 


### Screenshots

https://image.prntscr.com/image/r82yB-1WTb_szJMJsbd6rA.png

### Changelog entry

> Added  notification when someone like a post /  activity