### PR TITLE
#2974 - Fix undefined function symlink() error when server doesn't support symlink

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -5719,6 +5719,10 @@ function bb_core_enable_default_symlink_support() {
 		return;
 	}
 
+	if ( true === bb_check_server_disabled_symlink() ) {
+		return;
+	}
+
 	$upload_dir = wp_upload_dir();
 	$upload_dir = $upload_dir['basedir'];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #2974.

### How to test the changes in this Pull Request:

1. Make sure to test it on the server that doesn't support symlink.
2. Use platform plugin version 1.7.6 above.
3. Activate the plugin and see the error.
4. If ever you see no error when activating the plugin, try deactivating the activity component and activate it back.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed undefined function symlink() error when server doesn't support symlink
