### PR TITLE
PROD-653 #fixed 3257 changes made for directory slug as group key

### DIFF
--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -3721,7 +3721,7 @@ function bp_register_active_group_types() {
 						'name'          => $name,
 						'singular_name' => $singular_name,
 					),
-					'has_directory'         => strtolower( $name ),
+					'has_directory'         => $key,
 					'show_in_create_screen' => true,
 					'show_in_list'          => true,
 					'description'           => '',


### PR DESCRIPTION
changes made for directory slug as group key instead of the label name, as we are passing the $key in the bp_groups_register_group_type function

### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes #3257.

### How to test the changes in this Pull Request:

1. Go to Buddyboss > Groups and group types
2. Create group type with same group type title(key) and labels
3. Then save and assign some groups and visit the group type via URL
4. Edit group type with group type title different to name label
5. Check will work in both case

### Proof Screenshots or Video

https://somup.com/crltQc0Ss4

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Changes made for taking directory slug as group key

**Jira issue** : [PROD-653]


[PROD-653]: https://buddyboss.atlassian.net/browse/PROD-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ