### PR TITLE
Fix Forums Groups not respecting Parent setting

### DIFF
--- a/src/bp-forums/groups.php
+++ b/src/bp-forums/groups.php
@@ -427,7 +427,8 @@ if ( ! class_exists( 'BBP_Forums_Group_Extension' ) && class_exists( 'BP_Group_E
 					array(
 						'post_title'   => $group->name,
 						'post_content' => $group->description,
-						'post_status'  => $status,
+						'post_status'  => $status,						
+						'post_parent' => bbp_get_group_forums_root_id(),
 					)
 				);
 
@@ -578,6 +579,7 @@ if ( ! class_exists( 'BBP_Forums_Group_Extension' ) && class_exists( 'BP_Group_E
 							'post_title'   => bp_get_new_group_name(),
 							'post_content' => bp_get_new_group_description(),
 							'post_status'  => $status,
+							'post_parent' => bbp_get_group_forums_root_id(),
 						)
 					);
 


### PR DESCRIPTION
I noticed that all groups forum creations were not respecting the "bbp_get_group_forums_root_id" filter. I don't know if this forum "Parent" setting was purposely removed from Groups Forums creation but I had to re-add it here to fix Groups forums on my site not going into the correct sub-forum.

### All Submissions:

* [X] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [X] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #ISSUE_NUMBER .

### How to test the changes in this Pull Request:

1.
2.
3.

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
