### PR TITLE
Fix php notice in admin components active tab

### DIFF
--- a/src/bp-core/admin/bp-core-admin-components.php
+++ b/src/bp-core/admin/bp-core-admin-components.php
@@ -115,12 +115,16 @@ function bp_core_admin_components_options() {
 			break;
 		case 'active':
 			foreach ( array_keys( $active_components ) as $component ) {
-				$current_components[ $component ] = $all_components[ $component ];
+				if ( isset( $all_components[ $component ] ) ) {
+					$current_components[ $component ] = $all_components[ $component ];
+				}
 			}
 			break;
 		case 'inactive':
 			foreach ( $inactive_components as $component ) {
-				$current_components[ $component ] = $all_components[ $component ];
+				if ( isset( $all_components[ $component ] ) ) {
+					$current_components[ $component ] = $all_components[ $component ];
+				}
 			}
 			break;
 		case 'mustuse':


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #ISSUE_NUMBER .

### How to test the changes in this Pull Request:

1. Go to BuddyBoss > Components
2. Activate the Media Component.
3. Go to the Active component list and see the notice in the log.

### Proof Screenshots or Video
http://prntscr.com/1gl5i8f

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

