### PR TITLE
#2751-Fix-Disappearing Comma on Members Page after ajax request

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/ajax.php
@@ -165,12 +165,12 @@ function bp_nouveau_object_template_results_members_tabs( $results, $object ) {
 
 	add_filter( 'bp_ajax_querystring', 'bp_member_object_template_results_members_all_scope', 20, 2 );
 	bp_has_members( bp_ajax_querystring( 'members' ) );
-	$results['scopes']['all'] = $GLOBALS['members_template']->total_member_count;
+	$results['scopes']['all'] = bp_core_number_format( $GLOBALS['members_template']->total_member_count );
 	remove_filter( 'bp_ajax_querystring', 'bp_member_object_template_results_members_all_scope', 20, 2 );
 
 	add_filter( 'bp_ajax_querystring', 'bp_nouveau_object_template_results_members_personal_scope', 20, 2 );
 	bp_has_members( bp_ajax_querystring( 'members' ) );
-	$results['scopes']['personal'] = $GLOBALS['members_template']->total_member_count;
+	$results['scopes']['personal'] = bp_core_number_format( $GLOBALS['members_template']->total_member_count );
 	remove_filter( 'bp_ajax_querystring', 'bp_nouveau_object_template_results_members_personal_scope', 20, 2 );
 
 	if ( bp_is_active( 'activity' ) && bp_is_activity_follow_active() ) {
@@ -178,7 +178,7 @@ function bp_nouveau_object_template_results_members_tabs( $results, $object ) {
 		if ( ! empty( $counts['following'] ) ) {
 			add_filter( 'bp_ajax_querystring', 'bp_nouveau_object_template_results_members_following_scope', 20, 2 );
 			bp_has_members( bp_ajax_querystring( 'members' ) );
-			$results['scopes']['following'] = $GLOBALS['members_template']->total_member_count;
+			$results['scopes']['following'] = bp_core_number_format( $GLOBALS['members_template']->total_member_count );
 			remove_filter( 'bp_ajax_querystring', 'bp_nouveau_object_template_results_members_following_scope', 20, 2 );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2751 

### How to test the changes in this Pull Request:

1. Go to 'Member page'
2. See the member count is showing.
3. Once the ajax request is complete, the comma from the member count disappears.

### Proof Screenshots or Video

https://www.loom.com/share/8a7cf84a9a894f20a0f58bf8178f3c4d

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
