### PR TITLE
Fixed - Title, Description not working from Yoast option some of the Buddyboss pages.

### DIFF
--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -527,3 +527,60 @@ function bp_core_set_uri_elementor_show_on_front( $bool ) {
 	return $bool;
 }
 add_filter( 'bp_core_set_uri_show_on_front', 'bp_core_set_uri_elementor_show_on_front', 10, 3 );
+
+/**
+ * Generate Yoast SEO title, when post id is empty.
+ *
+ * @since BuddyBoss 1.5.8
+ *
+ * @param string $title
+ * @param object $presentation
+ * @return string.
+ */
+function bp_set_wpseo_title( $title, $presentation ) {
+	global $post;
+
+	if ( ! empty( $post->ID ) ) {
+		return $title;
+	}
+
+	$page_id = bp_core_get_directory_page_id();
+
+	if ( empty( $page_id ) ) {
+		return $title;
+	}
+
+	$title = get_post_meta( $page_id, '_yoast_wpseo_title', true );
+
+	return $title;
+}
+add_filter( 'wpseo_title', 'bp_set_wpseo_title', 10, 2 );
+
+/**
+ * Generate Yoast SEO meta description, when post id is empty.
+ *
+ * @since BuddyBoss 1.5.8
+ *
+ * @param string $meta_description
+ * @param object $presentation
+ * @return string.
+ */
+function bp_set_wpseo_meta_description( $meta_description, $presentation ) {
+	global $post;
+
+	if ( ! empty( $post->ID ) ) {
+		return $meta_description;
+	}
+
+	$page_id = bp_core_get_directory_page_id();
+
+	if ( empty( $page_id ) ) {
+		return $meta_description;
+	}
+
+	$meta_description = get_post_meta( $page_id, '_yoast_wpseo_metadesc', true );
+
+	return $meta_description;
+}
+add_filter( 'wpseo_metadesc', 'bp_set_wpseo_meta_description', 10, 2 );
+


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [ ] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1371 .

### How to test the changes in this Pull Request:

1. Install Yoast SEO plugin and buddyboss-platform
2. Try to customize SEO description of some buddyboss page
3. Open the page and see source code of page (CTRL+U)
4. You should see description meta tag. It should be looks like this:
<meta name="description" content="Custom description of your page..." />
5. But you will not see the description meta tag.

### Proof Screenshots or Video

https://www.loom.com/share/b866f5ca2f46443da8a86ab4898b6f0a

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
