### PR TITLE
Fix - Security/Privacy issue /all-members still visible when core bpcore_remove_subnav_item used to remove members + all-members tabs

### DIFF
--- a/src/bp-groups/screens/single/members/all-members.php
+++ b/src/bp-groups/screens/single/members/all-members.php
@@ -13,7 +13,15 @@
  */
 function groups_screen_group_members_all_members() {
 
-	if ( 'all-members' != bp_get_group_current_members_tab() ) {
+	// should also not accessible if members slug is removed
+	$members_menu_removed = true;
+	foreach ( bp_get_nav_menu_items('groups') as $nav_item ) {
+		if( $nav_item->css_id == 'members' ) {
+			$members_menu_removed = false;
+		}
+	}
+
+	if ( 'all-members' != bp_get_group_current_members_tab() || $members_menu_removed ) {
 		return false;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1376.

### How to test the changes in this Pull Request:

1. Add the snippet below to functions.php
```
function bp_remove_group_tabs() {
  global $bp;
  if ( is_user_logged_in()) {
    $slug = bp_get_current_group_slug();
    bp_core_remove_subnav_item( $slug, 'members' );
  }
}
add_action( 'bp_actions', 'bp_remove_group_tabs' );
```
2. Check the group all members link.
3. Should show 404 page.

### Proof Screenshots or Video

https://www.loom.com/share/683b9af564534721af33ee97f0d9b1de

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed the issue with all members link in group even after removed thru bp_core_remove_subnav_item function.