### PR TITLE
Media activity 3 dot design conflicts with TranslatePress - Fixed

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress/media/activity-entry.php
+++ b/src/bp-templates/bp-nouveau/buddypress/media/activity-entry.php
@@ -32,7 +32,7 @@ $is_comment_pic = bp_media_is_activity_comment_photo( $media_template->media );
 $more_media     = $media_template->media_count > 5 ? true : false;
 ?>
 
-<div class="bb-activity-media-elem media-activity
+<div class="bb-activity-media-elem media-activity 
 <?php
 echo esc_attr( bp_media_id() ) . ' ';
 echo $media_template->current_media > 4 ? esc_attr( 'hide' ) : '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2497 .

### How to test the changes in this Pull Request:

1. Install TranslatePress and add additional language
2. Go to News-Feed page
3. Create some media activity then switch to another language
4. See no design breaks for 3 dot

### Proof Screenshots or Video

https://www.loom.com/share/5a19814c85834344bcda4db059197646

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Media activity 3 dot design conflicts with TranslatePress - Fixed
