### PR TITLE
Added Videos tab in Group Navigation

### DIFF
--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -491,7 +491,7 @@ class BP_Groups_Component extends BP_Component {
 			$default_tab = bp_nouveau_get_temporary_setting( $customizer_option, bp_nouveau_get_appearance_settings( $customizer_option ) );
 		}
 
-		if ( 'photos' === $default_tab || 'albums' === $default_tab || 'documents' === $default_tab ) {
+		if ( 'photos' === $default_tab || 'albums' === $default_tab || 'documents' === $default_tab || 'videos' === $default_tab) {
 			$default_tab = bp_is_active( 'media' ) ? $default_tab : 'members';
 		} else {
 			$default_tab = bp_is_active( $default_tab ) ? $default_tab : 'members';

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -491,7 +491,7 @@ class BP_Groups_Component extends BP_Component {
 			$default_tab = bp_nouveau_get_temporary_setting( $customizer_option, bp_nouveau_get_appearance_settings( $customizer_option ) );
 		}
 
-		if ( 'photos' === $default_tab || 'albums' === $default_tab || 'documents' === $default_tab || 'videos' === $default_tab) {
+		if ( 'photos' === $default_tab || 'albums' === $default_tab || 'documents' === $default_tab || 'videos' === $default_tab ) {
 			$default_tab = bp_is_active( 'media' ) ? $default_tab : 'members';
 		} else {
 			$default_tab = bp_is_active( $default_tab ) ? $default_tab : 'members';

--- a/src/bp-templates/bp-nouveau/includes/groups/classes.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/classes.php
@@ -292,6 +292,15 @@ class BP_Nouveau_Customizer_Group_Nav extends BP_Core_Nav {
 					'position'    => 85,
 				);
 			}
+
+			if ( bp_is_group_video_support_enabled () ) {
+				$nav_items['videos'] = array(
+					'name'        => __( 'Videos', 'buddyboss' ),
+					'slug'        => 'videos',
+					'parent_slug' => $this->group->slug,
+					'position'    => 90,
+				);
+			}
 		}
 
 		if ( bp_is_active( 'forums' ) && function_exists( 'bbp_is_group_forums_active' ) ) {

--- a/src/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -879,6 +879,10 @@ function bp_nouveau_groups_customizer_controls( $controls = array() ) {
 		$options['documents'] = __( 'Documents', 'buddyboss' );
 	}
 
+	if ( bp_is_active( 'media' ) && bp_is_group_video_support_enabled() ) {
+		$options['videos'] = __( 'Videos', 'buddyboss' );
+	}
+
 	return array_merge( $controls,
 		array(
 			'group_nav_display' => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2568 

### How to test the changes in this Pull Request:

1.Go to Group Navigation
2.Check different menu items and they are draggable and
3.We can set order of any menu

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

