### PR TITLE
Fix : #3015 fixed Forum search with spaces

### DIFF
--- a/src/bp-forums/search/template.php
+++ b/src/bp-forums/search/template.php
@@ -90,6 +90,9 @@ function bbp_has_search_results( $args = '' ) {
 	// Call the query
 	if ( ! empty( $r['s'] ) ) {
 		$bbp->search_query = new WP_Query( $r );
+	} else {
+		unset( $r['s'] );
+		$bbp->search_query = new WP_Query( $r );
 	}
 
 	// Add pagination values to query object


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #3015.

### How to test the changes in this Pull Request:

1. First of all, allow search on forum archive under Buddyboss>>Settings>>Forum and check "Allow forum wide search" or from 2. theme option under Theme Options>>Forums and switch on "Show Forum Banner" and "Enable Search"
3. Go to the forum archive page and try to search with only space/s
4. It will show all the forums as result.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->
https://www.loom.com/share/14db142e36b74ea59a6be9b426070be8