### PR TITLE
Profile > Courses returns 404 when Learndash Courses URL is nested

### DIFF
--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -394,6 +394,13 @@ function bp_core_set_uri_globals() {
 
 	$bp->current_action = $current_action;
 
+	/**
+	 * Extend support for the $bp setup based on uri.
+	 *
+	 * @since BuddyBoss 1.5.9
+	 */
+	do_action( 'bp_core_set_uri_globals', $bp, $bp_uri );
+
 	// Slice the rest of the $bp_uri array and reset offset.
 	$bp_uri     = array_slice( $bp_uri, $uri_offset + 2 );
 	$uri_offset = 0;

--- a/src/bp-integrations/learndash/bp-learndash-filters.php
+++ b/src/bp-integrations/learndash/bp-learndash-filters.php
@@ -19,6 +19,8 @@ add_filter( 'sfwd_cpt_options', 'bb_ld_group_archive_slug_change', 999, 2 );
 add_filter( 'learndash_settings_fields', 'bb_ld_group_archive_backend_slug_print', 9999, 2 );
 
 /* Actions *******************************************************************/
+add_action( 'bp_core_set_uri_globals', 'bb_support_learndash_course_permalink', 10, 2 );
+
 add_action( 'add_meta_boxes', 'bp_activity_add_meta_boxes', 50 );
 
 add_action( 'admin_bar_menu', 'bb_group_wp_admin_bar_updates_menu', 99 );
@@ -352,4 +354,20 @@ function bb_ld_group_archive_backend_slug_print( $setting_option_fields, $settin
 
 	return $setting_option_fields;
 
+}
+
+/**
+ * Update the current component and action while nested URL setup from the learndash permalink.
+ * For member courses.
+ *
+ * @since BuddyBoss 1.5.9
+ *
+ * @param object $bp     BuddyPress object.
+ * @param array  $bp_uri Array of URI.
+ */
+function bb_support_learndash_course_permalink( $bp, $bp_uri ) {
+	if ( ! empty( $bp_uri ) && implode( '/', $bp_uri ) === bb_learndash_profile_courses_slug() ) {
+		$bp->current_component = bb_learndash_profile_courses_slug();
+		$bp->current_action    = '';
+	}
 }

--- a/src/bp-integrations/learndash/bp-learndash-functions.php
+++ b/src/bp-integrations/learndash/bp-learndash-functions.php
@@ -473,6 +473,8 @@ function bb_profiles_tutorial_my_courses() {
 /**
  * LeanDash permalink slug for profile courses.
  *
+ * @since BuddyBoss 1.5.9
+ *
  * @return string
  */
 function bb_learndash_profile_courses_slug() {

--- a/src/bp-integrations/learndash/bp-learndash-functions.php
+++ b/src/bp-integrations/learndash/bp-learndash-functions.php
@@ -469,3 +469,12 @@ function bb_profiles_tutorial_my_courses() {
 
 	<?php
 }
+
+/**
+ * LeanDash permalink slug for profile courses.
+ *
+ * @return string
+ */
+function bb_learndash_profile_courses_slug() {
+	return ltrim( apply_filters( 'bp_learndash_profile_courses_slug', \LearnDash_Settings_Section::get_section_setting( 'LearnDash_Settings_Section_Permalinks', 'courses' ) ), '/' );
+}

--- a/src/bp-integrations/learndash/core/Core.php
+++ b/src/bp-integrations/learndash/core/Core.php
@@ -118,7 +118,7 @@ class Core {
 		$this->my_courses_name          = sprintf( __( 'My %s', 'buddyboss' ), $this->course_name );
 		$this->create_courses_name      = sprintf( __( 'Create a %s', 'buddyboss' ), $this->course_name );
 		$this->create_courses_slug      = apply_filters( 'bp_learndash_profile_create_courses_slug', 'create-courses' );
-		$this->course_slug              = apply_filters( 'bp_learndash_profile_courses_slug', \LearnDash_Settings_Section::get_section_setting('LearnDash_Settings_Section_Permalinks', 'courses' ) );
+		$this->course_slug              = bb_learndash_profile_courses_slug();
 		$this->my_courses_slug          = apply_filters( 'bp_learndash_profile_courses_slug', 'my-courses' );
 		$this->course_access            = bp_core_can_edit_settings();
 		$this->certificates_enables     = bp_core_learndash_certificates_enables();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1518

### How to test the changes in this Pull Request:

1. Go to Settings > Permalinks
2. On LearnDash Permalinks section, change courses slug to a nested one (nested/courses)
3. Course archive displays correctly
4. Members Profile Courses

### Proof Screenshots or Video
Backend Permalink: http://prntscr.com/12sitdk
Course Directory: http://prntscr.com/12siv5p
Member Courses: http://prntscr.com/12siw58

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
