### PR TITLE
#2690 - quick reply ajax

### DIFF
--- a/src/bp-forums/common/template.php
+++ b/src/bp-forums/common/template.php
@@ -1776,7 +1776,7 @@ function bbp_reply_form_fields() {
 		<input type="hidden" name="bbp_reply_to"    id="bbp_reply_to"    value="<?php bbp_form_reply_to(); ?>" />
 		<input type="hidden" name="action"          id="bbp_post_action" value="bbp-edit-reply" />
 		<input type="hidden" name="bbp_redirect_page_to" id="bbp_redirect_page_to" value="<?php echo intval( $forum_redirect_to ); ?>" />
-	
+
 		<?php
 		if ( current_user_can( 'unfiltered_html' ) ) {
 			wp_nonce_field( 'bbp-unfiltered-html-reply_' . bbp_get_reply_id(), '_bbp_unfiltered_html_reply', false );}
@@ -1786,9 +1786,16 @@ function bbp_reply_form_fields() {
 		wp_nonce_field( 'bbp-edit-reply_' . bbp_get_reply_id() );
 
 	else :
+
+		if ( isset ( $_POST['topic_id'] ) && ! empty( $_POST['topic_id'] ) ) {
+			$topic_id = $_POST['topic_id'];
+		}else{
+			$topic_id = bbp_get_topic_id();
+		}
+
 		?>
 
-		<input type="hidden" name="bbp_topic_id"    id="bbp_topic_id"    value="<?php bbp_topic_id(); ?>" />
+		<input type="hidden" name="bbp_topic_id"    id="bbp_topic_id"    value="<?php echo $topic_id; ?>" />
 		<input type="hidden" name="bbp_reply_to"    id="bbp_reply_to"    value="<?php bbp_form_reply_to(); ?>" />
 		<input type="hidden" name="action"          id="bbp_post_action" value="bbp-new-reply" />
 

--- a/src/bp-forums/common/template.php
+++ b/src/bp-forums/common/template.php
@@ -1786,16 +1786,9 @@ function bbp_reply_form_fields() {
 		wp_nonce_field( 'bbp-edit-reply_' . bbp_get_reply_id() );
 
 	else :
-
-		if ( isset ( $_POST['topic_id'] ) && ! empty( $_POST['topic_id'] ) ) {
-			$topic_id = $_POST['topic_id'];
-		} else {
-			$topic_id = bbp_get_topic_id();
-		}
-
 		?>
 
-		<input type="hidden" name="bbp_topic_id"    id="bbp_topic_id"    value="<?php echo esc_attr( $topic_id ); ?>" />
+		<input type="hidden" name="bbp_topic_id"    id="bbp_topic_id"    value="<?php bbp_topic_id(); ?>" />
 		<input type="hidden" name="bbp_reply_to"    id="bbp_reply_to"    value="<?php bbp_form_reply_to(); ?>" />
 		<input type="hidden" name="action"          id="bbp_post_action" value="bbp-new-reply" />
 

--- a/src/bp-forums/common/template.php
+++ b/src/bp-forums/common/template.php
@@ -1789,13 +1789,13 @@ function bbp_reply_form_fields() {
 
 		if ( isset ( $_POST['topic_id'] ) && ! empty( $_POST['topic_id'] ) ) {
 			$topic_id = $_POST['topic_id'];
-		}else{
+		} else {
 			$topic_id = bbp_get_topic_id();
 		}
 
 		?>
 
-		<input type="hidden" name="bbp_topic_id"    id="bbp_topic_id"    value="<?php echo $topic_id; ?>" />
+		<input type="hidden" name="bbp_topic_id"    id="bbp_topic_id"    value="<?php echo esc_attr( $topic_id ); ?>" />
 		<input type="hidden" name="bbp_reply_to"    id="bbp_reply_to"    value="<?php bbp_form_reply_to(); ?>" />
 		<input type="hidden" name="action"          id="bbp_post_action" value="bbp-new-reply" />
 

--- a/src/bp-forums/templates/default/bbpress/form-attachments.php
+++ b/src/bp-forums/templates/default/bbpress/form-attachments.php
@@ -6,8 +6,10 @@
  * @package BuddyBoss\Theme
  */
 
-$group_id = 0;
-$forum_id = 0;
+$group_id = apply_filters( 'bb_forum_attachment_group_id', 0 );
+$forum_id = apply_filters( 'bb_forum_attachment_forum_id', 0 );
+$topic_id = apply_filters( 'bb_forum_attachment_topic_id', 0 );
+
 if ( bp_is_active( 'groups' ) && bp_is_group_single() ) {
 	$group_id = bp_get_current_group_id();
 }

--- a/src/bp-forums/templates/default/bbpress/form-attachments.php
+++ b/src/bp-forums/templates/default/bbpress/form-attachments.php
@@ -8,14 +8,6 @@
 
 $group_id = 0;
 $forum_id = 0;
-
-if ( isset ( $_POST['topic_id'] ) && ! empty( $_POST['topic_id'] ) ) {
-	$forum_id = bbp_get_topic_forum_id( $_POST['topic_id'] );
-}
-if ( isset ( $_POST['group_id'] ) && ! empty( $_POST['group_id'] ) ) {
-	$group_id = $_POST['group_id'];
-}
-
 if ( bp_is_active( 'groups' ) && bp_is_group_single() ) {
 	$group_id = bp_get_current_group_id();
 }

--- a/src/bp-forums/templates/default/bbpress/form-attachments.php
+++ b/src/bp-forums/templates/default/bbpress/form-attachments.php
@@ -8,6 +8,14 @@
 
 $group_id = 0;
 $forum_id = 0;
+
+if ( isset ( $_POST['topic_id'] ) && ! empty( $_POST['topic_id'] ) ) {
+	$forum_id = bbp_get_topic_forum_id( $_POST['topic_id'] );
+}
+if ( isset ( $_POST['group_id'] ) && ! empty( $_POST['group_id'] ) ) {
+	$group_id = $_POST['group_id'];
+}
+
 if ( bp_is_active( 'groups' ) && bp_is_group_single() ) {
 	$group_id = bp_get_current_group_id();
 }

--- a/src/bp-templates/bp-nouveau/js/buddypress-media.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-media.js
@@ -2185,6 +2185,11 @@ window.bp = window.bp || {};
 				var dropzone_obj_key = dropzone_container.data( 'key' );
 				if ( dropzone_container.hasClass( 'closed' ) ) {
 
+					if (  self.options.previewTemplate !== 'undefined' && self.options.previewTemplate == '' ) {
+						var ForumMediaTemplate = document.getElementsByClassName('forum-post-media-template').length ? document.getElementsByClassName('forum-post-media-template')[0].innerHTML : ''; //Check to avoid error if Node is missing.
+						self.options.previewTemplate = ForumMediaTemplate;
+					}
+
 					// init dropzone.
 					self.dropzone_obj[ dropzone_obj_key ] = new Dropzone( dropzone_container[ 0 ], self.options );
 					self.dropzone_media[ dropzone_obj_key ] = [];
@@ -2870,6 +2875,11 @@ window.bp = window.bp || {};
 
 				if ( dropzone_container.hasClass( 'closed' ) ) {
 
+					if (  self.documentOptions.previewTemplate !== 'undefined' && self.documentOptions.previewTemplate == '' ) {
+						var ForumDocumentTemplates = document.getElementsByClassName('forum-post-document-template').length ? document.getElementsByClassName('forum-post-document-template')[0].innerHTML : ''; //Check to avoid error if Node is missing.
+						self.documentOptions.previewTemplate = ForumDocumentTemplates;
+					}
+
 					// init dropzone.
 					self.dropzone_obj[ dropzone_obj_key ] = new Dropzone( dropzone_container[ 0 ], self.documentOptions );
 					self.dropzone_media[ dropzone_obj_key ] = [];
@@ -3107,6 +3117,11 @@ window.bp = window.bp || {};
 				var dropzone_obj_key = dropzone_container.data( 'key' );
 
 				if ( dropzone_container.hasClass( 'closed' ) ) {
+
+					if (  self.videoOptions.previewTemplate !== 'undefined' && self.videoOptions.previewTemplate == '' ) {
+						var ForumVideoTemplate = document.getElementsByClassName('forum-post-video-template').length ? document.getElementsByClassName('forum-post-video-template')[0].innerHTML : ''; //Check to avoid error if Node is missing.
+						self.videoOptions.previewTemplate = ForumVideoTemplate;
+					}
 
 					// init dropzone.
 					self.dropzone_obj[ dropzone_obj_key ] = new Dropzone( dropzone_container[ 0 ], self.videoOptions );

--- a/src/bp-templates/bp-nouveau/js/buddypress-media.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-media.js
@@ -2185,11 +2185,6 @@ window.bp = window.bp || {};
 				var dropzone_obj_key = dropzone_container.data( 'key' );
 				if ( dropzone_container.hasClass( 'closed' ) ) {
 
-					if (  self.options.previewTemplate !== 'undefined' && self.options.previewTemplate == '' ) {
-						var ForumMediaTemplate = document.getElementsByClassName('forum-post-media-template').length ? document.getElementsByClassName('forum-post-media-template')[0].innerHTML : ''; //Check to avoid error if Node is missing.
-						self.options.previewTemplate = ForumMediaTemplate;
-					}
-
 					// init dropzone.
 					self.dropzone_obj[ dropzone_obj_key ] = new Dropzone( dropzone_container[ 0 ], self.options );
 					self.dropzone_media[ dropzone_obj_key ] = [];
@@ -2875,11 +2870,6 @@ window.bp = window.bp || {};
 
 				if ( dropzone_container.hasClass( 'closed' ) ) {
 
-					if (  self.documentOptions.previewTemplate !== 'undefined' && self.documentOptions.previewTemplate == '' ) {
-						var ForumDocumentTemplates = document.getElementsByClassName('forum-post-document-template').length ? document.getElementsByClassName('forum-post-document-template')[0].innerHTML : ''; //Check to avoid error if Node is missing.
-						self.documentOptions.previewTemplate = ForumDocumentTemplates;
-					}
-
 					// init dropzone.
 					self.dropzone_obj[ dropzone_obj_key ] = new Dropzone( dropzone_container[ 0 ], self.documentOptions );
 					self.dropzone_media[ dropzone_obj_key ] = [];
@@ -3117,11 +3107,6 @@ window.bp = window.bp || {};
 				var dropzone_obj_key = dropzone_container.data( 'key' );
 
 				if ( dropzone_container.hasClass( 'closed' ) ) {
-
-					if (  self.videoOptions.previewTemplate !== 'undefined' && self.videoOptions.previewTemplate == '' ) {
-						var ForumVideoTemplate = document.getElementsByClassName('forum-post-video-template').length ? document.getElementsByClassName('forum-post-video-template')[0].innerHTML : ''; //Check to avoid error if Node is missing.
-						self.videoOptions.previewTemplate = ForumVideoTemplate;
-					}
 
 					// init dropzone.
 					self.dropzone_obj[ dropzone_obj_key ] = new Dropzone( dropzone_container[ 0 ], self.videoOptions );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Implemented ajax to load the popup for the quick reply as we need to pass topic id and group id if the forum is associated with a group

Fixes #2690  .

### How to test the changes in this Pull Request:

1. Go to buddyboss > settings > media access
2. Set media access for target user
3. Login to a user who does not have access to upload media, documents and videos
4. Created a discussion from a group forum
5. Go to news feed page and find that post
6. click on quick reply and test adding post including photos, video & documents

### Proof Screenshots or Video
https://www.loom.com/share/617147c2f53a4d00b36687bb29c0c31a

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Related Theme PR
https://github.com/buddyboss/buddyboss-theme/pull/1584