### PR TITLE
Fixed - Loading Groups message display instead 404 page when entered …

### DIFF
--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -173,7 +173,7 @@ class BP_Groups_Component extends BP_Component {
 			}
 
 			// Screens - Directory.
-			if ( bp_is_groups_directory() ) {
+			if ( bp_is_groups_directory() && ! empty( bp_get_current_group_directory_type() ) ) {
 				require $this->path . 'bp-groups/screens/directory.php';
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
I have fixed the issue to display 404 page instead of Loading groups message.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2194  .

### How to test the changes in this Pull Request:

1. Enter an incorrect group type slug in the URL. Ex: site.com/groups/type/xyz/

### Proof Screenshots or Video

![f684f1ec-be62-4ba6-8998-b51b4021915a](https://user-images.githubusercontent.com/33976417/109545080-6168df00-7aee-11eb-87a1-fcb5339b42b5.png)

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
