### PR TITLE
Fix user activity friends scope

### DIFF
--- a/src/bp-friends/bp-friends-activity.php
+++ b/src/bp-friends/bp-friends-activity.php
@@ -281,6 +281,11 @@ function bp_friends_filter_activity_scope( $retval = array(), $filter = array() 
 		}
 	}
 
+	if ( is_user_logged_in() && bp_loggedin_user_id() === $user_id ) {
+		$friends[]        = bp_loggedin_user_id();
+		$mutual_friends[] = bp_loggedin_user_id();
+	}
+
 	if ( empty( $friends ) ) {
 		$friends = array( 0 );
 	}

--- a/src/bp-friends/bp-friends-activity.php
+++ b/src/bp-friends/bp-friends-activity.php
@@ -266,34 +266,63 @@ function bp_friends_filter_activity_scope( $retval = array(), $filter = array() 
 		$user_id = bp_loggedin_user_id();
 	}
 
+	$mutual_friends = array();
+
 	// Determine friends of user.
 	$friends = friends_get_friend_user_ids( $user_id );
+
+	if ( is_user_logged_in() ) {
+		$mutual_friends = friends_get_friend_user_ids( bp_loggedin_user_id() );
+		if ( bp_loggedin_user_id() !== $user_id && in_array( $user_id, $mutual_friends ) ) {
+			$mutual_friends[] = bp_loggedin_user_id();
+		}
+		if ( ! empty( $mutual_friends ) ) {
+			$mutual_friends = array_intersect( $friends, $mutual_friends );
+		}
+	}
+
 	if ( empty( $friends ) ) {
 		$friends = array( 0 );
+	}
+
+	if ( empty( $mutual_friends ) ) {
+		$mutual_friends = array( 0 );
 	}
 
 	$privacy = array( 'public' );
 	if ( is_user_logged_in() ) {
 		$privacy[] = 'loggedin';
-
-		if ( ! empty( $friends ) ) {
-			$privacy[] = 'friends';
-		}
 	}
 
 	$retval = array(
 		'relation' => 'AND',
 		array(
-			'column'  => 'user_id',
-			'compare' => 'IN',
-			'value'   => (array) $friends,
+			'relation' => 'OR',
+			array(
+				array(
+					'column'  => 'user_id',
+					'compare' => 'IN',
+					'value'   => (array) $friends,
+				),
+				array(
+					'column'  => 'privacy',
+					'compare' => 'IN',
+					'value'   => $privacy,
+				),
+			),
+			array(
+				array(
+					'column'  => 'user_id',
+					'compare' => 'IN',
+					'value'   => (array) $mutual_friends,
+				),
+				array(
+					'column'  => 'privacy',
+					'compare' => 'IN',
+					'value'   => 'friends',
+				),
+			),
 		),
-		array(
-			'column'  => 'privacy',
-			'compare' => 'IN',
-			'value'   => $privacy
-		),
-
 		// We should only be able to view sitewide activity content for friends.
 		array(
 			'column' => 'hide_sitewide',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Goto BuddyBoss > Settings > Activity and enable "Activity tabs"
2. User A and B are friends.
3. User B and C are friends.
4. Logged in as user C and post an activity with "My Connection" privacy.
5. Logged in as User A and view the profile of User B Go to the Connections tab and you can see user C activity.
event User A and C are not friends.

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
