### PR TITLE
Fix - The My Groups tab is showing in the Photos directory even if the Social Group Component is deactivated

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/media/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/media/functions.php
@@ -214,7 +214,7 @@ function bp_nouveau_get_media_directory_nav_items() {
 		);
 	}
 
-	if ( is_user_logged_in() && bp_is_group_media_support_enabled() ) {
+	if ( is_user_logged_in() && bp_is_group_media_support_enabled() && bp_is_active('groups') ) {
 		$nav_items['group'] = array(
 			'component' => 'media',
 			'slug'      => 'groups', // slug is used because BP_Core_Nav requires it, but it's the scope.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I have added one condition for that and checked when the social group will active then this menu will display.

Fixes #1992.

### How to test the changes in this Pull Request:

1. Go to BuddyBoss > Components
2. Deactivate Social Groups
3. Now, go to the photos directory
4. Select the "My Groups" tab and notice the error

### Proof Screenshots or Video

https://screencast-o-matic.com/watch/crVj24PU3x

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixed - Group tabbing is showing  in Photos dir even if Social group component is deactivated