### PR TITLE
Added Function check for group component is active on Phots and Videos directory page

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/media/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/media/functions.php
@@ -227,7 +227,7 @@ function bp_nouveau_get_media_directory_nav_items() {
 		);
 	}
 
-	if ( is_user_logged_in() && bp_is_group_media_support_enabled() ) {
+	if ( is_user_logged_in() && bp_is_group_media_support_enabled() && bp_is_active( 'groups' ) ) {
 		$nav_items['group'] = array(
 			'component' => 'media',
 			'slug'      => 'groups', // slug is used because BP_Core_Nav requires it, but it's the scope.

--- a/src/bp-templates/bp-nouveau/includes/video/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/video/functions.php
@@ -202,7 +202,7 @@ function bp_nouveau_get_video_directory_nav_items() {
 		);
 	}
 
-	if ( is_user_logged_in() && bp_is_group_video_support_enabled() ) {
+	if ( is_user_logged_in() && bp_is_group_video_support_enabled() && bp_is_active( 'groups' ) ) {
 		$nav_items['group'] = array(
 			'component' => 'video',
 			'slug'      => 'groups', // slug is used because BP_Core_Nav requires it, but it's the scope.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2654 .

### How to test the changes in this Pull Request:

1. Go to Settings>Components>deactivate 'social group'
2. Go to Videos directory tab.
3. See mismatch and interchange of photos between tab, count is wrong and also 'My groups' tab is appearing.

### Proof Screenshots or Video

https://www.loom.com/share/fe682eaf770542e397e984e12b1f12fc

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
