### PR TITLE
Fix: Activity date & time from listview doesn't match with activity date & time when you edit it

### DIFF
--- a/src/bp-activity/bp-activity-admin.php
+++ b/src/bp-activity/bp-activity-admin.php
@@ -841,8 +841,12 @@ function bp_activity_admin_edit_metabox_status( $item ) {
 				<div class="misc-pub-section curtime misc-pub-section-last">
 					<?php
 					// Translators: Publish box date format, see http://php.net/date.
-					$datef = __( 'M j, Y @ G:i', 'buddyboss' );
-					$date  = date_i18n( $datef, strtotime( $item->date_recorded ) );
+					$date  = sprintf(
+								/* translators: 1: activity date, 2: activity time */
+								__( '%1$s @ %2$s', 'buddyboss' ),
+								date_i18n( bp_get_option( 'date_format' ), strtotime( $item->date_recorded) ),
+								get_date_from_gmt( $item->date_recorded, bp_get_option( 'time_format' ) )
+							);
 					?>
 					<span id="timestamp"><?php printf( __( 'Submitted on: %s', 'buddyboss' ), '<strong>' . $date . '</strong>' ); ?></span>&nbsp;<a href="#edit_timestamp" class="edit-timestamp hide-if-no-js" tabindex='4'><?php _e( 'Edit', 'buddyboss' ); ?></a>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2547 

### How to test the changes in this Pull Request:

1. Go to activities and see the date and time.
2. Try to edit it.
3. You will see that the time is not the same as what in list view.

### Proof Screenshots or Video

https://www.loom.com/share/49e305a38cb847ce89e420d191690623

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

Thanks