### PR TITLE
Update bp_get_member_type function

### DIFF
--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -2829,7 +2829,7 @@ function bp_remove_member_type( $user_id, $member_type ) {
 function bp_get_member_type( $user_id, $single = true ) {
 	$types = wp_cache_get( $user_id, 'bp_member_member_type' );
 
-	if ( false == $types ) {
+	if ( empty( $types ) ) {
 		$raw_types = bp_get_object_terms( $user_id, bp_get_member_type_tax_name() );
 
 		if ( ! is_wp_error( $raw_types ) ) {

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -2829,7 +2829,7 @@ function bp_remove_member_type( $user_id, $member_type ) {
 function bp_get_member_type( $user_id, $single = true ) {
 	$types = wp_cache_get( $user_id, 'bp_member_member_type' );
 
-	if ( false === $types ) {
+	if ( false == $types ) {
 		$raw_types = bp_get_object_terms( $user_id, bp_get_member_type_tax_name() );
 
 		if ( ! is_wp_error( $raw_types ) ) {


### PR DESCRIPTION
change the comparison from strict to loose comparison for $types
[https://github.com/buddyboss/buddyboss-platform/issues/2043](https://github.com/buddyboss/buddyboss-platform/issues/2043)

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #ISSUE_NUMBER .

### How to test the changes in this Pull Request:

1.
2.
3.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

On getting member type, it always returns “member” when on “view as” on other members. now on wp_cache_get function, according to WordPress it returns mixed|false - The cache contents on success, false on failure to retrieve contents. the original condition with strict comparison sometimes failed to validate FALSE, because sometimes the wp_cache_get function returns an array without data something like this “array(0) { }” due to a strict condition. this array is considered TRUE on a strict comparison “===” my suggestion is to change the comparison from strict to loose comparison. as I’ve done on the screenshot https://prnt.sc/wo0tuh.
