### PR TITLE
#3156 - Fixed autocomplete in group results in new activity > post in: group should be sorted by title alphabetically

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -519,8 +519,10 @@ function bp_nouveau_ajax_get_activity_objects() {
 				'user_id'      => bp_loggedin_user_id(),
 				'search_terms' => $_POST['search'],
 				'show_hidden'  => true,
-				'per_page'     => 2,
+				'per_page'     => 5,
 				'exclude'      => $exclude_groups,
+				'orderby'	   => 'title',
+				'order'	       => 'ASC'
 			)
 		);
 

--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -521,7 +521,7 @@ function bp_nouveau_ajax_get_activity_objects() {
 				'show_hidden'  => true,
 				'per_page'     => 5,
 				'exclude'      => $exclude_groups,
-				'orderby'	   => 'title',
+				'orderby'      => 'title',
 				'order'	       => 'ASC'
 			)
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #3156

### How to test the changes in this Pull Request:
https://www.loom.com/share/2ca50b34cfe64796a4cdc26cef0ffb1d

### Proof Screenshots or Video

![image](https://user-images.githubusercontent.com/82648504/141307274-0eacfc29-5ab8-4f58-a918-d24860feb9a3.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added code to search group autocomplete results so will be sorted alphabetically by default and changed per page to 5
