### PR TITLE
Fix #1479 Error when user posting group post via site wide activity page

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -703,6 +703,12 @@ function bp_nouveau_ajax_post_update() {
 
 				$is_private = 'public' !== $status;
 			}
+		} else {
+			wp_send_json_error(
+				array(
+					'message' => ( ! $item_id ) ? __( 'There was a problem posting your update. Please set the group details properly.', 'buddyboss' ): __( 'There was a problem posting your update. Group component is disabled, it should be enabled.', 'buddyboss' ),
+				)
+			);
 		}
 	} else {
 		/** This filter is documented in bp-activity/bp-activity-actions.php */

--- a/src/languages/buddyboss.pot
+++ b/src/languages/buddyboss.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BuddyBoss Platform 1.7.7\n"
 "Report-Msgid-Bugs-To: https://www.buddyboss.com/contact/\n"
-"POT-Creation-Date: 2021-09-15 12:29:47+00:00\n"
+"POT-Creation-Date: 2021-09-16 09:32:24+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -8052,13 +8052,13 @@ msgstr ""
 
 #: bp-core/deprecated/buddypress/1.5.php:376
 msgid ""
-"%1$s mentioned you in the group \"%2$s\":\n"
-"\n"
-"\"%3$s\"\n"
-"\n"
-"To view and respond to the message, log in and visit: %4$s\n"
-"\n"
-"---------------------\n"
+"%1$s mentioned you in the group \"%2$s\":\r\n"
+"\r\n"
+"\"%3$s\"\r\n"
+"\r\n"
+"To view and respond to the message, log in and visit: %4$s\r\n"
+"\r\n"
+"---------------------\r\n"
 msgstr ""
 
 #: bp-core/deprecated/buddypress/1.6.php:154
@@ -25261,23 +25261,35 @@ msgstr[1] ""
 msgid "You don't have access to do a activity."
 msgstr ""
 
-#: bp-templates/bp-nouveau/includes/activity/ajax.php:715
+#: bp-templates/bp-nouveau/includes/activity/ajax.php:709
+msgid ""
+"There was a problem posting your update. Please set the group details "
+"properly."
+msgstr ""
+
+#: bp-templates/bp-nouveau/includes/activity/ajax.php:709
+msgid ""
+"There was a problem posting your update. Group component is disabled, it "
+"should be enabled."
+msgstr ""
+
+#: bp-templates/bp-nouveau/includes/activity/ajax.php:721
 msgid "There was a problem posting your update. Please try again."
 msgstr ""
 
-#: bp-templates/bp-nouveau/includes/activity/ajax.php:738
+#: bp-templates/bp-nouveau/includes/activity/ajax.php:744
 msgid "Update posted."
 msgstr ""
 
-#: bp-templates/bp-nouveau/includes/activity/ajax.php:738
+#: bp-templates/bp-nouveau/includes/activity/ajax.php:744
 msgid "View activity."
 msgstr ""
 
-#: bp-templates/bp-nouveau/includes/activity/ajax.php:769
+#: bp-templates/bp-nouveau/includes/activity/ajax.php:775
 msgid "There was a problem marking this activity as spam. Please try again."
 msgstr ""
 
-#: bp-templates/bp-nouveau/includes/activity/ajax.php:818
+#: bp-templates/bp-nouveau/includes/activity/ajax.php:824
 msgid "This activity has been marked as spam and is no longer visible."
 msgstr ""
 
@@ -28971,14 +28983,15 @@ msgstr ""
 msgctxt "extension notification"
 msgid ""
 "Your server needs %1$s installed to automatically create thumbnails after "
-"uploading videos (optional). Ask your web host.\n"
+"uploading videos (optional). Ask your web host.\r\n"
 "\t\t\t\t\t<br/><br/>If FFmpeg is already installed on your server and you "
 "still see the above warning, this means BuddyBoss Platform is unable to "
 "auto-detect the binary file path for FFmpeg. You will need to add the below "
 "FFmpeg absolute path constants into your %2$s file, replacing "
 "PATH_OF_BINARY_FILE with the actual file path to the FFmpeg binary file. "
-"Ask your web host to provide the absolute path for the FFmpeg binary file.\n"
-"\t\t\t\t\t<br /><br />%3$s\n"
+"Ask your web host to provide the absolute path for the FFmpeg binary "
+"file.\r\n"
+"\t\t\t\t\t<br /><br />%3$s\r\n"
 "\t\t\t\t\t<br />%4$s"
 msgstr ""
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1479.

### How to test the changes in this Pull Request:

1. Go to Activity Feed page, add the new post content in the text area
2. Click on Post in Group
3. Don't add group name and click on "Post" button to post the activity

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

http://somup.com/crQDXurgHL

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added specific error message, earlier it was showing general message & ran grunt to add the new message strings to pot file
