### PR TITLE
Fix - Trashed reply can't be restore

### DIFF
--- a/src/bp-forums/core/actions.php
+++ b/src/bp-forums/core/actions.php
@@ -184,7 +184,7 @@ add_action( 'delete_post', 'bbp_delete_reply' );
 
 // After Deleted/Trashed/Untrashed Reply
 add_action( 'trashed_post', 'bbp_trashed_reply' );
-add_action( 'untrashed_post', 'bbp_untrashed_reply' );
+add_action( 'untrashed_post', 'bbp_untrashed_reply', 10, 2 );
 add_action( 'deleted_post', 'bbp_deleted_reply' );
 
 // New/Edit Topic

--- a/src/bp-forums/replies/functions.php
+++ b/src/bp-forums/replies/functions.php
@@ -1910,12 +1910,18 @@ function bbp_trashed_reply( $reply_id = 0 ) {
  * @uses bbp_is_reply() To check if the passed id is a reply
  * @uses do_action() Calls 'bbp_untrashed_reply' with the reply id
  */
-function bbp_untrashed_reply( $reply_id = 0 ) {
+function bbp_untrashed_reply( $reply_id = 0, $previous_status ) {
 	$reply_id = bbp_get_reply_id( $reply_id );
 
 	if ( empty( $reply_id ) || ! bbp_is_reply( $reply_id ) ) {
 		return false;
 	}
+
+	$update_reply = array(
+		'ID'          => $reply_id,
+		'post_status' => $previous_status
+	);
+	wp_update_post($update_reply);
 
 	do_action( 'bbp_untrashed_reply', $reply_id );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2441

### How to test the changes in this Pull Request:

1. Go to any discussion.
2. Trash any reply.
3. Restore it.
4. Now reply will be restored.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->
https://www.loom.com/share/bfeaca6bbcac4141a15b3a97c012684b



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
