### PR TITLE
fix/2536 > GIF disappears in the activity post once read more has bee…

### DIFF
--- a/src/bp-media/bp-media-filters.php
+++ b/src/bp-media/bp-media-filters.php
@@ -290,6 +290,45 @@ function bp_media_activity_append_media( $content, $activity ) {
 }
 
 /**
+ * Append the gif content to activity read more content
+ *
+ * @since BuddyBoss 1.7.4
+ *
+ * @param $content
+ * @param $activity
+ *
+ * @return string
+ */
+function bp_gif_activity_append_gif( $content, $activity ) {
+	$gif_data = bp_activity_get_meta( $activity->id, '_gif_data', true );
+	if ( ! empty( $gif_data ) ) {
+		
+		$preview_url = ( is_int( $gif_data['still'] ) ) ? wp_get_attachment_url( $gif_data['still'] ) : $gif_data['still'];
+		$video_url   = ( is_int( $gif_data['mp4'] ) ) ? wp_get_attachment_url( $gif_data['mp4'] ) : $gif_data['mp4'];
+		$preview_url = $preview_url . '?' . wp_rand() . '=' . wp_rand();
+		$video_url   = $video_url . '?' . wp_rand() . '=' . wp_rand();
+		ob_start();
+		?>
+		<div class="activity-attached-gif-container">
+			<div class="gif-image-container">
+				<div class="gif-player">
+					<video preload="auto" playsinline poster="<?php echo $preview_url; ?>" loop muted>
+						<source src="<?php echo $video_url; ?>" type="video/mp4">
+					</video>
+					<a href="#" class="gif-play-button">
+						<span class="bb-icon-play-thin"></span>
+					</a>
+					<span class="gif-icon"></span>
+				</div>
+			</div>
+		</div>
+		<?php
+		$content .= ob_get_clean();
+	}
+	return $content;
+}
+
+/**
  * Get activity comment entry media to render on front end
  */
 function bp_media_activity_comment_entry( $comment_id ) {

--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -350,6 +350,7 @@ function bp_nouveau_ajax_get_single_activity_content() {
 		add_filter( 'bp_get_activity_content_body', 'bp_media_activity_append_media', 20, 2 );
 		add_filter( 'bp_get_activity_content_body', 'bp_video_activity_append_video', 20, 2 );
 		add_filter( 'bp_get_activity_content_body', 'bp_document_activity_append_document', 20, 2 );
+		add_filter( 'bp_get_activity_content_body', 'bp_gif_activity_append_gif', 20, 2 );
 	}
 
 	/** This filter is documented in bp-activity/bp-activity-template.php */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2536 .

### How to test the changes in this Pull Request:

1. Go to activity feed
2. Post a long text with GIF attached
3. After posting, try to click the read more link
4. Notice the issue

### Proof Screenshots or Video
https://www.loom.com/share/b0b78391dc24443dbbde1a3d5d2e5b14

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
