### PR TITLE
Fixed issue with wp email translation

### DIFF
--- a/src/bp-core/classes/class-bp-email.php
+++ b/src/bp-core/classes/class-bp-email.php
@@ -730,9 +730,9 @@ class BP_Email {
 		$this->post_object = apply_filters( 'bp_email_set_post_object', $post, $this );
 
 		if ( is_a( $this->post_object, 'WP_Post' ) ) {
-			$this->set_subject( $this->post_object->post_title )
-				->set_content_html( $this->post_object->post_content )
-				->set_content_plaintext( $this->post_object->post_excerpt );
+			$this->set_subject( __( $this->post_object->post_title, 'buddyboss' ) )
+				->set_content_html( __( $this->post_object->post_content, 'buddyboss' ) )
+				->set_content_plaintext( __( $this->post_object->post_excerpt, 'buddyboss' ) );
 
 			ob_start();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1099

### How to test the changes in this Pull Request:

1. Make sure, Buddyboss theme and Buddyboss Platform is activated.
2. Install the "Loco Translate" plugin for translation.
2. Go to Settings>>General.
3. Change "Site Language" to "Français".
4. Now in another chrome window, try to register yourself. 
5. You will get the welcome email in the "Français" language.  

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->
https://www.loom.com/share/818de562d23b4e8ba031799ffb48b00d