### PR TITLE
#3162 fixed the mention to show correctly instead of the nice_name in group

### DIFF
--- a/src/bp-groups/classes/class-bp-groups-member-suggestions.php
+++ b/src/bp-groups/classes/class-bp-groups-member-suggestions.php
@@ -155,7 +155,7 @@ class BP_Groups_Member_Suggestions extends BP_Members_Suggestions {
 		$results = array();
 		foreach ( $user_query->results as $user ) {
 			$result          = new stdClass();
-			$result->ID      = $user->user_nicename;
+			$result->ID      = bp_activity_get_user_mentionname( $user->ID );
 			$result->image   = bp_core_fetch_avatar(
 				array(
 					'html'    => false,


### PR DESCRIPTION
@mentions members suggestions not using a user's nickname in groups instead using user_nicename for members other than first 10 members suggestions that are loaded by default on the page load

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Its working fine in the news feed already because we are using the bp_activity_get_user_mentionname() instead of nice_name directly, so did the same

Fixes #3162 .

### How to test the changes in this Pull Request:

1. Create a social group with more than 10-12 members and members should have the nickname and nice_name different
2. Note that first 10 member's mention suggestion for the group will load by default in JS ( shown in video ) which will work fine as they are been loaded from other function
3. One who is not in the default list go the the group feed with that member mention you will notice it will load the nice_name, to cross check update that member nice_name other than the user nickname first in the database wp_users table

### Proof Screenshots or Video
https://somup.com/crXbih0QzR


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed the mention to show correctly instead of the nice_name in group