### PR TITLE
Fix link preview does not refresh while updating the url

### DIFF
--- a/src/bp-templates/bp-nouveau/js/buddypress-activity-post-form.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-activity-post-form.js
@@ -1885,7 +1885,6 @@ window.bp = window.bp || {};
 
 			handleKeyUp: function () {
 				var self = this;
-
 				if ( this.linkTimeout != null ) {
 					clearTimeout( this.linkTimeout );
 				}
@@ -1977,8 +1976,7 @@ window.bp = window.bp || {};
 				var regexp = /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,24}(:[0-9]{1,5})?(\/.*)?$/;
 				url        = $.trim( url );
 				if ( regexp.test( url ) ) {
-
-					if ( ! _.isUndefined( self.options.activity.get( 'link_success' ) ) && self.options.activity.get( 'link_success' ) == true ) {
+					if ( ( ! _.isUndefined( self.options.activity.get( 'link_success' ) ) && self.options.activity.get( 'link_success' ) == true ) && self.options.activity.get( 'link_url' ) === url ) {
 						return false;
 					}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a chcek to validate the current url. If the current URL and the changed URL are the same then it will not make a request for a new preview.

Fixes #2164

### How to test the changes in this Pull Request:

1. Add URLs to activity editor or write some URL.
2. Now preview should be there.
3. Try to change the URL and the preview will change as per the URL.

### Proof Screenshots or Video
https://www.awesomescreenshot.com/video/4751895?key=68e1a4310759b780673b422410c8ea7d

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
