### PR TITLE
Fixes BB Latest activities widget not shows the private group feed updates even when logged in

### DIFF
--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -221,7 +221,7 @@ function bp_has_activities( $args = '' ) {
 	$scope = bp_activity_default_scope( $scope );
 
 	// Group filtering.
-	if ( bp_is_group() ) {
+	if ( bp_is_active( 'groups' ) ) {
 		$object          = $bp->groups->id;
 		$args['privacy'] = ( isset( $args['privacy'] ) ? $args['privacy'] : array( 'public' ) );
 		$primary_id      = bp_get_current_group_id();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Add function `bp_is_active( 'groups' )` to check, Group component is active or not. Remove function that was checking that the page is a group's single page or not.

### How to test the changes in this Pull Request:

1. Add the latest activities to any page and then go to the private group and create a feed
2. Check the activity in the widget, will not show
3. Check the activity on the news feed page it will show

### Proof Screenshots or Video
<img width="1440" alt="Screenshot 2021-07-22 at 2 15 39 PM" src="https://user-images.githubusercontent.com/25550562/126617333-ed3e965c-fa23-42a3-afb5-4c5e69e8bb31.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
