### PR TITLE
Creating a discussion within a hidden group redirects to the homepage

### DIFF
--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -69,7 +69,7 @@ function bp_core_set_uri_globals() {
 	// Ajax or not?
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX || strpos( $_SERVER['REQUEST_URI'], 'wp-load.php' ) ) {
 		$path = bp_get_referer_path();
-	} elseif ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
+	} elseif ( ! empty( $_REQUEST['_wp_http_referer'] ) && ! empty( $_REQUEST['action'] ) && in_array( $_REQUEST['action'], array( 'bbp-edit-topic', 'bbp-new-topic' ), true ) ) {
 		$path = esc_url( $_REQUEST['_wp_http_referer'] );
 	} else {
 		$path = esc_url( $_SERVER['REQUEST_URI'] );


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2307

### How to test the changes in this Pull Request:

1. Create a group and set the privacy to hidden
2. Associate a forum
3. Add a non-admin user to the group as a member
4. Login/View as a group member of the hidden group you just created
5. Try to create a discussion
6. Notice the issue

### Proof Screenshots or Video
Re-fix for the issue and also fix the notification bulk edit while previous PR: #2362

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
