### PR TITLE
Fix - When submitting signup form, values for fields of type multi-select are not preserved if form is rejected

### DIFF
--- a/src/bp-xprofile/classes/class-bp-xprofile-field-type-multiselectbox.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field-type-multiselectbox.php
@@ -136,7 +136,11 @@ class BP_XProfile_Field_Type_Multiselectbox extends BP_XProfile_Field_Type {
 		$html    = '';
 
 		if ( empty( $original_option_values ) && ! empty( $_POST[ 'field_' . $this->field_obj->id ] ) ) {
-			$original_option_values = sanitize_text_field( $_POST[ 'field_' . $this->field_obj->id ] );
+			if( is_array( $_POST[ 'field_' . $this->field_obj->id ] ) ) {
+				$original_option_values = array_map( 'sanitize_text_field', $_POST[ 'field_' . $this->field_obj->id ] );
+			} else {
+				$original_option_values = sanitize_text_field( $_POST[ 'field_' . $this->field_obj->id ] );
+			}
 		}
 
 		$option_values = ( $original_option_values ) ? (array) $original_option_values : array();


### PR DESCRIPTION
#2534 

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2534 .

### How to test the changes in this Pull Request:

1. Create a multi-select profile field and add it to "details (signup)" field group.
2. Add some test selections for this field.
3. Open an incognito window
4. Navigate to the signup page.
5. Submit the form with an illegal handle.
6. Form should re-display, previous selections in multi-select do not appear.

### Proof Screenshots or Video

https://www.loom.com/share/b1bc320d644547cb9567aecfa6869886

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

