### PR TITLE
PROD-755 BuddyBoss component pages are rendered blank on Platform + Multisite + TranslatePress - Fixed

### DIFF
--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -154,6 +154,30 @@ function bp_helper_plugins_loaded_callback() {
 
 		add_filter( 'wdmir_exclude_post_types', 'bp_core_instructor_role_post_exclude', 10, 1 );
 	}
+
+	if ( in_array( 'translatepress-multilingual/index.php', $bp_plugins, true ) && is_multisite() ) {
+
+		/**
+		 * Exclude translatepress lang slug from URL path for only multisite
+		 * Fix for the issue: #2835
+		 *
+		 * @param string $path
+		 * @return string $path
+		 */
+		function bb_core_multisite_multilang_translatepress_exclude_lang_slug( $path ) {
+			if( ! is_admin() ) {
+				$tp_settings = get_option( 'trp_settings' );
+				if ( $tp_settings && isset( $tp_settings['url-slugs'] ) && !empty( $tp_settings['url-slugs'] ) ) {
+					foreach ( $tp_settings['url-slugs'] as $lang_key => $lang_slug ) {
+					$path = str_replace( $lang_slug . '/', '', $path );
+					}
+				}
+			}
+			return $path;
+		}
+
+		add_filter( 'bp_uri', 'bb_core_multisite_multilang_translatepress_exclude_lang_slug' );
+	}
 }
 
 add_action( 'init', 'bp_helper_plugins_loaded_callback', 0 );

--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -159,21 +159,23 @@ function bp_helper_plugins_loaded_callback() {
 
 		/**
 		 * Exclude translatepress lang slug from URL path for only multisite
-		 * Fix for the issue: #2835
+		 * 
+		 * @since BuddyBoss [BBVERSION]
 		 *
-		 * @param string $path
-		 * @return string $path
+		 * @param string $url URL with Language code
+		 * 
+		 * @return string $url URL without language code
 		 */
-		function bb_core_multisite_multilang_translatepress_exclude_lang_slug( $path ) {
+		function bb_core_multisite_multilang_translatepress_exclude_lang_slug( $url ) {
 			if( ! is_admin() ) {
 				$tp_settings = get_option( 'trp_settings' );
 				if ( $tp_settings && isset( $tp_settings['url-slugs'] ) && !empty( $tp_settings['url-slugs'] ) ) {
 					foreach ( $tp_settings['url-slugs'] as $lang_key => $lang_slug ) {
-					$path = str_replace( $lang_slug . '/', '', $path );
+					$url = str_replace( $lang_slug . '/', '', $url );
 					}
 				}
 			}
-			return $path;
+			return $url;
 		}
 
 		add_filter( 'bp_uri', 'bb_core_multisite_multilang_translatepress_exclude_lang_slug' );

--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -158,20 +158,20 @@ function bp_helper_plugins_loaded_callback() {
 	if ( in_array( 'translatepress-multilingual/index.php', $bp_plugins, true ) && is_multisite() ) {
 
 		/**
-		 * Exclude translatepress lang slug from URL path for only multisite
+		 * Exclude translatepress lang slug from URL path for only multisite.
 		 * 
 		 * @since BuddyBoss [BBVERSION]
 		 *
-		 * @param string $url URL with Language code
+		 * @param string $url URL with Language code.
 		 * 
-		 * @return string $url URL without language code
+		 * @return string $url URL without language code.
 		 */
 		function bb_core_multisite_multilang_translatepress_exclude_lang_slug( $url ) {
-			if( ! is_admin() ) {
+			if ( ! is_admin() ) {
 				$tp_settings = get_option( 'trp_settings' );
-				if ( $tp_settings && isset( $tp_settings['url-slugs'] ) && !empty( $tp_settings['url-slugs'] ) ) {
+				if ( $tp_settings && isset( $tp_settings['url-slugs'] ) && ! empty( $tp_settings['url-slugs'] ) ) {
 					foreach ( $tp_settings['url-slugs'] as $lang_key => $lang_slug ) {
-					$url = str_replace( $lang_slug . '/', '', $url );
+						$url = str_replace( $lang_slug . '/', '', $url );
 					}
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2835  .

### How to test the changes in this Pull Request:

1. Create a Multisite environment
2. Install BuddyBoss Theme, Platform and TranslatePress
3. In TranslatePress, create another language aside from default language
4. In front end, check BuddyBoss pages (activity page for instance ) and try to switch language.
5. See error is not happening anymore

### Proof Screenshots or Video

https://www.loom.com/share/ed7b21c45676430fa070a74208157588

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
