### PR TITLE
Members widget not working when Member Connections component is disabled - Fixed

### DIFF
--- a/src/bp-members/bp-members-widgets.php
+++ b/src/bp-members/bp-members-widgets.php
@@ -115,13 +115,13 @@ function bp_core_ajax_widget_members() {
                 <div class="item">
                     <div class="item-title fn"><a href="<?php bp_member_permalink(); ?>"><?php bp_member_name(); ?></a></div>
                     <div class="item-meta">
-						<?php if ( 'newest' == $settings['member_default'] ) : ?>
+	                    <?php if ( 'newest' == $settings['member_default'] ) : ?>
                             <span class="activity" data-livestamp="<?php bp_core_iso8601_date( bp_get_member_registered( array( 'relative' => false ) ) ); ?>"><?php bp_member_registered(); ?></span>
-						<?php elseif ( 'active' == $settings['member_default'] ) : ?>
+	                    <?php elseif ( 'active' == $settings['member_default'] ) : ?>
                             <span class="activity" data-livestamp="<?php bp_core_iso8601_date( bp_get_member_last_active( array( 'relative' => false ) ) ); ?>"><?php bp_member_last_active(); ?></span>
-						<?php else : ?>
-                            <span class="activity"><?php bp_is_active( 'friends' ) ? bp_member_total_friend_count() : ''; ?></span>
-						<?php endif; ?>
+	                    <?php elseif ( bp_is_active( 'friends' ) ) : ?>
+                            <span class="activity"><?php bp_member_total_friend_count(); ?></span>
+	                    <?php endif; ?>
                     </div>
                 </div>
                 <div class="member_last_visit"></div>

--- a/src/bp-members/bp-members-widgets.php
+++ b/src/bp-members/bp-members-widgets.php
@@ -120,7 +120,7 @@ function bp_core_ajax_widget_members() {
 						<?php elseif ( 'active' == $settings['member_default'] ) : ?>
                             <span class="activity" data-livestamp="<?php bp_core_iso8601_date( bp_get_member_last_active( array( 'relative' => false ) ) ); ?>"><?php bp_member_last_active(); ?></span>
 						<?php else : ?>
-                            <span class="activity"><?php bp_member_total_friend_count(); ?></span>
+                            <span class="activity"><?php bp_is_active( 'friends' ) ? bp_member_total_friend_count() : ''; ?></span>
 						<?php endif; ?>
                     </div>
                 </div>

--- a/src/bp-members/classes/class-bp-core-members-widget.php
+++ b/src/bp-members/classes/class-bp-core-members-widget.php
@@ -172,7 +172,7 @@ class BP_Core_Members_Widget extends WP_Widget {
 								<?php elseif ( 'active' == $settings['member_default'] ) : ?>
                                     <span class="activity"
                                           data-livestamp="<?php bp_core_iso8601_date( bp_get_member_last_active( array( 'relative' => false ) ) ); ?>"><?php bp_member_last_active(); ?></span>
-								<?php else : ?>
+								<?php elseif ( bp_is_active( 'friends' ) ) : ?>
                                     <span class="activity"><?php bp_member_total_friend_count(); ?></span>
 								<?php endif; ?>
                             </div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1139  .

### How to test the changes in this Pull Request:

1. Add Members widget in any page
2. Deactivate Member connection component
3. See the issue is not happening any more

### Proof Screenshots or Video

https://www.loom.com/share/14d694a030db464d89c415c3fdef8bc7

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
