### PR TITLE
Older Document Preview Fixes

### DIFF
--- a/src/bp-document/bp-document-functions.php
+++ b/src/bp-document/bp-document-functions.php
@@ -3726,8 +3726,11 @@ function bp_document_create_symlinks( $document, $size = '' ) {
 
 				$file = image_get_intermediate_size( $attachment_id, $size );
 
-				if ( false === $file ) {
+				if ( false === $file && 'pdf' !== $extension ) {
 					bb_document_regenerate_attachment_thumbnails( $attachment_id );
+					$file = image_get_intermediate_size( $attachment_id, $size );
+				} elseif ( false === $file && 'pdf' === $extension ) {
+					bp_document_generate_document_previews( $attachment_id );
 					$file = image_get_intermediate_size( $attachment_id, $size );
 				}
 
@@ -4180,8 +4183,11 @@ function bp_document_get_preview_url( $document_id, $attachment_id, $size = 'bb-
 			$file          = image_get_intermediate_size( $attachment_id, $size );
 			$attached_file = get_attached_file( $attachment_id );
 
-			if ( false === $file ) {
+			if ( false === $file && 'pdf' !== $extension ) {
 				bb_document_regenerate_attachment_thumbnails( $attachment_id );
+				$file = image_get_intermediate_size( $attachment_id, $size );
+			} elseif ( false === $file && 'pdf' === $extension ) {
+				bp_document_generate_document_previews( $attachment_id );
 				$file = image_get_intermediate_size( $attachment_id, $size );
 			}
 
@@ -4193,10 +4199,14 @@ function bp_document_get_preview_url( $document_id, $attachment_id, $size = 'bb-
 				$file_path = $file_path . '/' . $file['file'];
 			}
 
-			if ( $file && ! empty( $file['file'] ) && ( ! empty( $file['path'] ) || ! file_exists( $file_path ) ) ) {
+			if ( $file && ! empty( $file['file'] ) && ( ! empty( $file['path'] ) || ! file_exists( $file_path ) ) && 'pdf' !== $extension ) {
 				// Regenerate attachment thumbnails.
 				bb_document_regenerate_attachment_thumbnails( $attachment_id );
 				$file      = image_get_intermediate_size( $attachment_id, $size );
+				$file_path = $file_path . '/' . $file['file'];
+			} elseif ( $file && ! empty( $file['file'] ) && ( ! empty( $file['path'] ) || ! file_exists( $file_path ) ) && 'pdf' === $extension ) {
+				bp_document_generate_document_previews( $attachment_id );
+				$file = image_get_intermediate_size( $attachment_id, $size );
 				$file_path = $file_path . '/' . $file['file'];
 			}
 

--- a/src/bp-document/bp-document-functions.php
+++ b/src/bp-document/bp-document-functions.php
@@ -3739,6 +3739,14 @@ function bp_document_create_symlinks( $document, $size = '' ) {
 					$file = image_get_intermediate_size( $attachment_id, 'full' );
 				}
 
+				if ( false === $file ) {
+					$file = image_get_intermediate_size( $attachment_id, 'original' );
+				}
+
+				if ( false === $file ) {
+					$file = image_get_intermediate_size( $attachment_id, 'thumbnail' );
+				}
+
 				$attached_file_info = pathinfo( $attached_file );
 				$file_path          = '';
 
@@ -4199,6 +4207,14 @@ function bp_document_get_preview_url( $document_id, $attachment_id, $size = 'bb-
 			// If the given size is not found then use the full image.
 			if ( false === $file ) {
 				$file = image_get_intermediate_size( $attachment_id, 'full' );
+			}
+
+			if ( false === $file ) {
+				$file = image_get_intermediate_size( $attachment_id, 'original' );
+			}
+
+			if ( false === $file ) {
+				$file = image_get_intermediate_size( $attachment_id, 'thumbnail' );
 			}
 
 			$attached_file_info = pathinfo( $attached_file );

--- a/src/bp-document/bp-document-functions.php
+++ b/src/bp-document/bp-document-functions.php
@@ -3734,6 +3734,11 @@ function bp_document_create_symlinks( $document, $size = '' ) {
 					$file = image_get_intermediate_size( $attachment_id, $size );
 				}
 
+				// If the given size is not found then use the full image.
+				if ( false === $file ) {
+					$file = image_get_intermediate_size( $attachment_id, 'full' );
+				}
+
 				$attached_file_info = pathinfo( $attached_file );
 				$file_path          = '';
 
@@ -4189,6 +4194,11 @@ function bp_document_get_preview_url( $document_id, $attachment_id, $size = 'bb-
 			} elseif ( false === $file && 'pdf' === $extension ) {
 				bp_document_generate_document_previews( $attachment_id );
 				$file = image_get_intermediate_size( $attachment_id, $size );
+			}
+
+			// If the given size is not found then use the full image.
+			if ( false === $file ) {
+				$file = image_get_intermediate_size( $attachment_id, 'full' );
 			}
 
 			$attached_file_info = pathinfo( $attached_file );


### PR DESCRIPTION
**From Mike:**
This PR fixes the issue with documents uploaded prior to Video Uploading release.
Sometimes they would not display the image preview properly after this update, and show a blank image. Esp with PDFs.