### PR TITLE
PROD-903 #1638 - fixed avatar and cover photo upload size issue

### DIFF
--- a/src/bp-core/bp-core-attachments.php
+++ b/src/bp-core/bp-core-attachments.php
@@ -155,7 +155,11 @@ function bp_attachments_get_max_upload_file_size( $type = '' ) {
 	$fileupload_maxk = bp_core_get_root_option( 'fileupload_maxk' );
 
 	if ( '' === $fileupload_maxk ) {
-		$fileupload_maxk = 5120000; // 5mb;
+		if ( function_exists( 'bp_media_file_upload_max_size' ) ) {
+			$fileupload_maxk = bp_media_file_upload_max_size() * 1024 * 1024;
+		} else {
+			$fileupload_maxk = (int) wp_max_upload_size();
+		}
 	} else {
 		$fileupload_maxk = $fileupload_maxk * 1024;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #1638  .

### How to test the changes in this Pull Request:

For wp single site, the issue occurs for members & groups avatar and cover photo. 

1. Go to Profile  > Edit cover image
2. Upload cover image more than 5 mb
4. See now image can be uploaded if server max upload size is set more than 5 MB

### Note For wpmu site:

In wpmu network settings, default value 1500KB https://prnt.sc/wfw3vu it can be changed, and the value is used as maximum upload size for members & groups avatar and cover photo. This default value has been set during network setup by this code https://prnt.sc/wfvy8f and all subsites use this network setting. This code coming from wp default, so we can't change this.

### Proof Screenshots or Video
https://www.loom.com/share/0db1151f746e4e9a900646bd6467aaa9

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
