### PR TITLE
PROD-808 Fix - Restoring trashed discussion from frontend

### DIFF
--- a/src/bp-forums/topics/functions.php
+++ b/src/bp-forums/topics/functions.php
@@ -2288,7 +2288,14 @@ function bbp_toggle_topic_handler( $action = '' ) {
 				case 'untrash':
 					check_ajax_referer( 'untrash-' . bbp_get_topic_post_type() . '_' . $topic_id );
 
+					// Status filters that a post gets assigned when it is restored from the trash (untrashed).
+					add_filter( 'wp_untrash_post_status', 'bbp_update_topic_status', 10, 3 );
+
 					$success = wp_untrash_post( $topic_id );
+					
+					// Remove the status filter that a post gets assigned when it is restored from the trash (untrashed).
+					remove_filter( 'wp_untrash_post_status', 'bbp_update_topic_status', 10, 3 );
+					
 					$failure = __( '<strong>ERROR</strong>: There was a problem untrashing the discussion.', 'buddyboss' );
 
 					break;
@@ -3792,4 +3799,21 @@ function bbp_check_topic_tag_edit() {
 		wp_safe_redirect( bbp_get_topic_tag_link() );
 		exit();
 	}
+}
+
+/**
+ * Filters the status that a post gets assigned when it is restored from the trash (untrashed).
+ *
+ * @param string $new_status      The new status of the post being restored.
+ * @param int    $post_id         The ID of the post being restored.
+ * @param string $previous_status The status of the post at the point where it was trashed.
+ */
+function bbp_update_topic_status( $new_status, $post_id, $previous_status ) {
+
+	// Change post status to publish if post type is " topic ". 
+	if( bbp_get_topic_post_type() === get_post_type( $post_id )  && ! empty( $previous_status ) ) {
+		$new_status = 'publish';
+	}
+
+	return $new_status;
 }

--- a/src/languages/buddyboss.pot
+++ b/src/languages/buddyboss.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BuddyBoss Platform 1.7.1\n"
 "Report-Msgid-Bugs-To: https://www.buddyboss.com/contact/\n"
-"POT-Creation-Date: 2021-07-09 05:28:33+00:00\n"
+"POT-Creation-Date: 2021-07-12 07:25:15+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -8024,13 +8024,13 @@ msgstr ""
 
 #: bp-core/deprecated/buddypress/1.5.php:376
 msgid ""
-"%1$s mentioned you in the group \"%2$s\":\n"
-"\n"
-"\"%3$s\"\n"
-"\n"
-"To view and respond to the message, log in and visit: %4$s\n"
-"\n"
-"---------------------\n"
+"%1$s mentioned you in the group \"%2$s\":\r\n"
+"\r\n"
+"\"%3$s\"\r\n"
+"\r\n"
+"To view and respond to the message, log in and visit: %4$s\r\n"
+"\r\n"
+"---------------------\r\n"
 msgstr ""
 
 #: bp-core/deprecated/buddypress/1.6.php:154
@@ -13901,7 +13901,7 @@ msgstr ""
 msgid "All Replies"
 msgstr ""
 
-#: bp-forums/replies/functions.php:2247 bp-forums/topics/functions.php:3720
+#: bp-forums/replies/functions.php:2247 bp-forums/topics/functions.php:3727
 msgid "Replies: %s"
 msgstr ""
 
@@ -15002,15 +15002,15 @@ msgstr ""
 msgid "<strong>ERROR</strong>: There was a problem trashing the discussion."
 msgstr ""
 
-#: bp-forums/topics/functions.php:2292
+#: bp-forums/topics/functions.php:2299
 msgid "<strong>ERROR</strong>: There was a problem untrashing the discussion."
 msgstr ""
 
-#: bp-forums/topics/functions.php:2300
+#: bp-forums/topics/functions.php:2307
 msgid "<strong>ERROR</strong>: There was a problem deleting the discussion."
 msgstr ""
 
-#: bp-forums/topics/functions.php:3692 bp-forums/topics/template.php:52
+#: bp-forums/topics/functions.php:3699 bp-forums/topics/template.php:52
 msgid "All Discussions"
 msgstr ""
 
@@ -28648,14 +28648,15 @@ msgstr ""
 msgctxt "extension notification"
 msgid ""
 "Your server needs %1$s installed to automatically create thumbnails after "
-"uploading videos (optional). Ask your web host.\n"
+"uploading videos (optional). Ask your web host.\r\n"
 "\t\t\t\t\t<br/><br/>If FFmpeg is already installed on your server and you "
 "still see the above warning, this means BuddyBoss Platform is unable to "
 "auto-detect the binary file path for FFmpeg. You will need to add the below "
 "FFmpeg absolute path constants into your %2$s file, replacing "
 "PATH_OF_BINARY_FILE with the actual file path to the FFmpeg binary file. "
-"Ask your web host to provide the absolute path for the FFmpeg binary file.\n"
-"\t\t\t\t\t<br /><br />%3$s\n"
+"Ask your web host to provide the absolute path for the FFmpeg binary "
+"file.\r\n"
+"\t\t\t\t\t<br /><br />%3$s\r\n"
 "\t\t\t\t\t<br />%4$s"
 msgstr ""
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [X] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2467 

### How to test the changes in this Pull Request:

1. Create a discussion in any group
2. Logged in as an admin user
3. Try to trash the discussion
4. Restore the discussion will disappear from the frontend and it will go into draft status also

### Proof Screenshots or Video

https://www.loom.com/share/c7b7757d11304851a91c0b25c9c84df0

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

