### PR TITLE
cli activity create: group id incorrectly set to component

### DIFF
--- a/src/cli/components/activity.php
+++ b/src/cli/components/activity.php
@@ -130,7 +130,7 @@ class Activity extends BuddypressCommand {
 		}
 
 		if ( 'groups' === $r['component'] ) {
-			$group_id = $r['component'];
+			$group_id = $r['item-id'];
 
 			if ( ! is_numeric( $group_id ) ) {
 				$group_id = groups_get_id( $group_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

It is not possible to create group activity post to a named group using the wp cli tool. This pull request corrects where the group id is incorrectly set to the component type instead of the supplied group id ( item-id ).

### How to test the changes in this Pull Request:

1. create a group activity post using the wp cli tool
`wp bp activity create --component=groups --type=activity_update --content="foo" --item-id=1`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

cli activity create: group id incorrectly set to component
