### PR TITLE
Activity Post on Public Group to Private Group do not change the privacy of the post - Fixed

### DIFF
--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -378,7 +378,15 @@ function groups_edit_group_settings( $group_id, $enable_forum, $status, $invite_
 	 * from public and there are existing activity feed, change feed status private. ( hide_sitewide = 1 )
 	 */
 	if ( 'public' === $group->status && 'private' === $status ) {
-		groups_make_all_activity_feed_status_private( $group->id );
+		groups_change_all_activity_feed_status( $group->id, 1 );
+	}
+
+	/**
+	 * Before we potentially switch the group status, if it has been changed to public
+	 * from private and there are existing activity feed, change feed status public. ( hide_sitewide = 0 )
+	 */
+	if ( 'private' === $group->status && 'public' === $status ) {
+		groups_change_all_activity_feed_status( $group->id, 0 );
 	}
 
 	// Now update the status.
@@ -2661,15 +2669,16 @@ function groups_get_membership_requested_user_ids( $group_id = 0 ) {
 }
 
 /**
- * Make all activity feed status to private to a group.
+ * Change all activity feed status for a group.
  *
  * @since BuddyPress 1.7.6
  *
  * @param int $group_id ID of the group.
+ * @param int $status ( 1 = private, 0 = public )
  *
  * @return bool True on success, false on failure.
  */
-function groups_make_all_activity_feed_status_private( $group_id = 0 ) {
+function groups_change_all_activity_feed_status( $group_id = 0, $status = 0 ) {
 	global $wpdb, $bp;
 
 	//bail if no group_id
@@ -2677,7 +2686,7 @@ function groups_make_all_activity_feed_status_private( $group_id = 0 ) {
 		return false;
 	}
 
-	$q = $wpdb->prepare( "UPDATE {$bp->activity->table_name} SET hide_sitewide = 1 WHERE item_id = %d and component = 'groups'", $group_id );
+	$q = $wpdb->prepare( "UPDATE {$bp->activity->table_name} SET hide_sitewide = %d WHERE item_id = %d and component = 'groups'", $status, $group_id );
 	if ( false === $wpdb->query( $q ) ) {
 		return false;
 	}
@@ -2689,7 +2698,7 @@ function groups_make_all_activity_feed_status_private( $group_id = 0 ) {
 	 *
 	 * @param int $group_id ID of the group.
 	 */
-	do_action( 'groups_make_all_activity_feed_status_private', $group_id );
+	do_action( 'groups_change_all_activity_feed_status', $status, $group_id );
 
 	return true;
 }

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -377,7 +377,7 @@ function groups_edit_group_settings( $group_id, $enable_forum, $status, $invite_
 	 * Before we potentially switch the group status, if it has been changed to private
 	 * from public and there are existing activity feed, change feed status private. ( hide_sitewide = 1 )
 	 */
-	if ( 'public' === $group->status && 'private' === $status ) {
+	if ( 'public' === $group->status && ( 'private' === $status || 'hidden' === $status ) ) {
 		groups_change_all_activity_feed_status( $group->id, 1 );
 	}
 

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -385,7 +385,7 @@ function groups_edit_group_settings( $group_id, $enable_forum, $status, $invite_
 	 * Before we potentially switch the group status, if it has been changed to public
 	 * from private and there are existing activity feed, change feed status public. ( hide_sitewide = 0 )
 	 */
-	if ( 'private' === $group->status && 'public' === $status ) {
+	if ( ( 'private' === $group->status || 'hidden' === $group->status ) && 'public' === $status ) {
 		groups_change_all_activity_feed_status( $group->id, 0 );
 	}
 

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -2663,9 +2663,10 @@ function groups_get_membership_requested_user_ids( $group_id = 0 ) {
 /**
  * Make all activity feed status to private to a group.
  *
- * @since BuddyPress 1.7.4
+ * @since BuddyPress 1.7.6
  *
  * @param int $group_id ID of the group.
+ *
  * @return bool True on success, false on failure.
  */
 function groups_make_all_activity_feed_status_private( $group_id = 0 ) {
@@ -2684,7 +2685,7 @@ function groups_make_all_activity_feed_status_private( $group_id = 0 ) {
 	/**
 	 * Fires after makeing all activity feed status to private to a group.
 	 *
-	 * @since BuddyPress 1.7.4
+	 * @since BuddyPress 1.7.6
 	 *
 	 * @param int $group_id ID of the group.
 	 */

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -2686,7 +2686,7 @@ function groups_change_all_activity_feed_status( $group_id = 0, $status = 0 ) {
 		return false;
 	}
 
-	$q = $wpdb->prepare( "UPDATE {$bp->activity->table_name} SET hide_sitewide = %d WHERE item_id = %d and component = 'groups'", $status, $group_id );
+	$q = $wpdb->prepare( "UPDATE {$bp->activity->table_name} SET hide_sitewide = %d WHERE item_id = %d and component = 'groups' AND privacy = 'public' ", $status, $group_id );
 	if ( false === $wpdb->query( $q ) ) {
 		return false;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2171  .

### How to test the changes in this Pull Request:

1. Create activity post on a public group
2. Change the group status to private
3. View as another user who is not a member of that group
4. See the activity feed
5. You will not see that group feed anymore

### Proof Screenshots or Video

https://www.loom.com/share/4716f0e88963454ab4f2201fb3503d44

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
