### PR TITLE
BuddyBoss compatibility issue with TranslatePress in multisite setup - Fixed

### DIFF
--- a/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
+++ b/src/bp-core/compatibility/bp-incompatible-plugins-helper.php
@@ -53,6 +53,34 @@ function bp_helper_plugins_loaded_callback() {
 	}
 
 	/**
+	 * Make translatePress compatible with Multisite installation of platform
+	 *
+	 * Support TranslatePress on Multisite
+	 */
+	if ( in_array( 'translatepress-multilingual/index.php', $bp_plugins ) && ! is_admin() && is_multisite() ) {
+		
+		/**
+		 * Remove lang code from URL slug
+		 *
+		 * @since BuddyBoss 1.7.8
+		 *
+		 * @param string $path
+		 * @return string $path
+		 */
+		function bb_multilang_multisite_translatepress_support( $path ) {
+			$tp_settings = get_option( 'trp_settings' );
+			if ( $tp_settings && isset( $tp_settings['url-slugs'] ) && !empty( $tp_settings['url-slugs'] ) ) {
+				foreach ( $tp_settings['url-slugs'] as $lang_key => $lang_slug ) {
+					$path = str_replace( $lang_slug . '/', '', $path );
+				}
+			}
+			return $path;
+		}
+		add_filter( 'bp_uri', 'bb_multilang_multisite_translatepress_support' );
+
+	}
+
+	/**
 	 * Include plugin when plugin is activated
 	 *
 	 * Support MemberPress + BuddyPress Integration


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1185  .

### How to test the changes in this Pull Request:

1. Activate TranslatePress
2. In the admin toolbar, go to Translate Site > Settings
3. Add other languages
4. Go to any component pages
5. change the URL or switch to other languages and see it is fine now.
### Proof Screenshots or Video

https://www.loom.com/share/d2a2d9fcdce54ca5b59a13b1b3198ba8

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
