### PR TITLE
PROD-666 #3224 - Fix export personal data doesn't display profile type in downloaded file

### DIFF
--- a/src/bp-xprofile/classes/class-bp-xprofile-field-type-member-types.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field-type-member-types.php
@@ -243,4 +243,24 @@ class BP_XProfile_Field_Type_Member_Types extends BP_XProfile_Field_Type {
 
 		return bp_xprofile_get_meta( $field_id, 'field', 'selected_post_type', true );
 	}
+
+	/**
+	 * Format profile type to display name instead of id.
+	 *
+	 * @since BuddyBoss [BBVERSION]
+	 *
+	 * @param string     $field_value The profile type id value, as saved in the database.
+	 * @param string|int $field_id    Optional. ID of the field.
+	 * @return string profile type name.
+	 */
+	public static function display_filter( $field_value, $field_id = '' ) {
+
+		$member_type_name = get_post_meta( $field_value, '_bp_member_type_label_singular_name', true );
+
+		if ( '' === $member_type_name || false === $member_type_name ) {
+			return '---';
+		}
+
+		return $member_type_name;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #3224.

### How to test the changes in this Pull Request:
https://www.loom.com/share/8064d721578841a8bd5af91c8b53980f

### Proof Screenshots or Video

Before fix
![image](https://user-images.githubusercontent.com/82648504/144631920-48303862-eb08-4222-a6d6-06836d398503.png)

After fix
![image](https://user-images.githubusercontent.com/82648504/144631864-34bd3c87-f642-4a22-9741-dcd323cffc71.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix export personal data doesn't display profile type in the downloaded file
