### PR TITLE
Fix wrong Nicknames generating after migrating to buddyboss-platform

### DIFF
--- a/src/bp-xprofile/bp-xprofile-filters.php
+++ b/src/bp-xprofile/bp-xprofile-filters.php
@@ -117,6 +117,9 @@ add_filter( 'bp_after_has_profile_parse_args', 'bp_xprofile_exclude_display_name
 // Repair repeater field repeated in admin side.
 add_filter( 'bp_repair_list', 'bb_xprofile_repeater_field_repair' );
 
+// Repair user nicknames.
+add_filter( 'bp_repair_list', 'bb_xprofile_repair_user_nicknames' );
+
 /**
  * Sanitize each field option name for saving to the database.
  *
@@ -1177,4 +1180,75 @@ function bb_xprofile_repeater_field_repair_callback() {
 			'message' => __( 'Field update complete!', 'buddyboss' ),
 		);
 	}
+}
+
+/**
+ * Add xprofile repair user nicknames.
+ *
+ * @param array $repair_list Repair list items.
+ *
+ * @return array Repair list items.
+ *
+ * @since BuddyBoss 1.7.9
+ */
+function bb_xprofile_repair_user_nicknames( $repair_list ) {
+	$repair_list[] = array(
+		'bb-xprofile-repair-user-nicknames',
+		__( 'Repair user nicknames.', 'buddyboss' ),
+		'bb_xprofile_repair_user_nicknames_callback',
+	);
+	return $repair_list;
+}
+
+/**
+ * This function will work as migration process which will update user nicknames.
+ *
+ * @since BuddyBoss 1.7.9
+ */
+function bb_xprofile_repair_user_nicknames_callback() {
+	global $wpdb;
+
+	$records_updated = 0;
+	$users_query     = "
+		SELECT
+			users.ID, users.display_name, users.user_login, users.user_nicename, meta.meta_value
+		FROM
+			`{$wpdb->users}` as users, `{$wpdb->usermeta}` as meta
+		WHERE
+			users.ID = meta.user_ID
+			and meta.meta_key = 'nickname'
+			and users.user_nicename != meta.meta_value";
+	$records         = $wpdb->get_results( $users_query );
+
+	if ( ! empty( $records ) ) {
+		$wpdb->query(
+			"UPDATE
+				`{$wpdb->usermeta}` as meta, `{$wpdb->users}` as users
+			SET
+				meta.meta_value = users.user_nicename
+			WHERE
+				users.ID = meta.user_ID
+				and meta.meta_key = 'nickname'
+				and users.user_nicename != meta.meta_value"
+		);
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE
+					`{$wpdb->users}` as users, `{$wpdb->prefix}bp_xprofile_data` as xprofile
+				SET
+					xprofile.value = users.user_nicename
+				WHERE
+					users.ID = xprofile.user_id
+					and xprofile.field_id = %d
+					and users.user_nicename != xprofile.value",
+				bp_xprofile_nickname_field_id()
+			)
+		);
+		$records_updated = sprintf( __( '%s user nicknames updated successfully.', 'buddyboss' ), number_format_i18n( count( $records ) ) );
+	}
+	return array(
+		'status'  => 1,
+		'records' => $records_updated,
+		'message' => __( 'User nickname update complete!', 'buddyboss' ),
+	);
 }

--- a/src/languages/buddyboss.pot
+++ b/src/languages/buddyboss.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPLv2 or later (license.txt).
 msgid ""
 msgstr ""
-"Project-Id-Version: BuddyBoss Platform 1.7.7\n"
+"Project-Id-Version: BuddyBoss Platform 1.7.7.1\n"
 "Report-Msgid-Bugs-To: https://www.buddyboss.com/contact/\n"
-"POT-Creation-Date: 2021-09-15 12:29:47+00:00\n"
+"POT-Creation-Date: 2021-09-27 11:18:28+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -20086,7 +20086,7 @@ msgid "That username is not allowed"
 msgstr ""
 
 #: bp-members/bp-members-functions.php:1709
-#: bp-xprofile/bp-xprofile-filters.php:789
+#: bp-xprofile/bp-xprofile-filters.php:792
 msgid "Invalid %s. Only \"a-z\", \"0-9\", \"-\", \"_\" and \".\" are allowed."
 msgstr ""
 
@@ -27665,47 +27665,59 @@ msgid ""
 "fields?"
 msgstr ""
 
-#: bp-xprofile/bp-xprofile-filters.php:784
-#: bp-xprofile/bp-xprofile-filters.php:879
-#: bp-xprofile/bp-xprofile-filters.php:992
+#: bp-xprofile/bp-xprofile-filters.php:787
+#: bp-xprofile/bp-xprofile-filters.php:882
+#: bp-xprofile/bp-xprofile-filters.php:995
 #: bp-xprofile/classes/class-bp-rest-xprofile-update-endpoint.php:532
 #: bp-xprofile/screens/edit.php:140
 #. translators: Field name
 msgid "%s is required and not allowed to be empty."
 msgstr ""
 
-#: bp-xprofile/bp-xprofile-filters.php:795
+#: bp-xprofile/bp-xprofile-filters.php:798
 msgid "%1$s must be shorter than %2$d characters."
 msgstr ""
 
-#: bp-xprofile/bp-xprofile-filters.php:800
+#: bp-xprofile/bp-xprofile-filters.php:803
 msgid "%s must be at least 3 characters"
 msgstr ""
 
-#: bp-xprofile/bp-xprofile-filters.php:809
-#: bp-xprofile/bp-xprofile-filters.php:829
+#: bp-xprofile/bp-xprofile-filters.php:812
+#: bp-xprofile/bp-xprofile-filters.php:832
 msgid "%s has already been taken."
 msgstr ""
 
-#: bp-xprofile/bp-xprofile-filters.php:888
-#: bp-xprofile/bp-xprofile-filters.php:898
+#: bp-xprofile/bp-xprofile-filters.php:891
+#: bp-xprofile/bp-xprofile-filters.php:901
 msgid "Enter valid %s"
 msgstr ""
 
-#: bp-xprofile/bp-xprofile-filters.php:1003
+#: bp-xprofile/bp-xprofile-filters.php:1006
 msgid "Please enter valid %s profile url."
 msgstr ""
 
-#: bp-xprofile/bp-xprofile-filters.php:1079
+#: bp-xprofile/bp-xprofile-filters.php:1082
 msgid "Repair xProfile repeater fieldset."
 msgstr ""
 
-#: bp-xprofile/bp-xprofile-filters.php:1157
+#: bp-xprofile/bp-xprofile-filters.php:1160
 msgid "%s field updated successfully."
 msgstr ""
 
-#: bp-xprofile/bp-xprofile-filters.php:1177
+#: bp-xprofile/bp-xprofile-filters.php:1180
 msgid "Field update complete!"
+msgstr ""
+
+#: bp-xprofile/bp-xprofile-filters.php:1197
+msgid "Repair user nicknames."
+msgstr ""
+
+#: bp-xprofile/bp-xprofile-filters.php:1247
+msgid "%s user nicknames updated successfully."
+msgstr ""
+
+#: bp-xprofile/bp-xprofile-filters.php:1252
+msgid "User nickname update complete!"
 msgstr ""
 
 #: bp-xprofile/bp-xprofile-functions.php:1548


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1308 

### How to test the changes in this Pull Request:

1. User should be registered in BuddyPress. 
2. Before migrating username (nickname) and user's Name (Fist and Last name) should be different
3. Try to migrate from buddypress to buddyboss-platfrom
4. See wrong Nicknames for some users.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
