### PR TITLE
Fixed - The LearnDash Integration settings are not saving with multisite

### DIFF
--- a/src/bp-integrations/learndash/core/Settings.php
+++ b/src/bp-integrations/learndash/core/Settings.php
@@ -76,7 +76,7 @@ class Settings {
 	 * @since BuddyBoss 1.0.0
 	 */
 	public function update() {
-		$oldOptions                                        = $this->options;
+		$oldOptions = $this->options;
 		bp_update_option( $this->optionKey, $this->options = $this->loader->get() );
 		do_action( 'bp_ld_sync/setting_updated', $this->options, $oldOptions );
 		return $this;
@@ -143,7 +143,7 @@ class Settings {
 	 * @since BuddyBoss 1.0.0
 	 */
 	protected function installDefaultSettings() {
-		if ( ! $options = get_option( $this->optionKey ) ) {
+		if ( ! $options = bp_get_option( $this->optionKey ) ) {
 			$options = $this->defaultOptions();
 			bp_update_option( $this->optionKey, $options );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2079.

### How to test the changes in this Pull Request:
Not reproduce this issue locally. I have tried to reproduce it but not found it. So I have checked on the customer's site to deactivate all plugins and found this solution.

1. Multisite is required
2. Go to Integration -> Learndash
3. Enable Social Group Sync and LearnDash Group Sync
4. Save it
5. After some time when you refresh the page, the setting would be lost.

### Proof Screenshots or Video

https://screencast-o-matic.com/watch/crVtqbRenF

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry