### PR TITLE
Moderation background process gives memory limit error

### DIFF
--- a/src/bp-core/bp-core-actions.php
+++ b/src/bp-core/bp-core-actions.php
@@ -351,11 +351,11 @@ add_action( 'bb_init_email_background_updater', 'bb_email_handle_cron_healthchec
  *
  * @since BuddyBoss [BBVERSION]
  */
-function bp_handle_cron_healthcheck() {
+function bb_handle_cron_healthcheck() {
 	global $bp_background_updater;
 	if ( $bp_background_updater->is_updating() ) {
 		$bp_background_updater->schedule_event();
 	}
 }
 
-add_action( 'bp_init_background_updater', 'bp_handle_cron_healthcheck' );
+add_action( 'bp_init_background_updater', 'bb_handle_cron_healthcheck' );

--- a/src/bp-core/bp-core-actions.php
+++ b/src/bp-core/bp-core-actions.php
@@ -344,3 +344,14 @@ function bb_email_handle_cron_healthcheck() {
 }
 
 add_action( 'bb_init_email_background_updater', 'bb_email_handle_cron_healthcheck' );
+
+
+function bp_handle_cron_healthcheck() {
+	global $bp_background_updater;
+	if ( $bp_background_updater->is_updating() ) {
+		$bp_background_updater->handle_cron_healthcheck();
+//		$bp_background_updater->dispatch();
+	}
+}
+
+add_action( 'bp_init_background_updater', 'bp_handle_cron_healthcheck' );

--- a/src/bp-core/bp-core-actions.php
+++ b/src/bp-core/bp-core-actions.php
@@ -349,7 +349,8 @@ add_action( 'bb_init_email_background_updater', 'bb_email_handle_cron_healthchec
 function bp_handle_cron_healthcheck() {
 	global $bp_background_updater;
 	if ( $bp_background_updater->is_updating() ) {
-		$bp_background_updater->handle_cron_healthcheck();
+//		$bp_background_updater->handle_cron_healthcheck();
+		$bp_background_updater->schedule_event();
 //		$bp_background_updater->dispatch();
 	}
 }

--- a/src/bp-core/bp-core-actions.php
+++ b/src/bp-core/bp-core-actions.php
@@ -346,12 +346,15 @@ function bb_email_handle_cron_healthcheck() {
 add_action( 'bb_init_email_background_updater', 'bb_email_handle_cron_healthcheck' );
 
 
+/**
+ * Check and reschedule the background process if queue is not empty.
+ *
+ * @since BuddyBoss [BBVERSION]
+ */
 function bp_handle_cron_healthcheck() {
 	global $bp_background_updater;
 	if ( $bp_background_updater->is_updating() ) {
-//		$bp_background_updater->handle_cron_healthcheck();
 		$bp_background_updater->schedule_event();
-//		$bp_background_updater->dispatch();
 	}
 }
 

--- a/src/bp-moderation/classes/class-bp-moderation-activity-comment.php
+++ b/src/bp-moderation/classes/class-bp-moderation-activity-comment.php
@@ -60,7 +60,6 @@ class BP_Moderation_Activity_Comment extends BP_Moderation_Abstract {
 		// Validate item before proceed.
 		add_filter( "bp_moderation_{$this->item_type}_validate", array( $this, 'validate_single_item' ), 10, 2 );
 
-
 		// Report button text.
 		add_filter( "bb_moderation_{$this->item_type}_report_button_text", array( $this, 'report_button_text' ), 10, 2 );
 		add_filter( "bb_moderation_{$this->item_type}_reported_button_text", array( $this, 'report_button_text' ), 10, 2 );
@@ -229,7 +228,7 @@ class BP_Moderation_Activity_Comment extends BP_Moderation_Abstract {
 		$author_id = self::get_content_owner_id( $item_id );
 
 		if ( ( $this->is_member_blocking_enabled() && ! empty( $author_id ) && ! bp_moderation_is_user_suspended( $author_id ) && bp_moderation_is_user_blocked( $author_id ) ) ||
-		     ( $this->is_reporting_enabled() && BP_Core_Suspend::check_hidden_content( $item_id, $this->item_type ) ) ) {
+			 ( $this->is_reporting_enabled() && BP_Core_Suspend::check_hidden_content( $item_id, $this->item_type ) ) ) {
 			return true;
 		}
 		return false;

--- a/src/bp-moderation/classes/class-bp-moderation-comment.php
+++ b/src/bp-moderation/classes/class-bp-moderation-comment.php
@@ -375,7 +375,7 @@ class BP_Moderation_Comment extends BP_Moderation_Abstract {
 		$author_id = self::get_content_owner_id( $item_id );
 
 		if ( ( $this->is_member_blocking_enabled() && ! empty( $author_id ) && ! bp_moderation_is_user_suspended( $author_id ) && bp_moderation_is_user_blocked( $author_id ) ) ||
-		     ( $check_hidden && $this->is_reporting_enabled() && BP_Core_Suspend::check_hidden_content( $item_id, $this->item_type ) ) ) {
+			 ( $check_hidden && $this->is_reporting_enabled() && BP_Core_Suspend::check_hidden_content( $item_id, $this->item_type ) ) ) {
 			return true;
 		}
 

--- a/src/bp-moderation/classes/class-bp-moderation-component.php
+++ b/src/bp-moderation/classes/class-bp-moderation-component.php
@@ -192,11 +192,11 @@ class BP_Moderation_Component extends BP_Component {
 		if ( false === $is_moderation_terms ) {
 
 			$moderation_terms = array(
-				'offensive'        => array(
+				'offensive'      => array(
 					'name'        => __( 'Offensive', 'buddyboss' ),
 					'description' => __( 'Contains abusive or derogatory content', 'buddyboss' ),
 				),
-				'inappropriate'       => array(
+				'inappropriate'  => array(
 					'name'        => __( 'Inappropriate', 'buddyboss' ),
 					'description' => __( 'Contains mature or sensitive content', 'buddyboss' ),
 				),
@@ -204,11 +204,11 @@ class BP_Moderation_Component extends BP_Component {
 					'name'        => __( 'Misinformation', 'buddyboss' ),
 					'description' => __( 'Contains misleading or false information', 'buddyboss' ),
 				),
-				'suspicious'  => array(
+				'suspicious'     => array(
 					'name'        => __( 'Suspicious', 'buddyboss' ),
 					'description' => __( 'Contains spam, fake content or potential malware', 'buddyboss' ),
 				),
-				'harassment'  => array(
+				'harassment'     => array(
 					'name'        => __( 'Harassment', 'buddyboss' ),
 					'description' => __( 'Harassment or bullying behavior', 'buddyboss' ),
 				),

--- a/src/bp-moderation/classes/class-bp-moderation-document.php
+++ b/src/bp-moderation/classes/class-bp-moderation-document.php
@@ -236,11 +236,20 @@ class BP_Moderation_Document extends BP_Moderation_Abstract {
 		$document_id  = bp_activity_get_meta( $activity->id, 'bp_document_id', true );
 		$document_ids = bp_activity_get_meta( $activity->id, 'bp_document_ids', true );
 
-		if ( ( ! empty( $document_id ) || ! empty( $document_ids ) ) && ! in_array( $activity->type, array(
-				'bbp_forum_create',
-				'bbp_topic_create',
-				'bbp_reply_create'
-			) ) ) {
+		if (
+			(
+				! empty( $document_id ) ||
+				! empty( $document_ids )
+			) &&
+			! in_array(
+				$activity->type,
+				array(
+					'bbp_forum_create',
+					'bbp_topic_create',
+					'bbp_reply_create',
+				)
+			)
+		) {
 			$explode_documents = explode( ',', $document_ids );
 			if ( ! empty( $document_id ) ) {
 				$args['button_attr']['data-bp-content-id']   = $document_id;

--- a/src/bp-moderation/classes/class-bp-moderation-forum-replies.php
+++ b/src/bp-moderation/classes/class-bp-moderation-forum-replies.php
@@ -224,7 +224,7 @@ class BP_Moderation_Forum_Replies extends BP_Moderation_Abstract {
 		$author_id = self::get_content_owner_id( $item_id );
 
 		if ( ( $this->is_member_blocking_enabled() && ! empty( $author_id ) && ! bp_moderation_is_user_suspended( $author_id ) && bp_moderation_is_user_blocked( $author_id ) ) ||
-		     ( $this->is_reporting_enabled() && BP_Core_Suspend::check_hidden_content( $item_id, $this->item_type ) ) ) {
+			 ( $this->is_reporting_enabled() && BP_Core_Suspend::check_hidden_content( $item_id, $this->item_type ) ) ) {
 			return true;
 		}
 		return false;

--- a/src/bp-moderation/classes/class-bp-moderation-groups.php
+++ b/src/bp-moderation/classes/class-bp-moderation-groups.php
@@ -94,7 +94,7 @@ class BP_Moderation_Groups extends BP_Moderation_Abstract {
 	 * @return array
 	 */
 	public static function get_content_owner_id( $group_id ) {
-		$g_admins     = groups_get_group_admins( $group_id );
+		$g_admins = groups_get_group_admins( $group_id );
 
 		return ( ! empty( $g_admins ) ) ? wp_list_pluck( $g_admins, 'user_id' ) : 0;
 	}

--- a/src/bp-moderation/classes/class-bp-moderation-list-table.php
+++ b/src/bp-moderation/classes/class-bp-moderation-list-table.php
@@ -481,7 +481,15 @@ class BP_Moderation_List_Table extends WP_List_Table {
 
 		$current_tab = filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_STRING );
 		$current_tab = ( ! bp_is_moderation_member_blocking_enable() ) ? 'reported-content' : $current_tab;
-		$admins      = array_map( 'intval', get_users( array( 'role' => 'administrator', 'fields' => 'ID' ) ) );
+		$admins      = array_map(
+			'intval',
+			get_users(
+				array(
+					'role'   => 'administrator',
+					'fields' => 'ID',
+				)
+			)
+		);
 
 		$actions = array();
 
@@ -496,10 +504,10 @@ class BP_Moderation_List_Table extends WP_List_Table {
 			$moderation_args['tab'] = 'reported-content';
 		}
 
-		$action_type       = ( 1 === (int) $item['hide_sitewide'] ) ? 'unhide' : 'hide';
-		$action_label      = ( 'unhide' === $action_type ) ? esc_html__( 'Unhide Content', 'buddyboss' ) : esc_html__( 'Hide Content', 'buddyboss' );
-		$user_id           = bp_moderation_get_content_owner_id( $item['item_id'], $item['item_type'] );
-		$class             = ( BP_Moderation_Members::$moderation_type === $item['item_type'] ) ? 'bp-hide-user' : 'bp-hide-request';
+		$action_type  = ( 1 === (int) $item['hide_sitewide'] ) ? 'unhide' : 'hide';
+		$action_label = ( 'unhide' === $action_type ) ? esc_html__( 'Unhide Content', 'buddyboss' ) : esc_html__( 'Hide Content', 'buddyboss' );
+		$user_id      = bp_moderation_get_content_owner_id( $item['item_id'], $item['item_type'] );
+		$class        = ( BP_Moderation_Members::$moderation_type === $item['item_type'] ) ? 'bp-hide-user' : 'bp-hide-request';
 
 		$view_url               = add_query_arg( $moderation_args, bp_get_admin_url( 'admin.php' ) );
 		$actions['view_report'] = sprintf(
@@ -583,7 +591,7 @@ class BP_Moderation_List_Table extends WP_List_Table {
 		$action_label     = ( 'unsuspend' === $user_action_type ) ? esc_html__( 'Unsuspend', 'buddyboss' ) : esc_html__( 'Suspend', 'buddyboss' );
 
 		// Build actions URL.
-		$view_url          = add_query_arg( $moderation_args, bp_get_admin_url( 'admin.php' ) );
+		$view_url = add_query_arg( $moderation_args, bp_get_admin_url( 'admin.php' ) );
 
 		$actions['view_report'] = sprintf( '<a href="%s" title="%s"> %s </a>', esc_url( $view_url ), esc_attr__( 'View', 'buddyboss' ), esc_html__( 'View Reports', 'buddyboss' ) );
 		$actions['suspend']     = sprintf( '<a href="" class="bp-block-user" data-id="%s" data-type="user" data-nonce="%s" data-action="%s" title="%s">%s</a>', esc_attr( $item['item_id'] ), esc_attr( wp_create_nonce( 'bp-hide-unhide-moderation' ) ), esc_attr( $user_action_type ), esc_attr( $action_label ), esc_html( $action_label ) );
@@ -599,11 +607,11 @@ class BP_Moderation_List_Table extends WP_List_Table {
 	 */
 	public function column_content_owner( $item = array() ) {
 		$user_ids = bp_moderation_get_content_owner_id( $item['item_id'], $item['item_type'] );
-		if ( ! is_array( $user_ids ) ){
+		if ( ! is_array( $user_ids ) ) {
 			$user_ids = array( $user_ids );
 		}
 
-		foreach ( $user_ids as $user_id ){
+		foreach ( $user_ids as $user_id ) {
 			printf( '%s <strong>%s</strong> <br/>', get_avatar( $user_id, '32' ), wp_kses_post( bp_core_get_userlink( $user_id ) ) );
 		}
 	}

--- a/src/bp-moderation/classes/class-bp-moderation-media.php
+++ b/src/bp-moderation/classes/class-bp-moderation-media.php
@@ -153,7 +153,7 @@ class BP_Moderation_Media extends BP_Moderation_Abstract {
 	 * @return array
 	 */
 	public function update_button_args( $args, $item_id ) {
-		$media = new BP_Media($item_id);
+		$media = new BP_Media( $item_id );
 
 		// Remove report button if forum is group forums.
 		if ( ! empty( $media->id ) && ! empty( $media->privacy ) && in_array( $media->privacy, array( 'comment', 'forums' ), true ) ) {
@@ -236,11 +236,20 @@ class BP_Moderation_Media extends BP_Moderation_Abstract {
 		$media_id  = bp_activity_get_meta( $activity->id, 'bp_media_id', true );
 		$media_ids = bp_activity_get_meta( $activity->id, 'bp_media_ids', true );
 
-		if ( ( ! empty( $media_id ) || ! empty( $media_ids ) ) && ! in_array( $activity->type, array(
-				'bbp_forum_create',
-				'bbp_topic_create',
-				'bbp_reply_create'
-			) ) ) {
+		if (
+			(
+				! empty( $media_id ) ||
+				! empty( $media_ids )
+			) &&
+			! in_array(
+				$activity->type,
+				array(
+					'bbp_forum_create',
+					'bbp_topic_create',
+					'bbp_reply_create',
+				)
+			)
+		) {
 			$explode_medias = explode( ',', $media_ids );
 			if ( ! empty( $media_id ) ) {
 				$args['button_attr']['data-bp-content-id']   = $media_id;

--- a/src/bp-moderation/classes/class-bp-moderation-video.php
+++ b/src/bp-moderation/classes/class-bp-moderation-video.php
@@ -236,11 +236,20 @@ class BP_Moderation_Video extends BP_Moderation_Abstract {
 		$video_id  = bp_activity_get_meta( $args['button_attr']['data-bp-content-id'], 'bp_video_id', true );
 		$video_ids = bp_activity_get_meta( $args['button_attr']['data-bp-content-id'], 'bp_video_ids', true );
 
-		if ( ( ! empty( $video_id ) || ! empty( $video_ids ) ) && ! in_array( $activity->type, array(
-				'bbp_forum_create',
-				'bbp_topic_create',
-				'bbp_reply_create'
-			) ) ) {
+		if (
+			(
+				! empty( $video_id ) ||
+				! empty( $video_ids )
+			) &&
+			! in_array(
+				$activity->type,
+				array(
+					'bbp_forum_create',
+					'bbp_topic_create',
+					'bbp_reply_create',
+				)
+			)
+		) {
 			$explode_videos = explode( ',', $video_ids );
 			if ( ! empty( $video_id ) ) {
 				$args['button_attr']['data-bp-content-id']   = $video_id;

--- a/src/bp-moderation/classes/class-bp-moderation.php
+++ b/src/bp-moderation/classes/class-bp-moderation.php
@@ -1208,7 +1208,6 @@ class BP_Moderation {
 				foreach ( $admins as $admin ) {
 					bp_moderation_member_suspend_email( bp_core_get_user_email( $admin ), $tokens );
 				}
-
 			} elseif ( bp_is_moderation_auto_hide_enable( false, $this->item_type ) ) {
 
 				$content_report_link = ( bp_is_moderation_member_blocking_enable() ) ? add_query_arg( array( 'tab' => 'reported-content' ), bp_get_admin_url( 'admin.php' ) ) : bp_get_admin_url( 'admin.php' );
@@ -1244,7 +1243,6 @@ class BP_Moderation {
 				foreach ( $admins as $admin ) {
 					bp_moderation_content_hide_email( bp_core_get_user_email( $admin ), $tokens );
 				}
-
 			}
 
 			unset( $_GET['username_visible'] );

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-abstract.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-abstract.php
@@ -124,7 +124,7 @@ abstract class BP_Suspend_Abstract {
 	 * @param int|null $hide_sitewide item hidden sitewide or user specific.
 	 * @param array    $args          parent args.
 	 */
-	public function hide_related_content( $item_id, $hide_sitewide, $args = array() ) {
+	public function hide_related_content( $item_id, $hide_sitewide = 0, $args = array() ) {
 		$args = $this->prepare_suspend_args( $item_id, $hide_sitewide, $args );
 
 		if ( empty( $args['action'] ) ) {
@@ -225,7 +225,7 @@ abstract class BP_Suspend_Abstract {
 	 * @param int      $force_all     un-hide for all users.
 	 * @param array    $args          parent args.
 	 */
-	public function unhide_related_content( $item_id, $hide_sitewide, $force_all, $args = array() ) {
+	public function unhide_related_content( $item_id, $hide_sitewide = 0, $force_all = 0, $args = array() ) {
 		$args = $this->prepare_suspend_args( $item_id, $hide_sitewide, $args );
 
 		if ( empty( $item_id ) ) {

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-abstract.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-abstract.php
@@ -24,6 +24,13 @@ abstract class BP_Suspend_Abstract {
 	public $backgroup_diabled = false;
 
 	/**
+	 * Item per page
+	 *
+	 * @var integer
+	 */
+	public static $item_per_page = 10;
+
+	/**
 	 * Item type
 	 *
 	 * @var string
@@ -125,6 +132,8 @@ abstract class BP_Suspend_Abstract {
 	 * @param array    $args          parent args.
 	 */
 	public function hide_related_content( $item_id, $hide_sitewide = 0, $args = array() ) {
+		global $bp_background_updater;
+
 		$args = $this->prepare_suspend_args( $item_id, $hide_sitewide, $args );
 
 		if ( empty( $args['action'] ) ) {
@@ -138,48 +147,80 @@ abstract class BP_Suspend_Abstract {
 		$blocked_user   = ! empty( $args['blocked_user'] ) ? $args['blocked_user'] : '';
 		$suspended_user = ! empty( $args['user_suspended'] ) ? $args['user_suspended'] : '';
 
-		$related_contents = $this->get_related_contents( $item_id, $args );
+		if ( ! isset( $args['enable_pagination'] ) ) {
+			$args['enable_pagination'] = 1;
+		}
 
-		foreach ( $related_contents as $content_type => $content_ids ) {
-			if ( ! empty( $content_ids ) ) {
-				foreach ( $content_ids as $content_id ) {
+		$page = 1;
 
-					if (
-						BP_Core_Suspend::check_hidden_content( $content_id, $content_type ) ||
-						BP_Core_Suspend::check_suspended_content( $content_id, $content_type )
-					) {
-						continue;
+		if ( empty( $args['page'] ) ) {
+			$args['page'] = $page;
+		} else {
+			$page = $args['page'];
+		}
+
+		$related_contents = array_filter( $this->get_related_contents( $item_id, $args ) );
+
+		if ( ! empty( $related_contents ) ) {
+			foreach ( $related_contents as $content_type => $content_ids ) {
+				if ( ! empty( $content_ids ) ) {
+					foreach ( $content_ids as $content_id ) {
+
+						if (
+							BP_Core_Suspend::check_hidden_content( $content_id, $content_type ) ||
+							BP_Core_Suspend::check_suspended_content( $content_id, $content_type )
+						) {
+							continue;
+						}
+
+						if (
+							! empty( $blocked_user ) &&
+							empty( $suspended_user ) &&
+							BP_Core_Suspend::check_blocked_user_content( $content_id, $content_type, $blocked_user )
+						) {
+							continue;
+						}
+
+						/**
+						 * Fire before hide item
+						 *
+						 * @since BuddyBoss 1.6.2
+						 *
+						 * @param string $content_type content type
+						 * @param int    $content_id   item id
+						 * @param array  $args         unhide item arguments
+						 */
+						do_action( 'bb_suspend_hide_before', $content_type, $content_id, $args );
+
+						$args['page'] = 1;
+
+						/**
+						 * Add related content of reported item into hidden list
+						 *
+						 * @since BuddyBoss 1.5.6
+						 *
+						 * @param int $content_id    item id
+						 * @param int $hide_sitewide item hidden sitewide or user specific
+						 */
+						do_action( 'bp_suspend_hide_' . $content_type, $content_id, null, $args );
 					}
-
-					if (
-						! empty( $blocked_user ) &&
-						empty( $suspended_user ) &&
-						BP_Core_Suspend::check_blocked_user_content( $content_id, $content_type, $blocked_user )
-					) {
-						continue;
-					}
-
-					/**
-					 * Fire before hide item
-					 *
-					 * @since BuddyBoss 1.6.2
-					 *
-					 * @param string $content_type content type
-					 * @param int    $content_id   item id
-					 * @param array  $args         unhide item arguments
-					 */
-					do_action( 'bb_suspend_hide_before', $content_type, $content_id, $args );
-
-					/**
-					 * Add related content of reported item into hidden list
-					 *
-					 * @since BuddyBoss 1.5.6
-					 *
-					 * @param int $content_id    item id
-					 * @param int $hide_sitewide item hidden sitewide or user specific
-					 */
-					do_action( 'bp_suspend_hide_' . $content_type, $content_id, null, $args );
 				}
+			}
+
+			if ( $this->backgroup_diabled ) {
+				$args['page'] = ++$page;
+				$this->hide_related_content( $item_id, $hide_sitewide, $args );
+			} else {
+				$args['page'] = ++$page;
+				$bp_background_updater->data(
+					array(
+						array(
+							'callback' => array( $this, 'hide_related_content' ),
+							'args'     => array( $item_id, $hide_sitewide, $args ),
+						),
+					)
+				);
+				$bp_background_updater->save()->schedule_event();
 			}
 		}
 	}
@@ -226,6 +267,8 @@ abstract class BP_Suspend_Abstract {
 	 * @param array    $args          parent args.
 	 */
 	public function unhide_related_content( $item_id, $hide_sitewide = 0, $force_all = 0, $args = array() ) {
+		global $bp_background_updater;
+
 		$args = $this->prepare_suspend_args( $item_id, $hide_sitewide, $args );
 
 		if ( empty( $item_id ) ) {
@@ -240,54 +283,86 @@ abstract class BP_Suspend_Abstract {
 		$action_suspend = ! empty( $args['action_suspend'] ) ? $args['action_suspend'] : '';
 		$hide_parent    = ! empty( $args['hide_parent'] ) ? $args['hide_parent'] : '';
 
-		$related_contents = $this->get_related_contents( $item_id, $args );
+		if ( ! isset( $args['enable_pagination'] ) ) {
+			$args['enable_pagination'] = 1;
+		}
 
-		foreach ( $related_contents as $content_type => $content_ids ) {
-			if ( ! empty( $content_ids ) ) {
-				foreach ( $content_ids as $content_id ) {
+		$page = 1;
 
-					if (
-						! empty( $blocked_user ) &&
-						empty( $action_suspend ) &&
-						! BP_Core_Suspend::check_blocked_user_content( $content_id, $content_type, $blocked_user )
-					) {
-						continue;
+		if ( empty( $args['page'] ) ) {
+			$args['page'] = $page;
+		} else {
+			$page = $args['page'];
+		}
+
+		$related_contents = array_filter( $this->get_related_contents( $item_id, $args ) );
+
+		if ( ! empty( $related_contents ) ) {
+			foreach ( $related_contents as $content_type => $content_ids ) {
+				if ( ! empty( $content_ids ) ) {
+					foreach ( $content_ids as $content_id ) {
+
+						if (
+							! empty( $blocked_user ) &&
+							empty( $action_suspend ) &&
+							! BP_Core_Suspend::check_blocked_user_content( $content_id, $content_type, $blocked_user )
+						) {
+							continue;
+						}
+
+						if (
+							(
+								! empty( $action_suspend )
+								|| empty( $hide_parent )
+							) &&
+							! (
+								BP_Core_Suspend::check_hidden_content( $content_id, $content_type ) ||
+								BP_Core_Suspend::check_suspended_content( $content_id, $content_type )
+							)
+						) {
+							continue;
+						}
+
+						/**
+						 * Fire before unhide item
+						 *
+						 * @since BuddyBoss 1.6.2
+						 *
+						 * @param string $content_type content type
+						 * @param int    $content_id   item id
+						 * @param array  $args         unhide item arguments
+						 */
+						do_action( 'bb_suspend_unhide_before', $content_type, $content_id, $args );
+
+						$args['page'] = 1;
+
+						/**
+						 * Remove related content of reported item from hidden list.
+						 *
+						 * @since BuddyBoss 1.5.6
+						 *
+						 * @param int $content_id    item id
+						 * @param int $hide_sitewide item hidden sitewide or user specific
+						 */
+						do_action( 'bp_suspend_unhide_' . $content_type, $content_id, null, $force_all, $args );
 					}
-
-					if (
-						(
-							! empty( $action_suspend )
-							|| empty( $hide_parent )
-						) &&
-						! (
-							BP_Core_Suspend::check_hidden_content( $content_id, $content_type ) ||
-							BP_Core_Suspend::check_suspended_content( $content_id, $content_type )
-						)
-					) {
-						continue;
-					}
-
-					/**
-					 * Fire before unhide item
-					 *
-					 * @since BuddyBoss 1.6.2
-					 *
-					 * @param string $content_type content type
-					 * @param int    $content_id   item id
-					 * @param array  $args         unhide item arguments
-					 */
-					do_action( 'bb_suspend_unhide_before', $content_type, $content_id, $args );
-
-					/**
-					 * Remove related content of reported item from hidden list.
-					 *
-					 * @since BuddyBoss 1.5.6
-					 *
-					 * @param int $content_id    item id
-					 * @param int $hide_sitewide item hidden sitewide or user specific
-					 */
-					do_action( 'bp_suspend_unhide_' . $content_type, $content_id, null, $force_all, $args );
 				}
+			}
+
+			if ( $this->backgroup_diabled ) {
+				$args['page'] = ++$page;
+				$this->unhide_related_content( $item_id, $hide_sitewide, $force_all, $args );
+			} else {
+				$args['page'] = ++$page;
+				$bp_background_updater->data(
+					array(
+						array(
+							'callback' => array( $this, 'unhide_related_content' ),
+							'args'     => array( $item_id, $hide_sitewide, $force_all, $args ),
+						),
+					)
+				);
+				$bp_background_updater->save()->schedule_event();
 			}
 		}
 	}

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-abstract.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-abstract.php
@@ -212,10 +212,12 @@ abstract class BP_Suspend_Abstract {
 				$this->hide_related_content( $item_id, $hide_sitewide, $args );
 			} else {
 				$args['page'] = ++$page;
-				$bp_background_updater->push_to_queue(
+				$bp_background_updater->data(
 					array(
-						'callback' => array( $this, 'hide_related_content' ),
-						'args'     => array( $item_id, $hide_sitewide, $args ),
+						array(
+							'callback' => array( $this, 'hide_related_content' ),
+							'args'     => array( $item_id, $hide_sitewide, $args ),
+						),
 					)
 				);
 				$bp_background_updater->save()->schedule_event();
@@ -352,10 +354,12 @@ abstract class BP_Suspend_Abstract {
 				$this->unhide_related_content( $item_id, $hide_sitewide, $force_all, $args );
 			} else {
 				$args['page'] = ++$page;
-				$bp_background_updater->push_to_queue(
+				$bp_background_updater->data(
 					array(
-						'callback' => array( $this, 'unhide_related_content' ),
-						'args'     => array( $item_id, $hide_sitewide, $force_all, $args ),
+						array(
+							'callback' => array( $this, 'unhide_related_content' ),
+							'args'     => array( $item_id, $hide_sitewide, $force_all, $args ),
+						),
 					)
 				);
 				$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-abstract.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-abstract.php
@@ -21,7 +21,7 @@ abstract class BP_Suspend_Abstract {
 	 *
 	 * @var string
 	 */
-	public $backgroup_diabled = false;
+	public $background_disabled = false;
 
 	/**
 	 * Item per page
@@ -207,17 +207,15 @@ abstract class BP_Suspend_Abstract {
 				}
 			}
 
-			if ( $this->backgroup_diabled ) {
+			if ( $this->background_disabled ) {
 				$args['page'] = ++$page;
 				$this->hide_related_content( $item_id, $hide_sitewide, $args );
 			} else {
 				$args['page'] = ++$page;
-				$bp_background_updater->data(
+				$bp_background_updater->push_to_queue(
 					array(
-						array(
-							'callback' => array( $this, 'hide_related_content' ),
-							'args'     => array( $item_id, $hide_sitewide, $args ),
-						),
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $item_id, $hide_sitewide, $args ),
 					)
 				);
 				$bp_background_updater->save()->schedule_event();
@@ -349,17 +347,15 @@ abstract class BP_Suspend_Abstract {
 				}
 			}
 
-			if ( $this->backgroup_diabled ) {
+			if ( $this->background_disabled ) {
 				$args['page'] = ++$page;
 				$this->unhide_related_content( $item_id, $hide_sitewide, $force_all, $args );
 			} else {
 				$args['page'] = ++$page;
-				$bp_background_updater->data(
+				$bp_background_updater->push_to_queue(
 					array(
-						array(
-							'callback' => array( $this, 'unhide_related_content' ),
-							'args'     => array( $item_id, $hide_sitewide, $force_all, $args ),
-						),
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $item_id, $hide_sitewide, $force_all, $args ),
 					)
 				);
 				$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-activity-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-activity-comment.php
@@ -65,22 +65,27 @@ class BP_Suspend_Activity_Comment extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_activity_comment_ids( $member_id, $action = '' ) {
+	public static function get_member_activity_comment_ids( $member_id, $action = '', $page = - 1 ) {
 		$activities_ids = array();
 
-		$activities = BP_Activity_Activity::get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'show_hidden'      => true,
-				'display_comments' => true,
-				'filter'           => array(
-					'user_id' => $member_id,
-					'action'  => 'activity_comment',
-				),
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'show_hidden'      => true,
+			'display_comments' => true,
+			'filter'           => array(
+				'user_id' => $member_id,
+				'action'  => 'activity_comment',
+			),
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$activities = BP_Activity_Activity::get( $args );
 
 		if ( ! empty( $activities['activities'] ) ) {
 			$activities_ids = $activities['activities'];
@@ -305,6 +310,11 @@ class BP_Suspend_Activity_Comment extends BP_Suspend_Abstract {
 	protected function get_related_contents( $acomment_id, $args = array() ) {
 		$action       = ! empty( $args['action'] ) ? $args['action'] : '';
 		$blocked_user = ! empty( $args['blocked_user'] ) ? $args['blocked_user'] : '';
+		$page         = ! empty( $args['page'] ) ? $args['page'] : - 1;
+
+		if ( $page > 1 ) {
+			return array();
+		}
 
 		$related_contents = array();
 

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-activity-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-activity-comment.php
@@ -62,6 +62,7 @@ class BP_Suspend_Activity_Comment extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-activity-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-activity-comment.php
@@ -191,13 +191,15 @@ class BP_Suspend_Activity_Comment extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $acomment_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $acomment_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $acomment_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -245,13 +247,15 @@ class BP_Suspend_Activity_Comment extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $acomment_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $acomment_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $acomment_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-activity-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-activity-comment.php
@@ -196,7 +196,7 @@ class BP_Suspend_Activity_Comment extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $acomment_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -252,7 +252,7 @@ class BP_Suspend_Activity_Comment extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $acomment_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
@@ -71,20 +71,25 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_activity_ids( $member_id, $action = '' ) {
+	public static function get_member_activity_ids( $member_id, $action = '', $page = - 1 ) {
 		$activities_ids = array();
 
-		$activities = BP_Activity_Activity::get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'show_hidden'      => true,
-				'filter'           => array(
-					'user_id' => $member_id,
-				),
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'show_hidden'      => true,
+			'filter'           => array(
+				'user_id' => $member_id,
+			),
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$activities = BP_Activity_Activity::get( $args );
 
 		if ( ! empty( $activities['activities'] ) ) {
 			$activities_ids = $activities['activities'];
@@ -110,21 +115,26 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_group_activity_ids( $group_id ) {
+	public static function get_group_activity_ids( $group_id, $page = - 1 ) {
 		$activities_ids = array();
 
-		$activities = BP_Activity_Activity::get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'show_hidden'      => true,
-				'filter'           => array(
-					'primary_id' => $group_id,
-					'object'     => 'groups',
-				),
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'show_hidden'      => true,
+			'filter'           => array(
+				'primary_id' => $group_id,
+				'object'     => 'groups',
+			),
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$activities = BP_Activity_Activity::get( $args );
 
 		if ( ! empty( $activities['activities'] ) ) {
 			$activities_ids = $activities['activities'];
@@ -142,40 +152,45 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_bbpress_activity_ids( $post_id ) {
+	public static function get_bbpress_activity_ids( $post_id, $page = -1 ) {
 		$activities_ids = array();
 
-		$activities = BP_Activity_Activity::get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'show_hidden'      => true,
-				'filter_query'     => array(
-					'relation' => 'or',
-					'bbpress'  => array(
-						array(
-							'column' => 'item_id',
-							'value'  => $post_id,
-						),
-						array(
-							'column' => 'component',
-							'value'  => 'bbpress',
-						),
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'show_hidden'      => true,
+			'filter_query'     => array(
+				'relation' => 'or',
+				'bbpress'  => array(
+					array(
+						'column' => 'item_id',
+						'value'  => $post_id,
 					),
-					'group'    => array(
-						array(
-							'column' => 'secondary_item_id',
-							'value'  => $post_id,
-						),
-						array(
-							'column' => 'component',
-							'value'  => 'groups',
-						),
+					array(
+						'column' => 'component',
+						'value'  => 'bbpress',
 					),
 				),
-			)
+				'group'    => array(
+					array(
+						'column' => 'secondary_item_id',
+						'value'  => $post_id,
+					),
+					array(
+						'column' => 'component',
+						'value'  => 'groups',
+					),
+				),
+			),
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$activities = BP_Activity_Activity::get( $args );
 
 		if ( ! empty( $activities['activities'] ) ) {
 			$activities_ids = $activities['activities'];
@@ -391,6 +406,11 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 	protected function get_related_contents( $activity_id, $args = array() ) {
 		$action       = ! empty( $args['action'] ) ? $args['action'] : '';
 		$blocked_user = ! empty( $args['blocked_user'] ) ? $args['blocked_user'] : '';
+		$page         = ! empty( $args['page'] ) ? $args['page'] : - 1;
+
+		if ( $page > 1 ) {
+			return array();
+		}
 
 		$related_contents = array(
 			BP_Suspend_Activity_Comment::$type => BP_Suspend_Activity_Comment::get_activity_comment_ids( $activity_id ),

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
@@ -322,7 +322,7 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $activity_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -378,7 +378,7 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $activity_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
@@ -152,7 +152,7 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_bbpress_activity_ids( $post_id, $page = -1 ) {
+	public static function get_bbpress_activity_ids( $post_id, $page = - 1 ) {
 		$activities_ids = array();
 
 		$args = array(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
@@ -68,6 +68,7 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */
@@ -112,6 +113,7 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.5.6
 	 *
 	 * @param int $group_id group id.
+	 * @param int $page     Number of page.
 	 *
 	 * @return array
 	 */
@@ -149,6 +151,7 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.5.6
 	 *
 	 * @param int $post_id post id.
+	 * @param int $page    Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-activity.php
@@ -307,13 +307,15 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $activity_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $activity_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $activity_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -361,13 +363,15 @@ class BP_Suspend_Activity extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $activity_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $activity_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $activity_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-album.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-album.php
@@ -66,17 +66,22 @@ class BP_Suspend_Album extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_album_ids( $member_id, $action = '' ) {
+	public static function get_member_album_ids( $member_id, $action = '', $page = - 1 ) {
 		$album_ids = array();
 
-		$albums = bp_album_get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'user_id'          => $member_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'user_id'          => $member_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$albums = bp_album_get( $args );
 
 		if ( ! empty( $albums['albums'] ) ) {
 			$album_ids = $albums['albums'];
@@ -102,17 +107,22 @@ class BP_Suspend_Album extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_group_album_ids( $group_id ) {
+	public static function get_group_album_ids( $group_id, $page = - 1 ) {
 		$album_ids = array();
 
-		$albums = bp_album_get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'group_id'         => $group_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'group_id'         => $group_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$albums = bp_album_get( $args );
 
 		if ( ! empty( $albums['albums'] ) ) {
 			$album_ids = $albums['albums'];
@@ -297,8 +307,14 @@ class BP_Suspend_Album extends BP_Suspend_Abstract {
 	 * @return array
 	 */
 	protected function get_related_contents( $album_id, $args = array() ) {
-		$related_contents                            = array();
-		$related_contents[ BP_Suspend_Media::$type ] = BP_Media::get_album_media_ids( $album_id );;
+		$related_contents = array();
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
+
+		if ( $page > 1 ) {
+			return $related_contents;
+		}
+
+		$related_contents[ BP_Suspend_Media::$type ] = BP_Media::get_album_media_ids( $album_id );
 
 		return $related_contents;
 	}

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-album.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-album.php
@@ -215,13 +215,15 @@ class BP_Suspend_Album extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $album_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $album_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $album_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -269,13 +271,15 @@ class BP_Suspend_Album extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $album_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $album_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $album_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-album.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-album.php
@@ -63,6 +63,7 @@ class BP_Suspend_Album extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */
@@ -104,6 +105,7 @@ class BP_Suspend_Album extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.5.6
 	 *
 	 * @param int $group_id group id.
+	 * @param int $page     Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-album.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-album.php
@@ -225,7 +225,7 @@ class BP_Suspend_Album extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $album_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -281,7 +281,7 @@ class BP_Suspend_Album extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $album_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
@@ -232,7 +232,7 @@ class BP_Suspend_Comment extends BP_Suspend_Abstract {
 	 */
 	public function blocked_get_comment_author_link( $return, $author, $comment_id ) {
 
-		if ( $this->check_is_hidden( $comment_id) ) {
+		if ( $this->check_is_hidden( $comment_id ) ) {
 			$return = esc_html__( 'Suspended Member', 'buddyboss' );
 		}
 

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
@@ -66,6 +66,7 @@ class BP_Suspend_Comment extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id Member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
@@ -124,7 +124,7 @@ class BP_Suspend_Comment extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $comment_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -180,7 +180,7 @@ class BP_Suspend_Comment extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $comment_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
@@ -119,13 +119,15 @@ class BP_Suspend_Comment extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $comment_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $comment_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $comment_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -173,13 +175,15 @@ class BP_Suspend_Comment extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $comment_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $comment_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $comment_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
@@ -79,7 +79,7 @@ class BP_Suspend_Comment extends BP_Suspend_Abstract {
 		);
 
 		if ( $page > 0 ) {
-			$args['offset'] = ( $page - 1 ) * self::$item_per_page;
+			$args['number'] = self::$item_per_page;
 			$args['paged']  = $page;
 		}
 

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-comment.php
@@ -69,16 +69,21 @@ class BP_Suspend_Comment extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_comment_ids( $member_id, $action = '' ) {
+	public static function get_member_comment_ids( $member_id, $action = '', $page = - 1 ) {
 
-		$comment_ids = get_comments(
-			array(
-				'user_id'                   => $member_id,
-				'fields'                    => 'ids',
-				'update_comment_meta_cache' => false,
-				'update_comment_post_cache' => false,
-			)
+		$args = array(
+			'user_id'                   => $member_id,
+			'fields'                    => 'ids',
+			'update_comment_meta_cache' => false,
+			'update_comment_post_cache' => false,
 		);
+
+		if ( $page > 0 ) {
+			$args['offset'] = ( $page - 1 ) * self::$item_per_page;
+			$args['paged']  = $page;
+		}
+
+		$comment_ids = get_comments( $args );
 
 		if ( 'hide' === $action && ! empty( $comment_ids ) ) {
 			foreach ( $comment_ids as $k => $comment_id ) {
@@ -381,6 +386,11 @@ class BP_Suspend_Comment extends BP_Suspend_Abstract {
 	protected function get_related_contents( $comment_id, $args = array() ) {
 
 		$related_contents = array();
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
+
+		if ( $page > 1 ) {
+			return $related_contents;
+		}
 
 		if ( bp_is_active( 'activity' ) ) {
 			$a_comment_id = get_comment_meta( $comment_id, 'bp_activity_comment_id', true );

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-document.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-document.php
@@ -267,13 +267,15 @@ class BP_Suspend_Document extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $document_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $document_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $document_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -321,13 +323,15 @@ class BP_Suspend_Document extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $document_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $document_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $document_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-document.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-document.php
@@ -72,17 +72,22 @@ class BP_Suspend_Document extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_document_ids( $member_id, $action = '' ) {
+	public static function get_member_document_ids( $member_id, $action = '', $page = - 1 ) {
 		$document_ids = array();
 
-		$documents = BP_Document::get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'user_id'          => $member_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'user_id'          => $member_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$documents = BP_Document::get( $args );
 
 		if ( ! empty( $documents['documents'] ) ) {
 			$document_ids = $documents['documents'];
@@ -108,17 +113,22 @@ class BP_Suspend_Document extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_group_document_ids( $group_id ) {
+	public static function get_group_document_ids( $group_id, $page = - 1 ) {
 		$document_ids = array();
 
-		$documents = BP_Document::get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'group_id'         => $group_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'group_id'         => $group_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$documents = BP_Document::get( $args );
 
 		if ( ! empty( $documents['documents'] ) ) {
 			$document_ids = $documents['documents'];
@@ -351,8 +361,14 @@ class BP_Suspend_Document extends BP_Suspend_Abstract {
 	protected function get_related_contents( $document_id, $args = array() ) {
 		$action           = ! empty( $args['action'] ) ? $args['action'] : '';
 		$blocked_user     = ! empty( $args['blocked_user'] ) ? $args['blocked_user'] : '';
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
 		$related_contents = array();
-		$document         = new BP_Document( $document_id );
+
+		if ( $page > 1 ) {
+			return $related_contents;
+		}
+
+		$document = new BP_Document( $document_id );
 
 		if ( bp_is_active( 'activity' ) && ! empty( $document ) && ! empty( $document->activity_id ) ) {
 

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-document.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-document.php
@@ -277,7 +277,7 @@ class BP_Suspend_Document extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $document_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -333,7 +333,7 @@ class BP_Suspend_Document extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $document_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-document.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-document.php
@@ -69,6 +69,7 @@ class BP_Suspend_Document extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id Member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */
@@ -110,6 +111,7 @@ class BP_Suspend_Document extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.5.6
 	 *
 	 * @param int $group_id group id.
+	 * @param int $page     Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-folder.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-folder.php
@@ -215,13 +215,15 @@ class BP_Suspend_Folder extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $folder_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $folder_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $folder_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -269,13 +271,15 @@ class BP_Suspend_Folder extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $folder_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $folder_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $folder_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-folder.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-folder.php
@@ -225,7 +225,7 @@ class BP_Suspend_Folder extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $folder_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -281,7 +281,7 @@ class BP_Suspend_Folder extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $folder_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-folder.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-folder.php
@@ -66,17 +66,22 @@ class BP_Suspend_Folder extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_folder_ids( $member_id, $action = '' ) {
+	public static function get_member_folder_ids( $member_id, $action = '', $page = - 1 ) {
 		$folder_ids = array();
 
-		$folders = BP_Document_Folder::get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'user_id'          => $member_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'user_id'          => $member_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$folders = BP_Document_Folder::get( $args );
 
 		if ( ! empty( $folders['folders'] ) ) {
 			$folder_ids = $folders['folders'];
@@ -102,17 +107,22 @@ class BP_Suspend_Folder extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_group_folder_ids( $group_id ) {
+	public static function get_group_folder_ids( $group_id, $page = - 1 ) {
 		$folder_ids = array();
 
-		$folders = BP_Document_Folder::get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'group_id'         => $group_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'group_id'         => $group_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$folders = BP_Document_Folder::get( $args );
 
 		if ( ! empty( $folders['folders'] ) ) {
 			$folder_ids = $folders['folders'];

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-folder.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-folder.php
@@ -63,6 +63,7 @@ class BP_Suspend_Folder extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id Member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */
@@ -104,6 +105,7 @@ class BP_Suspend_Folder extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.5.6
 	 *
 	 * @param int $group_id Group id.
+	 * @param int $page     Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum-reply.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum-reply.php
@@ -278,7 +278,7 @@ class BP_Suspend_Forum_Reply extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $reply_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -334,7 +334,7 @@ class BP_Suspend_Forum_Reply extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $reply_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum-reply.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum-reply.php
@@ -268,13 +268,15 @@ class BP_Suspend_Forum_Reply extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $reply_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $reply_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $reply_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -322,13 +324,15 @@ class BP_Suspend_Forum_Reply extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $reply_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $reply_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $reply_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum-reply.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum-reply.php
@@ -77,6 +77,7 @@ class BP_Suspend_Forum_Reply extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id Member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */
@@ -123,6 +124,7 @@ class BP_Suspend_Forum_Reply extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.5.6
 	 *
 	 * @param int $parent_id topic/reply id.
+	 * @param int $page      Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum-reply.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum-reply.php
@@ -80,22 +80,27 @@ class BP_Suspend_Forum_Reply extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_reply_ids( $member_id, $action = '' ) {
+	public static function get_member_reply_ids( $member_id, $action = '', $page = - 1 ) {
 		$reply_ids = array();
 
-		$reply_query = new WP_Query(
-			array(
-				'fields'                 => 'ids',
-				'post_type'              => bbp_get_reply_post_type(),
-				'post_status'            => 'publish',
-				'author'                 => $member_id,
-				'posts_per_page'         => - 1,
-				// Need to get all topics id of hidden forums.
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-				'suppress_filters'       => true,
-			)
+		$args = array(
+			'fields'                 => 'ids',
+			'post_type'              => bbp_get_reply_post_type(),
+			'post_status'            => 'publish',
+			'author'                 => $member_id,
+			'posts_per_page'         => - 1,
+			// Need to get all topics id of hidden forums.
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'suppress_filters'       => true,
 		);
+
+		if ( $page > 0 ) {
+			$args['posts_per_page'] = self::$item_per_page;
+			$args['paged']          = $page;
+		}
+
+		$reply_query = new WP_Query( $args );
 
 		if ( $reply_query->have_posts() ) {
 			$reply_ids = $reply_query->posts;
@@ -121,22 +126,27 @@ class BP_Suspend_Forum_Reply extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_topic_reply_replies( $parent_id ) {
+	public static function get_topic_reply_replies( $parent_id, $page = - 1 ) {
 		$reply_ids = array();
 
-		$reply_query = new WP_Query(
-			array(
-				'fields'                 => 'ids',
-				'post_type'              => bbp_get_reply_post_type(),
-				'post_status'            => 'publish',
-				'post_parent'            => $parent_id,
-				'posts_per_page'         => - 1,
-				// Need to get all topics id of hidden forums.
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-				'suppress_filters'       => true,
-			)
+		$args = array(
+			'fields'                 => 'ids',
+			'post_type'              => bbp_get_reply_post_type(),
+			'post_status'            => 'publish',
+			'post_parent'            => $parent_id,
+			'posts_per_page'         => - 1,
+			// Need to get all topics id of hidden forums.
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'suppress_filters'       => true,
 		);
+
+		if ( $page > 0 ) {
+			$args['posts_per_page'] = self::$item_per_page;
+			$args['paged']          = $page;
+		}
+
+		$reply_query = new WP_Query( $args );
 
 		if ( $reply_query->have_posts() ) {
 			$reply_ids = $reply_query->posts;
@@ -384,26 +394,27 @@ class BP_Suspend_Forum_Reply extends BP_Suspend_Abstract {
 		$related_contents = array();
 		$action           = ! empty( $args['action'] ) ? $args['action'] : '';
 		$blocked_user     = ! empty( $args['blocked_user'] ) ? $args['blocked_user'] : '';
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
 
 		// related activity comment only hide if parent activity hide or comment's/parent activity's author blocked or suspended.
 		if ( ! empty( $args ) && ( isset( $args['blocked_user'] ) || isset( $args['user_suspended'] ) || isset( $args['hide_parent'] ) ) ) {
-			$related_contents[ self::$type ] = self::get_topic_reply_replies( $reply_id );
+			$related_contents[ self::$type ] = self::get_topic_reply_replies( $reply_id, $page );
 		}
 
-		if ( bp_is_active( 'activity' ) ) {
+		if ( bp_is_active( 'activity' ) && $page < 2 ) {
 			$activity_id                                    = get_post_meta( $reply_id, '_bbp_activity_id', true );
 			$related_contents[ BP_Suspend_Activity::$type ] = array( $activity_id );
 		}
 
-		if ( bp_is_active( 'document' ) ) {
+		if ( bp_is_active( 'document' ) && $page < 2 ) {
 			$related_contents[ BP_Suspend_Document::$type ] = BP_Suspend_Document::get_document_ids_meta( $reply_id, 'get_post_meta', $action );
 		}
 
-		if ( bp_is_active( 'media' ) ) {
+		if ( bp_is_active( 'media' ) && $page < 2 ) {
 			$related_contents[ BP_Suspend_Media::$type ] = BP_Suspend_Media::get_media_ids_meta( $reply_id, 'get_post_meta', $action );
 		}
 
-		if ( bp_is_active( 'video' ) ) {
+		if ( bp_is_active( 'video' ) && $page < 2 ) {
 			$related_contents[ BP_Suspend_Video::$type ] = BP_Suspend_Video::get_video_ids_meta( $reply_id, 'get_post_meta', $action );
 		}
 

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum-topic.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum-topic.php
@@ -76,6 +76,7 @@ class BP_Suspend_Forum_Topic extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id Member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */
@@ -122,6 +123,7 @@ class BP_Suspend_Forum_Topic extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.5.6
 	 *
 	 * @param int $forum_id forums id.
+	 * @param int $page     Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum-topic.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum-topic.php
@@ -294,13 +294,15 @@ class BP_Suspend_Forum_Topic extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $topic_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $topic_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $topic_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -348,13 +350,15 @@ class BP_Suspend_Forum_Topic extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $topic_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $topic_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $topic_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum-topic.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum-topic.php
@@ -79,22 +79,27 @@ class BP_Suspend_Forum_Topic extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_topic_ids( $member_id, $action = '' ) {
+	public static function get_member_topic_ids( $member_id, $action = '', $page = - 1 ) {
 		$topic_ids = array();
 
-		$topic_query = new WP_Query(
-			array(
-				'fields'                 => 'ids',
-				'post_type'              => bbp_get_topic_post_type(),
-				'post_status'            => 'publish',
-				'author'                 => $member_id,
-				'posts_per_page'         => - 1,
-				// Need to get all topics id of hidden forums.
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-				'suppress_filters'       => true,
-			)
+		$args = array(
+			'fields'                 => 'ids',
+			'post_type'              => bbp_get_topic_post_type(),
+			'post_status'            => 'publish',
+			'author'                 => $member_id,
+			'posts_per_page'         => - 1,
+			// Need to get all topics id of hidden forums.
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'suppress_filters'       => true,
 		);
+
+		if ( $page > 0 ) {
+			$args['posts_per_page'] = self::$item_per_page;
+			$args['paged']          = $page;
+		}
+
+		$topic_query = new WP_Query( $args );
 
 		if ( $topic_query->have_posts() ) {
 			$topic_ids = $topic_query->posts;
@@ -120,22 +125,27 @@ class BP_Suspend_Forum_Topic extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_forum_topics_ids( $forum_id ) {
+	public static function get_forum_topics_ids( $forum_id, $page = - 1 ) {
 		$topic_ids = array();
 
-		$topic_query = new WP_Query(
-			array(
-				'fields'                 => 'ids',
-				'post_type'              => bbp_get_topic_post_type(),
-				'post_status'            => 'publish',
-				'post_parent'            => $forum_id,
-				'posts_per_page'         => - 1,
-				// Need to get all topics id of hidden forums.
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-				'suppress_filters'       => true,
-			)
+		$args = array(
+			'fields'                 => 'ids',
+			'post_type'              => bbp_get_topic_post_type(),
+			'post_status'            => 'publish',
+			'post_parent'            => $forum_id,
+			'posts_per_page'         => - 1,
+			// Need to get all topics id of hidden forums.
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'suppress_filters'       => true,
 		);
+
+		if ( $page > 0 ) {
+			$args['posts_per_page'] = self::$item_per_page;
+			$args['paged']          = $page;
+		}
+
+		$topic_query = new WP_Query( $args );
 
 		if ( $topic_query->have_posts() ) {
 			$topic_ids = $topic_query->posts;
@@ -379,25 +389,26 @@ class BP_Suspend_Forum_Topic extends BP_Suspend_Abstract {
 		$related_contents = array();
 		$action           = ! empty( $args['action'] ) ? $args['action'] : '';
 		$blocked_user     = ! empty( $args['blocked_user'] ) ? $args['blocked_user'] : '';
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
 
 		if ( bp_is_active( 'forums' ) ) {
-			$related_contents[ BP_Suspend_Forum_Reply::$type ] = BP_Suspend_Forum_Reply::get_topic_reply_replies( $topic_id );
+			$related_contents[ BP_Suspend_Forum_Reply::$type ] = BP_Suspend_Forum_Reply::get_topic_reply_replies( $topic_id, $page );
 		}
 
-		if ( bp_is_active( 'activity' ) ) {
+		if ( bp_is_active( 'activity' ) && $page < 2 ) {
 			$activity_id                                    = get_post_meta( $topic_id, '_bbp_activity_id', true );
 			$related_contents[ BP_Suspend_Activity::$type ] = array( $activity_id );
 		}
 
-		if ( bp_is_active( 'document' ) ) {
+		if ( bp_is_active( 'document' ) && $page < 2 ) {
 			$related_contents[ BP_Suspend_Document::$type ] = BP_Suspend_Document::get_document_ids_meta( $topic_id, 'get_post_meta', $action );
 		}
 
-		if ( bp_is_active( 'media' ) ) {
+		if ( bp_is_active( 'media' ) && $page < 2 ) {
 			$related_contents[ BP_Suspend_Media::$type ] = BP_Suspend_Media::get_media_ids_meta( $topic_id, 'get_post_meta', $action );
 		}
 
-		if ( bp_is_active( 'video' ) ) {
+		if ( bp_is_active( 'video' ) && $page < 2 ) {
 			$related_contents[ BP_Suspend_Video::$type ] = BP_Suspend_Video::get_video_ids_meta( $topic_id, 'get_post_meta', $action );
 		}
 

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum-topic.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum-topic.php
@@ -304,7 +304,7 @@ class BP_Suspend_Forum_Topic extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $topic_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -360,7 +360,7 @@ class BP_Suspend_Forum_Topic extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $topic_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
@@ -76,6 +76,7 @@ class BP_Suspend_Forum extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id Member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
@@ -283,10 +283,12 @@ class BP_Suspend_Forum extends BP_Suspend_Abstract {
 		if ( $this->backgroup_diabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
 			$this->hide_related_content( $forum_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $forum_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $forum_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -343,10 +345,12 @@ class BP_Suspend_Forum extends BP_Suspend_Abstract {
 		if ( $this->backgroup_diabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
 			$this->unhide_related_content( $forum_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $forum_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $forum_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
@@ -79,22 +79,27 @@ class BP_Suspend_Forum extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_forum_ids( $member_id, $action = '' ) {
+	public static function get_member_forum_ids( $member_id, $action = '', $page = - 1 ) {
 		$forum_ids = array();
 
-		$forum_query = new WP_Query(
-			array(
-				'fields'                 => 'ids',
-				'post_type'              => bbp_get_forum_post_type(),
-				'post_status'            => 'publish',
-				'author'                 => $member_id,
-				'posts_per_page'         => - 1,
-				// Need to get all topics id of hidden forums.
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-				'suppress_filters'       => true,
-			)
+		$args = array(
+			'fields'                 => 'ids',
+			'post_type'              => bbp_get_forum_post_type(),
+			'post_status'            => 'publish',
+			'author'                 => $member_id,
+			'posts_per_page'         => - 1,
+			// Need to get all topics id of hidden forums.
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'suppress_filters'       => true,
 		);
+
+		if ( $page > 0 ) {
+			$args['posts_per_page'] = self::$item_per_page;
+			$args['paged']          = $page;
+		}
+
+		$forum_query = new WP_Query( $args );
 
 		if ( $forum_query->have_posts() ) {
 			$forum_ids = $forum_query->posts;
@@ -371,13 +376,14 @@ class BP_Suspend_Forum extends BP_Suspend_Abstract {
 		$related_contents = array();
 		$action           = ! empty( $args['action'] ) ? $args['action'] : '';
 		$blocked_user     = ! empty( $args['blocked_user'] ) ? $args['blocked_user'] : '';
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
 
 		if ( bp_is_active( 'forums' ) ) {
-			$related_contents[ BP_Suspend_Forum_Topic::$type ] = BP_Suspend_Forum_Topic::get_forum_topics_ids( $forum_id );
+			$related_contents[ BP_Suspend_Forum_Topic::$type ] = BP_Suspend_Forum_Topic::get_forum_topics_ids( $forum_id, $page );
 		}
 
 		if ( bp_is_active( 'activity' ) ) {
-			$related_contents[ BP_Suspend_Activity::$type ] = BP_Suspend_Activity::get_bbpress_activity_ids( $forum_id );
+			$related_contents[ BP_Suspend_Activity::$type ] = BP_Suspend_Activity::get_bbpress_activity_ids( $forum_id, $page );
 		}
 
 		return $related_contents;

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
@@ -285,7 +285,7 @@ class BP_Suspend_Forum extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
+		if ( $this->background_disabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
 			$this->hide_related_content( $forum_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -347,7 +347,7 @@ class BP_Suspend_Forum extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
+		if ( $this->background_disabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
 			$this->unhide_related_content( $forum_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-forum.php
@@ -286,7 +286,7 @@ class BP_Suspend_Forum extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->background_disabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
+		if ( $this->background_disabled || ! $force_bg_process ) {
 			$this->hide_related_content( $forum_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -348,7 +348,7 @@ class BP_Suspend_Forum extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->background_disabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
+		if ( $this->background_disabled || ! $force_bg_process ) {
 			$this->unhide_related_content( $forum_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-group.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-group.php
@@ -222,15 +222,17 @@ class BP_Suspend_Group extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$args['type'] = self::$type;
 			$this->hide_related_content( $group_id, $hide_sitewide, $args );
 		} else {
 			$args['type'] = self::$type;
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $group_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $group_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -279,15 +281,17 @@ class BP_Suspend_Group extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$args['type'] = self::$type;
 			$this->unhide_related_content( $group_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$args['type'] = self::$type;
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $group_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $group_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-group.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-group.php
@@ -222,7 +222,7 @@ class BP_Suspend_Group extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$args['type'] = self::$type;
 			$this->hide_related_content( $group_id, $hide_sitewide, $args );
 		} else {
@@ -281,7 +281,7 @@ class BP_Suspend_Group extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$args['type'] = self::$type;
 			$this->unhide_related_content( $group_id, $hide_sitewide, $force_all, $args );
 		} else {

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-group.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-group.php
@@ -310,31 +310,32 @@ class BP_Suspend_Group extends BP_Suspend_Abstract {
 	 */
 	protected function get_related_contents( $group_id, $args = array() ) {
 		$related_contents = array();
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
 
-		if ( bp_is_active( 'forums' ) ) {
+		if ( bp_is_active( 'forums' ) && $page < 2 ) {
 			$related_contents[ BP_Suspend_Forum::$type ] = (array) bbp_get_group_forum_ids( $group_id );
 		}
 
 		if ( bp_is_active( 'activity' ) ) {
-			$related_contents[ BP_Suspend_Activity::$type ] = BP_Suspend_Activity::get_group_activity_ids( $group_id );
+			$related_contents[ BP_Suspend_Activity::$type ] = BP_Suspend_Activity::get_group_activity_ids( $group_id, $page );
 		}
 
-		if ( bp_is_active( 'messages' ) ) {
+		if ( bp_is_active( 'messages' ) && $page < 2 ) {
 			$related_contents[ BP_Suspend_Message::$type ] = BP_Suspend_Message::get_group_message_thread_ids( $group_id );
 		}
 
 		if ( bp_is_active( 'document' ) ) {
-			$related_contents[ BP_Suspend_Folder::$type ]   = BP_Suspend_Folder::get_group_folder_ids( $group_id );
-			$related_contents[ BP_Suspend_Document::$type ] = BP_Suspend_Document::get_group_document_ids( $group_id );
+			$related_contents[ BP_Suspend_Folder::$type ]   = BP_Suspend_Folder::get_group_folder_ids( $group_id, $page );
+			$related_contents[ BP_Suspend_Document::$type ] = BP_Suspend_Document::get_group_document_ids( $group_id, $page );
 		}
 
 		if ( bp_is_active( 'media' ) ) {
-			$related_contents[ BP_Suspend_Album::$type ] = BP_Suspend_Album::get_group_album_ids( $group_id );
-			$related_contents[ BP_Suspend_Media::$type ] = BP_Suspend_Media::get_group_media_ids( $group_id );
+			$related_contents[ BP_Suspend_Album::$type ] = BP_Suspend_Album::get_group_album_ids( $group_id, $page );
+			$related_contents[ BP_Suspend_Media::$type ] = BP_Suspend_Media::get_group_media_ids( $group_id, $page );
 		}
 
 		if ( bp_is_active( 'video' ) ) {
-			$related_contents[ BP_Suspend_Video::$type ] = BP_Suspend_Video::get_group_video_ids( $group_id );
+			$related_contents[ BP_Suspend_Video::$type ] = BP_Suspend_Video::get_group_video_ids( $group_id, $page );
 		}
 
 		return $related_contents;

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-media.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-media.php
@@ -282,7 +282,7 @@ class BP_Suspend_Media extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $media_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -338,7 +338,7 @@ class BP_Suspend_Media extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $media_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-media.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-media.php
@@ -76,17 +76,22 @@ class BP_Suspend_Media extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_media_ids( $member_id, $action = '' ) {
+	public static function get_member_media_ids( $member_id, $action = '', $page = - 1 ) {
 		$media_ids = array();
 
-		$medias = bp_media_get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'user_id'          => $member_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'user_id'          => $member_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$medias = bp_media_get( $args );
 
 		if ( ! empty( $medias['medias'] ) ) {
 			$media_ids = $medias['medias'];
@@ -112,17 +117,22 @@ class BP_Suspend_Media extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_group_media_ids( $group_id ) {
+	public static function get_group_media_ids( $group_id, $page = - 1 ) {
 		$media_ids = array();
 
-		$medias = bp_media_get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'group_id'         => $group_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'group_id'         => $group_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$medias = bp_media_get( $args );
 
 		if ( ! empty( $medias['medias'] ) ) {
 			$media_ids = $medias['medias'];
@@ -356,8 +366,14 @@ class BP_Suspend_Media extends BP_Suspend_Abstract {
 	protected function get_related_contents( $media_id, $args = array() ) {
 		$action           = ! empty( $args['action'] ) ? $args['action'] : '';
 		$blocked_user     = ! empty( $args['blocked_user'] ) ? $args['blocked_user'] : '';
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
 		$related_contents = array();
-		$media            = new BP_Media( $media_id );
+
+		if ( $page > 1 ) {
+			return $related_contents;
+		}
+
+		$media = new BP_Media( $media_id );
 
 		if (
 			bp_is_active( 'activity' ) &&

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-media.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-media.php
@@ -272,13 +272,15 @@ class BP_Suspend_Media extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $media_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $media_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $media_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -326,13 +328,15 @@ class BP_Suspend_Media extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $media_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $media_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $media_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-media.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-media.php
@@ -73,6 +73,7 @@ class BP_Suspend_Media extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id Member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of items per page.
 	 *
 	 * @return array
 	 */
@@ -113,7 +114,8 @@ class BP_Suspend_Media extends BP_Suspend_Abstract {
 	 *
 	 * @since BuddyBoss 1.5.6
 	 *
-	 * @param int    $group_id group id.
+	 * @param int $group_id group id.
+	 * @param int $page     Number of items per page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
@@ -294,7 +294,7 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
+		if ( $this->background_disabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
 			$this->hide_related_content( $member_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -350,7 +350,7 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
+		if ( $this->background_disabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
 			$this->unhide_related_content( $member_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
@@ -297,10 +297,12 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 		if ( $this->backgroup_diabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
 			$this->hide_related_content( $member_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $member_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $member_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -351,10 +353,12 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 		if ( $this->backgroup_diabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
 			$this->unhide_related_content( $member_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $member_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $member_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
@@ -293,7 +293,7 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->background_disabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
+		if ( $this->background_disabled || ! $force_bg_process ) {
 			$this->hide_related_content( $member_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -349,7 +349,7 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->background_disabled || ( ! empty( $args ) && ! $force_bg_process ) ) {
+		if ( $this->background_disabled || ! $force_bg_process ) {
 			$this->unhide_related_content( $member_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
@@ -53,7 +53,7 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 
 		add_filter( 'bp_user_query_join_sql', array( $this, 'update_join_sql' ), 10, 2 );
 		add_filter( 'bp_user_query_where_sql', array( $this, 'update_where_sql' ), 10, 2 );
-		
+
 		add_filter( 'bp_user_search_join_sql', array( $this, 'update_join_sql' ), 10, 2 );
 		add_filter( 'bp_user_search_where_sql', array( $this, 'update_where_sql' ), 10, 2 );
 
@@ -79,7 +79,6 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.5.6
 	 *
 	 * @param int $user_id user id.
-	 *
 	 */
 	public static function suspend_user( $user_id ) {
 		BP_Core_Suspend::add_suspend(
@@ -115,7 +114,6 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.5.6
 	 *
 	 * @param int $user_id user id.
-	 *
 	 */
 	public static function unsuspend_user( $user_id ) {
 		BP_Core_Suspend::add_suspend(
@@ -227,16 +225,17 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 		) {
 			return $where_conditions;
 		}
-		
+
 		$where          = array();
 		$hidden_members = bp_moderation_get_hidden_user_ids();
 		if ( ! empty( $hidden_members ) ) {
 			$where['blocked_where'] = "( r.user_id NOT IN('" . implode( "','", $hidden_members ) . "') )";
 		}
-		
-		$sql                    = $wpdb->prepare( "SELECT DISTINCT {$this->alias}.item_id FROM {$bp->moderation->table_name} {$this->alias} WHERE {$this->alias}.item_type = %s
-								  AND ( {$this->alias}.user_suspended = 1 )", 'user' ); // phpcs:ignore
-		$where['suspend_where'] = "( r.user_id NOT IN( " . $sql . " ) )";
+
+		// phpcs:ignore
+		$sql                    = $wpdb->prepare( "SELECT DISTINCT {$this->alias}.item_id FROM {$bp->moderation->table_name} {$this->alias} WHERE {$this->alias}.item_type = %s AND ( {$this->alias}.user_suspended = 1 )", 'user' );
+		$where['suspend_where'] = '( r.user_id NOT IN( ' . $sql . ' ) )';
+
 		/**
 		 * Filters the hidden member Where SQL statement.
 		 *
@@ -533,9 +532,11 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 
 		$related_contents[ BP_Suspend_Comment::$type ] = BP_Suspend_Comment::get_member_comment_ids( $member_id, $action, $page );
 
-		/*if ( bp_is_active( 'groups' ) ) {
+		/*
+		if ( bp_is_active( 'groups' ) ) {
 			$related_contents[ BP_Suspend_Group::$type ] = BP_Suspend_Group::get_member_group_ids( $member_id );
-		}*/
+		}
+		*/
 
 		if ( bp_is_active( 'forums' ) ) {
 			$related_contents[ BP_Suspend_Forum::$type ]       = BP_Suspend_Forum::get_member_forum_ids( $member_id, $action, $page );

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
@@ -528,37 +528,38 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 	 */
 	protected function get_related_contents( $member_id, $args = array() ) {
 		$action           = ! empty( $args['action'] ) ? $args['action'] : '';
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
 		$related_contents = array();
 
-		$related_contents[ BP_Suspend_Comment::$type ] = BP_Suspend_Comment::get_member_comment_ids( $member_id, $action );
+		$related_contents[ BP_Suspend_Comment::$type ] = BP_Suspend_Comment::get_member_comment_ids( $member_id, $action, $page );
 
 		/*if ( bp_is_active( 'groups' ) ) {
 			$related_contents[ BP_Suspend_Group::$type ] = BP_Suspend_Group::get_member_group_ids( $member_id );
 		}*/
 
 		if ( bp_is_active( 'forums' ) ) {
-			$related_contents[ BP_Suspend_Forum::$type ]       = BP_Suspend_Forum::get_member_forum_ids( $member_id, $action );
-			$related_contents[ BP_Suspend_Forum_Topic::$type ] = BP_Suspend_Forum_Topic::get_member_topic_ids( $member_id, $action );
-			$related_contents[ BP_Suspend_Forum_Reply::$type ] = BP_Suspend_Forum_Reply::get_member_reply_ids( $member_id, $action );
+			$related_contents[ BP_Suspend_Forum::$type ]       = BP_Suspend_Forum::get_member_forum_ids( $member_id, $action, $page );
+			$related_contents[ BP_Suspend_Forum_Topic::$type ] = BP_Suspend_Forum_Topic::get_member_topic_ids( $member_id, $action, $page );
+			$related_contents[ BP_Suspend_Forum_Reply::$type ] = BP_Suspend_Forum_Reply::get_member_reply_ids( $member_id, $action, $page );
 		}
 
 		if ( bp_is_active( 'activity' ) ) {
-			$related_contents[ BP_Suspend_Activity::$type ]         = BP_Suspend_Activity::get_member_activity_ids( $member_id, $action );
-			$related_contents[ BP_Suspend_Activity_Comment::$type ] = BP_Suspend_Activity_Comment::get_member_activity_comment_ids( $member_id, $action );
+			$related_contents[ BP_Suspend_Activity::$type ]         = BP_Suspend_Activity::get_member_activity_ids( $member_id, $action, $page );
+			$related_contents[ BP_Suspend_Activity_Comment::$type ] = BP_Suspend_Activity_Comment::get_member_activity_comment_ids( $member_id, $action, $page );
 		}
 
 		if ( bp_is_active( 'document' ) ) {
-			$related_contents[ BP_Suspend_Folder::$type ]   = BP_Suspend_Folder::get_member_folder_ids( $member_id, $action );
-			$related_contents[ BP_Suspend_Document::$type ] = BP_Suspend_Document::get_member_document_ids( $member_id, $action );
+			$related_contents[ BP_Suspend_Folder::$type ]   = BP_Suspend_Folder::get_member_folder_ids( $member_id, $action, $page );
+			$related_contents[ BP_Suspend_Document::$type ] = BP_Suspend_Document::get_member_document_ids( $member_id, $action, $page );
 		}
 
 		if ( bp_is_active( 'media' ) ) {
-			$related_contents[ BP_Suspend_Album::$type ] = BP_Suspend_Album::get_member_album_ids( $member_id, $action );
-			$related_contents[ BP_Suspend_Media::$type ] = BP_Suspend_Media::get_member_media_ids( $member_id, $action );
+			$related_contents[ BP_Suspend_Album::$type ] = BP_Suspend_Album::get_member_album_ids( $member_id, $action, $page );
+			$related_contents[ BP_Suspend_Media::$type ] = BP_Suspend_Media::get_member_media_ids( $member_id, $action, $page );
 		}
 
 		if ( bp_is_active( 'video' ) ) {
-			$related_contents[ BP_Suspend_Video::$type ] = BP_Suspend_Video::get_member_video_ids( $member_id, $action );
+			$related_contents[ BP_Suspend_Video::$type ] = BP_Suspend_Video::get_member_video_ids( $member_id, $action, $page );
 		}
 
 		return $related_contents;

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-message.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-message.php
@@ -180,13 +180,15 @@ class BP_Suspend_Message extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $message_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $message_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $message_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -234,13 +236,15 @@ class BP_Suspend_Message extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $message_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $message_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $message_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-message.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-message.php
@@ -180,7 +180,7 @@ class BP_Suspend_Message extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $message_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -236,7 +236,7 @@ class BP_Suspend_Message extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $message_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-message.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-message.php
@@ -92,7 +92,7 @@ class BP_Suspend_Message extends BP_Suspend_Abstract {
 
 		$action_name = current_filter();
 
-		if ( 'bp_messages_recipient_get_join_sql' === $action_name ){
+		if ( 'bp_messages_recipient_get_join_sql' === $action_name ) {
 			$join_sql .= $this->exclude_joint_query( 'r.thread_id' );
 		} else {
 			$join_sql .= $this->exclude_joint_query( 'm.thread_id' );

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
@@ -355,13 +355,15 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->hide_related_content( $video_id, $hide_sitewide, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'hide_related_content' ),
-					'args'     => array( $video_id, $hide_sitewide, $args ),
+					array(
+						'callback' => array( $this, 'hide_related_content' ),
+						'args'     => array( $video_id, $hide_sitewide, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();
@@ -409,13 +411,15 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled || ! empty( $args ) ) {
+		if ( $this->backgroup_diabled ) {
 			$this->unhide_related_content( $video_id, $hide_sitewide, $force_all, $args );
 		} else {
-			$bp_background_updater->push_to_queue(
+			$bp_background_updater->data(
 				array(
-					'callback' => array( $this, 'unhide_related_content' ),
-					'args'     => array( $video_id, $hide_sitewide, $force_all, $args ),
+					array(
+						'callback' => array( $this, 'unhide_related_content' ),
+						'args'     => array( $video_id, $hide_sitewide, $force_all, $args ),
+					),
 				)
 			);
 			$bp_background_updater->save()->schedule_event();

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
@@ -82,6 +82,7 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 	 *
 	 * @param int    $member_id member id.
 	 * @param string $action    Action name to perform.
+	 * @param int    $page      Number of page.
 	 *
 	 * @return array
 	 */
@@ -123,6 +124,7 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 	 * @since BuddyBoss 1.7.0
 	 *
 	 * @param int $group_id group id.
+	 * @param int $page     Number of page.
 	 *
 	 * @return array
 	 */

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
@@ -365,7 +365,7 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::add_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->hide_related_content( $video_id, $hide_sitewide, $args );
 		} else {
 			$bp_background_updater->data(
@@ -421,7 +421,7 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 
 		BP_Core_Suspend::remove_suspend( $suspend_args );
 
-		if ( $this->backgroup_diabled ) {
+		if ( $this->background_disabled ) {
 			$this->unhide_related_content( $video_id, $hide_sitewide, $force_all, $args );
 		} else {
 			$bp_background_updater->data(

--- a/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
@@ -85,17 +85,22 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_member_video_ids( $member_id, $action = '' ) {
+	public static function get_member_video_ids( $member_id, $action = '', $page = - 1 ) {
 		$video_ids = array();
 
-		$videos = bp_video_get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'user_id'          => $member_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'user_id'          => $member_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$videos = bp_video_get( $args );
 
 		if ( ! empty( $videos['videos'] ) ) {
 			$video_ids = $videos['videos'];
@@ -121,17 +126,22 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 	 *
 	 * @return array
 	 */
-	public static function get_group_video_ids( $group_id ) {
+	public static function get_group_video_ids( $group_id, $page = - 1 ) {
 		$video_ids = array();
 
-		$videos = bp_video_get(
-			array(
-				'moderation_query' => false,
-				'per_page'         => 0,
-				'fields'           => 'ids',
-				'group_id'         => $group_id,
-			)
+		$args = array(
+			'moderation_query' => false,
+			'per_page'         => 0,
+			'fields'           => 'ids',
+			'group_id'         => $group_id,
 		);
+
+		if ( $page > 0 ) {
+			$args['per_page'] = self::$item_per_page;
+			$args['page']     = $page;
+		}
+
+		$videos = bp_video_get( $args );
 
 		if ( ! empty( $videos['videos'] ) ) {
 			$video_ids = $videos['videos'];
@@ -439,8 +449,14 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 	protected function get_related_contents( $video_id, $args = array() ) {
 		$action           = ! empty( $args['action'] ) ? $args['action'] : '';
 		$blocked_user     = ! empty( $args['blocked_user'] ) ? $args['blocked_user'] : '';
+		$page             = ! empty( $args['page'] ) ? $args['page'] : - 1;
 		$related_contents = array();
-		$video            = new BP_Video( $video_id );
+
+		if ( $page > 1 ) {
+			return $related_contents;
+		}
+
+		$video = new BP_Video( $video_id );
 
 		if ( bp_is_active( 'activity' ) && ! empty( $video ) && ! empty( $video->activity_id ) ) {
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #3153

### How to test the changes in this Pull Request:

* [x] Create an individual background process for each and every item in moderation.
* [x] Implemented a paginated item when finding the related contents.
* [x] Re-scheduled the background process until the queue is not empty and not schedules

### Proof Screenshots or Video

<!-- Add proof video or screenshots of what is fixed or added -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
