### PR TITLE
Fix #2000: PHP 8.0 Deprecate required parameters after optional parameters

### DIFF
--- a/src/bp-core/classes/class-bp-invitation-manager.php
+++ b/src/bp-core/classes/class-bp-invitation-manager.php
@@ -611,7 +611,7 @@ abstract class BP_Invitation_Manager {
 	 * @param int $id The ID of the invitation to mark as sent.
 	 * @return bool True on success, false on failure.
 	 */
-	abstract public function run_acceptance_action( $type = 'invite', $r  );
+	abstract public function run_acceptance_action( $type, $r  );
 
 	/**
 	 * Mark invitation as accepted by invitation ID.

--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -292,7 +292,7 @@ add_action( 'xprofile_admin_group_action', 'bp_core_update_group_fields_id_in_db
  *
  * @return array Return the names or objects of the taxonomies which are registered for the requested object or object type
  */
-function bp_core_remove_authors_taxonomy_for_co_authors_plus( $taxonomies = array(), $post_type ) {
+function bp_core_remove_authors_taxonomy_for_co_authors_plus( $taxonomies, $post_type ) {
 
 	delete_blog_option( bp_get_root_blog_id(), "bp_search_{$post_type}_tax_author" );
 	return array_diff( $taxonomies, array( 'author' ) );

--- a/src/bp-groups/classes/class-bp-groups-invitation-manager.php
+++ b/src/bp-groups/classes/class-bp-groups-invitation-manager.php
@@ -67,7 +67,7 @@ class BP_Groups_Invitation_Manager extends BP_Invitation_Manager {
 	 * @param array  $r    Parameters that describe the invitation being accepted.
 	 * @return bool True on success, false on failure.
 	 */
-	public function run_acceptance_action( $type = 'invite', $r  ) {
+	public function run_acceptance_action( $type, $r  ) {
 		// If the user is already a member (because BP at one point allowed two invitations to
 		// slip through), return early.
 		if ( groups_is_user_member( $r['user_id'], $r['item_id'] ) ) {

--- a/src/bp-loader.php
+++ b/src/bp-loader.php
@@ -112,9 +112,9 @@ if ( empty( $is_bp_active ) && empty( $is_bb_active ) && empty( $bp_incompatible
 	function bp_core_set_bbpress_buddypress_on_admin_notices() {
 		global $bp_is_multisite;
 
-		add_filter( 'option_active_plugins', 'bp_core_set_bbpress_buddypress_active', 0, 2 );
+		add_filter( 'option_active_plugins', 'bp_core_set_bbpress_buddypress_active', 0 );
 		if ( $bp_is_multisite ) {
-			add_filter( 'site_option_active_sitewide_plugins', 'bp_core_set_bbpress_buddypress_active', 0, 2 );
+			add_filter( 'site_option_active_sitewide_plugins', 'bp_core_set_bbpress_buddypress_active', 0 );
 		}
 	}
 
@@ -127,7 +127,7 @@ if ( empty( $is_bp_active ) && empty( $is_bb_active ) && empty( $bp_incompatible
 	 * @since BuddyBoss 1.0.0
 	 * @return mixed
 	 */
-	function bp_core_set_bbpress_buddypress_active( $value = array(), $option ) {
+	function bp_core_set_bbpress_buddypress_active( $value = array() ) {
 
 		global $bp_plugin_file, $bb_plugin_file, $bp_is_multisite, $buddyboss_platform_plugin_file;
 
@@ -284,13 +284,13 @@ if ( empty( $is_bp_active ) && empty( $is_bb_active ) && empty( $bp_incompatible
 	}
 
 	if ( ! is_network_admin() ) {
-		add_filter( 'option_active_plugins', 'bp_core_set_bbpress_buddypress_active', 0, 2 );
+		add_filter( 'option_active_plugins', 'bp_core_set_bbpress_buddypress_active', 0 );
 	}
 	// Filter for setting the spoofing of BuddyPress.
 	add_filter( 'pre_update_option_active_plugins', 'bp_pre_update_option_active_plugins' );
 
 	if ( $bp_is_multisite ) {
-		add_filter( 'site_option_active_sitewide_plugins', 'bp_core_set_bbpress_buddypress_active', 0, 2 );
+		add_filter( 'site_option_active_sitewide_plugins', 'bp_core_set_bbpress_buddypress_active', 0 );
 		add_filter( 'pre_add_site_option_active_sitewide_plugins', 'bp_pre_update_option_active_plugins' );
 		add_filter( 'pre_update_site_option_active_sitewide_plugins', 'bp_pre_update_option_active_plugins' );
 	}

--- a/src/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/src/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -361,7 +361,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 */
-	public function set_additional_field_properties( $field_id = 0, WP_REST_Request $request ) {
+	public function set_additional_field_properties( $field_id, WP_REST_Request $request ) {
 		if ( ! $field_id ) {
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- For the first error, the second parameter is not used anywhere, so i removed that and updated the number of args of the add_filter() function
- For the second error, i have made the first parameter required because the function call never sends the null value.

Fixes #2000

### How to test the changes in this Pull Request:

1. use PHP 8.0 & WP 5.6 environment
2. go to wp-admin > dashboard page
3. see the errors are fixed now

### Proof Screenshots or Video
https://www.loom.com/share/c016a499cbbe4eaf8537867e233bea61

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?