### PR TITLE
#2586 - fix php warning for (BB) Latest Activities widget

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/activity/widgets.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/widgets.php
@@ -88,6 +88,9 @@ class BP_Latest_Activities extends WP_Widget {
 		// Check instance for custom activity types
 		if ( ! empty( $instance['type'] ) ) {
 			$type    = maybe_unserialize( $instance['type'] );
+			if ( ! is_array( $type ) ) {
+				$type = (array) maybe_unserialize( $type );
+			}
 			$classes = array_map( 'sanitize_html_class', array_merge( $type, array( 'bp-latest-activities' ) ) );
 
 			// Add classes to the container
@@ -147,9 +150,9 @@ class BP_Latest_Activities extends WP_Widget {
 			$instance['max'] = $new_instance['max'];
 		}
 
-		$instance['type'] = array( 'activity_update' );
+		$instance['type'] = maybe_serialize( array( 'activity_update' ) );
 		if ( ! empty( $new_instance['type'] ) ) {
-			$instance['type'] = $new_instance['type'];
+			$instance['type'] = maybe_serialize( $new_instance['type'] );
 		}
 
 		return $instance;
@@ -177,6 +180,9 @@ class BP_Latest_Activities extends WP_Widget {
 		$type = array( 'activity_update' );
 		if ( ! empty( $instance['type'] ) ) {
 			$type = maybe_unserialize( $instance['type'] );
+			if ( ! is_array( $type ) ) {
+				$type = (array) maybe_unserialize( $type );
+			}
 		}
 		?>
 		<p>
@@ -192,7 +198,7 @@ class BP_Latest_Activities extends WP_Widget {
 			<label for="<?php echo $this->get_field_id( 'type' ); ?>"><?php esc_html_e( 'Activity Type:', 'buddyboss' ); ?></label>
 			<select class="widefat" multiple="multiple" id="<?php echo $this->get_field_id( 'type' ); ?>" name="<?php echo $this->get_field_name( 'type' ); ?>[]">
 				<?php foreach ( bp_nouveau_get_activity_filters() as $key => $name ) : ?>
-					<option value="<?php echo esc_attr( $key ); ?>" <?php selected( in_array( $key, $type ) ); ?>><?php echo esc_html( $name ); ?></option>
+					<option value="<?php echo esc_attr( $key ); ?>" <?php selected( in_array( $key, $type, true ) ); ?>><?php echo esc_html( $name ); ?></option>
 				<?php endforeach; ?>
 			</select>
 		</p>

--- a/src/bp-templates/bp-nouveau/includes/activity/widgets.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/widgets.php
@@ -147,9 +147,9 @@ class BP_Latest_Activities extends WP_Widget {
 			$instance['max'] = $new_instance['max'];
 		}
 
-		$instance['type'] = maybe_serialize( array( 'activity_update' ) );
+		$instance['type'] = array( 'activity_update' );
 		if ( ! empty( $new_instance['type'] ) ) {
-			$instance['type'] = maybe_serialize( $new_instance['type'] );
+			$instance['type'] = $new_instance['type'];
 		}
 
 		return $instance;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
There was an additional serialize which breaks it and showing a warning. I removed that.

### Connected PR in Platform Pro
https://github.com/buddyboss/buddyboss-platform-pro/pull/179

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2586 .

### How to test the changes in this Pull Request:

1. Go to backend widget
2. Add (BB) Latest Activities widget and save
3. check frontend, the error gone

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?