### PR TITLE
Fix for Notifications for commenting on Blog post not working on Plat…

### DIFF
--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -2988,8 +2988,11 @@ function bp_activity_new_comment( $args = '' ) {
 	// Default error message.
 	$feedback = __( 'There was an error posting your reply. Please try again.', 'buddyboss' );
 
+	// Filter to skip comment content check for comment notification.
+	$check_empty_content = apply_filters( 'bp_has_activity_comment_content', true );
+
 	// Bail if missing necessary data.
-	if ( empty( $r['content'] ) || empty( $r['user_id'] ) || empty( $r['activity_id'] ) ) {
+	if ( ( $check_empty_content && empty( $r['content'] ) ) || empty( $r['user_id'] ) || empty( $r['activity_id'] ) ) {
 		$error = new WP_Error( 'missing_data', $feedback );
 
 		if ( 'wp_error' === $r['error_type'] ) {

--- a/src/bp-blogs/bp-blogs-functions.php
+++ b/src/bp-blogs/bp-blogs-functions.php
@@ -834,7 +834,7 @@ function bp_blogs_comment_sync_activity_comment( &$activity_id, $comment = null,
 			remove_action( 'bp_activity_before_save', 'bp_blogs_sync_activity_edit_to_post_comment', 20 );
 
 			// Added the filter to bypass the content check on blog or custom post types comments.
-			add_filter('bp_has_activity_comment_content', '__return_false()');
+			add_filter('bp_has_activity_comment_content', '__return_false');
 
 			$activity_id = bp_activity_new_comment( $activity_args );
 

--- a/src/bp-blogs/bp-blogs-functions.php
+++ b/src/bp-blogs/bp-blogs-functions.php
@@ -832,6 +832,10 @@ function bp_blogs_comment_sync_activity_comment( &$activity_id, $comment = null,
 			 * reply from blog or custom post types.
 			 */
 			remove_action( 'bp_activity_before_save', 'bp_blogs_sync_activity_edit_to_post_comment', 20 );
+
+			// Added the filter to bypass the content check on blog or custom post types comments.
+			add_filter('bp_has_activity_comment_content', '__return_false()');
+
 			$activity_id = bp_activity_new_comment( $activity_args );
 
 			// Removed the filter get back activity content.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2326

### How to test the changes in this Pull Request:

1. In BuddyBoss > Settings > Activity > Posts in Activity Feeds, enable Blog Posts
2. Create a Blog, with Comments enabled
3. log in to another user and its front end, comment on the created Blog
4. Log back into the previous user who posted the blog
5. See notification bell

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->
https://www.loom.com/share/edb0726f0d014f079e9b2c07a7c0816a