### PR TITLE
Update bp-groups-admin.php

### DIFF
--- a/src/bp-groups/bp-groups-admin.php
+++ b/src/bp-groups/bp-groups-admin.php
@@ -361,7 +361,7 @@ function bp_groups_admin_load() {
 		 * @param array $value Array of allowed media statuses.
 		 */
 		$allowed_media_status = apply_filters( 'groups_allowed_media_status', array( 'members', 'mods', 'admins' ) );
-		$media_status         = in_array( $_POST['group-media-status'], (array) $allowed_media_status ) ? $_POST['group-media-status'] : 'members';
+		$media_status         = isset( $_POST['group-media-status'] ) && in_array( $_POST['group-media-status'], (array) $allowed_media_status ) ? $_POST['group-media-status'] : 'members';
 
 		/**
 		 * Filters the allowed media status values for the group.
@@ -371,7 +371,7 @@ function bp_groups_admin_load() {
 		 * @param array $value Array of allowed media statuses.
 		 */
 		$allowed_document_status = apply_filters( 'groups_allowed_document_status', array( 'members', 'mods', 'admins' ) );
-		$document_status         = in_array( $_POST['group-document-status'], (array) $allowed_document_status ) ? $_POST['group-document-status'] : 'members';
+		$document_status         = isset( $_POST['group-document-status'] ) && in_array( $_POST['group-document-status'], (array) $allowed_document_status ) ? $_POST['group-document-status'] : 'members';
 
 		/**
 		 * Filters the allowed album status values for the group.
@@ -381,7 +381,7 @@ function bp_groups_admin_load() {
 		 * @param array $value Array of allowed album statuses.
 		 */
 		$allowed_album_status = apply_filters( 'groups_allowed_album_status', array( 'members', 'mods', 'admins' ) );
-		$album_status         = in_array( $_POST['group-album-status'], (array) $allowed_album_status ) ? $_POST['group-album-status'] : 'members';
+		$album_status         = isset( $_POST['group-album-status'] ) && in_array( $_POST['group-album-status'], (array) $allowed_album_status ) ? $_POST['group-album-status'] : 'members';
 
 		/**
 		 * Filters the allowed album status values for the group.
@@ -391,7 +391,7 @@ function bp_groups_admin_load() {
 		 * @param array $value Array of allowed album statuses.
 		 */
 		$allowed_message_status = apply_filters( 'groups_allowed_group_message_status', array( 'members', 'mods', 'admins' ) );
-		$message_status         = in_array( $_POST['group-message-status'], (array) $allowed_message_status ) ? $_POST['group-message-status'] : 'members';
+		$message_status         = isset( $_POST['group-message-status'] ) && in_array( $_POST['group-message-status'], (array) $allowed_message_status ) ? $_POST['group-message-status'] : 'members';
 
 		if ( ! groups_edit_group_settings( $group_id, $enable_forum, $status, $invite_status, $activity_feed_status, false, $media_status, $document_status, $album_status, $message_status ) ) {
 			$error = $group_id;


### PR DESCRIPTION
Error:
Notice: Undefined index: group-document-status in /home/wp_cf6ir3/app.positiveearth.com/wp-content/plugins/buddyboss-platform/bp-groups/bp-groups-admin.php on line 374 
Notice: Undefined index: group-message-status in /home/wp_cf6ir3/app.positiveearth.com/wp-content/plugins/buddyboss-platform/bp-groups/bp-groups-admin.php on line 394

When the user edit the groups on wordpress dashboard and save, those error persist and the settings are: 
"Group - Allow members to upload documents in groups, activity posts and forums" and "Group Messages - Allow for sending group messages to group members " is disabled
