### PR TITLE
Fix automatically add users while sending a personal message

### DIFF
--- a/src/bp-messages/classes/class-bp-messages-message.php
+++ b/src/bp-messages/classes/class-bp-messages-message.php
@@ -155,12 +155,12 @@ class BP_Messages_Message {
 
 		// If we have no thread_id then this is the first message of a new thread.
 		if ( empty( $this->thread_id ) ) {
-			$max_thread      = self::get(
+			$max_thread = self::get(
 				array(
 					'fields'   => 'thread_ids',
 					'per_page' => 1,
 					'page'     => 1,
-					'orderby'  => 'id',
+					'orderby'  => 'thread_id',
 				)
 			);
 			$this->thread_id = ( isset( $max_thread['messages'][0] ) && is_numeric( $max_thread['messages'][0] ) ) ? (int) $max_thread['messages'][0] + 1 : 1;
@@ -820,6 +820,13 @@ class BP_Messages_Message {
 		switch ( $orderby ) {
 			case 'id':
 				$order_by_term = 'm.id';
+				break;
+			case 'thread_id':
+				$order_by_term = 'm.thread_id';
+				break;
+			case 'user_id':
+			case 'sender_id':
+				$order_by_term = 'm.sender_id';
 				break;
 			case 'date_sent':
 			default:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. When the customer tries to send a private message (BCC) to every member of a large group, some members will not receive it in their message box (and no email notification).
2. Then, when somebody writes to somebody else (Whether he or she is part of the group or not), it will merge the message to a group full of unknown people, probably related to an undelivered BCC message.
3. If, as an admin, you delete the group message, private messages will work fine once again (until the next big group private message, probably).


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
