### PR TITLE
Modified query because when blocked any user from backend side then it was not working blocked member for message

### DIFF
--- a/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
@@ -227,7 +227,8 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 		) {
 			return $where_conditions;
 		}
-
+		
+		// Modified code.
 		$where                  = array();
 		$sql                    = $wpdb->prepare( "SELECT {$this->alias}.item_id FROM {$bp->table_prefix}bp_suspend {$this->alias} WHERE {$this->alias}.item_type = %s
 								  AND ( {$this->alias}.hide_sitewide != 1 OR {$this->alias}.hide_parent != 1 OR {$this->alias}.user_suspended != 1 )", 'user' ); // phpcs:ignore


### PR DESCRIPTION
Modified code because before that we were using this function **bp_moderation_get_hidden_user_ids** it was working fine for front end but if we suspend any member from user list section from backend side at that time above function was not working. So, I needed to added custom SQL query for that.

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/buddyboss/buddyboss-platform/pull/2884.

### How to test the changes in this Pull Request:

1. Go to user list section
2. Click on suspend
3. Check it message section - Click on block a member and check suspended member should not be display

### Proof Screenshots or Video

https://screencast-o-matic.com/watch/cr6fe4VXVyJ

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
