### PR TITLE
Fix - Error in assigning group leader role to user if social group component is disabled

### DIFF
--- a/src/bp-integrations/learndash/library/SyncGenerator.php
+++ b/src/bp-integrations/learndash/library/SyncGenerator.php
@@ -531,7 +531,7 @@ class SyncGenerator {
 			$this->bpGroupId = $this->loadBpGroupId();
 		}
 
-		if ( ! $this->ldGroupId ) {
+		if ( ! $this->ldGroupId && bp_is_active( 'groups' ) ) {
 			$this->ldGroupId = $this->loadLdGroupId();
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [X] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2571 

### How to test the changes in this Pull Request:

1. Disable Social Group component.
2. Try adding users with the Group Leader role.

### Proof Screenshots or Video

https://www.loom.com/share/d6366f9fdc0d4c2aaee250c9b1b86cc0

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

