### PR TITLE
PROD-830 Forum list widget parent forum ID issue - Fixed

### DIFF
--- a/src/bp-forums/common/widgets.php
+++ b/src/bp-forums/common/widgets.php
@@ -590,8 +590,7 @@ class BBP_Forums_Widget extends WP_Widget {
 		$widget_query = new WP_Query(
 			array(
 				'post_type'           => bbp_get_forum_post_type(),
-				// 'post_parent'         => $settings['parent_forum'],
-				'post_parent'         => 0,
+				'post_parent'         => $settings['parent_forum'],
 				'post_status'         => bbp_get_public_status_id(),
 				'posts_per_page'      => bbp_get_forums_per_page(),
 				'ignore_sticky_posts' => true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2343 .

### How to test the changes in this Pull Request:

1. Add the Forum List widget in any Widget area.
2. Add a parent forum ID
3. and see widget will show all subforums of this parent forum.

### Proof Screenshots or Video

[https://www.loom.com/share/c5b1bf697a774bc8a5cce097d9d5d0d8](https://www.loom.com/share/c5b1bf697a774bc8a5cce097d9d5d0d8)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Forum list widget parent forum ID issue - Fixed
