### PR TITLE
#2535 - Fix PHP Error: Network search not works if forums deleted

### DIFF
--- a/src/bp-search/classes/class-bp-search-bbpress-forums-topics.php
+++ b/src/bp-search/classes/class-bp-search-bbpress-forums-topics.php
@@ -173,7 +173,9 @@ if ( ! class_exists( 'Bp_Search_bbPress_Topics' ) ) :
 			);
 
 			$forum_id_in   = implode( ',', $forum_ids );
-			
+			if ( empty( $forum_id_in ) ) {
+				$forum_id_in = 0;
+			}
 			$where   = array();
 			$where[] = '1=1';
 			$where[] = "(post_title LIKE %s OR ExtractValue(post_content, '//text()') LIKE %s)";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2535 

### How to test the changes in this Pull Request:

1. Search on the network bar with the name of a user and you will get a result
2. Now remove all the forums and search again
3. See Search result

### Proof Screenshots or Video
https://www.awesomescreenshot.com/video/5077444?key=2f234d89b79599868599409dff1b6c89

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
