### PR TITLE
PROD-1135 Enhancement Update the Forum reply count, post count, scrubber count, and pagination to be the same --- For Theme 2.0

### DIFF
--- a/src/bp-forums/replies/template.php
+++ b/src/bp-forums/replies/template.php
@@ -2586,7 +2586,9 @@ function bbp_get_topic_pagination_count() {
 	$curr_page   = $bbp->reply_query->paged; // thread_reply
 	$total_pages = $bbp->reply_query->total_pages; // total_pages
 
-	$retstr = sprintf( __( 'Page %1$s of %2$s', 'buddyboss' ), $curr_page, $total_pages );
+	if( (int) $total_pages > 1 ) {
+		$retstr = sprintf( __( 'Page %1$s of %2$s', 'buddyboss' ), $curr_page, $total_pages );
+	}
 
 	// Filter and return
 	return apply_filters( 'bbp_get_topic_pagination_count', esc_html( $retstr ) );

--- a/src/bp-forums/replies/template.php
+++ b/src/bp-forums/replies/template.php
@@ -2583,52 +2583,10 @@ function bbp_get_topic_pagination_count() {
 
 	// Define local variable(s)
 	$retstr      = '';
-	$total_int   = $bbp->reply_query->total_count; // thread_reply
+	$curr_page   = $bbp->reply_query->paged; // thread_reply
 	$total_pages = $bbp->reply_query->total_pages; // total_pages
-	// Set pagination values
-	$start_num = intval( ( $bbp->reply_query->paged - 1 ) * $bbp->reply_query->posts_per_page ) + 1;
-	$from_num  = bbp_number_format( $start_num );
-	$to_num    = bbp_number_format( ( $start_num + ( $bbp->reply_query->posts_per_page - 1 ) > $bbp->reply_query->found_posts ) ? $bbp->reply_query->found_posts : $start_num + ( $bbp->reply_query->posts_per_page - 1 ) );
-	$total     = bbp_number_format( $total_int );
 
-	if ( (int) $total_pages === (int) $bbp->reply_query->paged ) {
-		$to_num = $total;
-	}
-
-	// We are threading replies
-	if ( bbp_thread_replies() && bbp_is_single_topic() ) {
-		// Several replies in a topic with a single page
-		if ( empty( $to_num ) ) {
-			$retstr = sprintf( _n( 'Viewing %1$s reply', 'Viewing %1$s replies', $total_int, 'buddyboss' ), $total );
-
-			// Several replies in a topic with several pages
-		} else {
-			$retstr = sprintf( _n( 'Viewing %2$s of %4$s replies', 'Viewing %2$s - %3$s of %4$s replies', $bbp->reply_query->post_count, 'buddyboss' ), $bbp->reply_query->post_count, $from_num, $to_num, $total );
-		}
-		// We are not including the lead topic
-	} elseif ( bbp_show_lead_topic() ) {
-
-		// Several replies in a topic with a single page
-		if ( empty( $to_num ) ) {
-			$retstr = sprintf( _n( 'Viewing %1$s reply', 'Viewing %1$s replies', $total_int, 'buddyboss' ), $total );
-
-			// Several replies in a topic with several pages
-		} else {
-			$retstr = sprintf( _n( 'Viewing %2$s of %4$s replies', 'Viewing %2$s - %3$s of %4$s replies', $bbp->reply_query->post_count, 'buddyboss' ), $bbp->reply_query->post_count, $from_num, $to_num, $total );
-		}
-
-		// We are including the lead topic
-	} else {
-
-		// Several posts in a topic with a single page
-		if ( empty( $to_num ) ) {
-			$retstr = sprintf( _n( 'Viewing %1$s post', 'Viewing %1$s posts', $total_int, 'buddyboss' ), $total );
-
-			// Several posts in a topic with several pages
-		} else {
-			$retstr = sprintf( _n( 'Viewing %2$s of %4$s posts', 'Viewing %2$s - %3$s of %4$s posts', $bbp->reply_query->post_count, 'buddyboss' ), $bbp->reply_query->post_count, $from_num, $to_num, $total );
-		}
-	}
+	$retstr = sprintf( __('Page %1$s of %2$s'), $curr_page, $total_pages );
 
 	// Filter and return
 	return apply_filters( 'bbp_get_topic_pagination_count', esc_html( $retstr ) );
@@ -2830,9 +2788,9 @@ function bbp_update_total_parent_reply( $reply_id, $topic_id, $new_topic_reply_c
 				// Get child reply.
 				$post_status   = "'" . implode( "','", array( bbp_get_public_status_id() ) ) . "'";
 				$bbp_gtcpq_sql = $wpdb->prepare(
-					"SELECT COUNT({$wpdb->posts}.ID) FROM {$wpdb->posts} LEFT JOIN {$wpdb->postmeta} 
-				ON {$wpdb->postmeta}.post_id = {$wpdb->posts}.ID WHERE {$wpdb->posts}.post_parent = %d AND {$wpdb->posts}.post_status 
-				IN ( {$post_status} ) AND {$wpdb->posts}.post_type = '%s' AND {$wpdb->posts}.post_type = '%s' 
+					"SELECT COUNT({$wpdb->posts}.ID) FROM {$wpdb->posts} LEFT JOIN {$wpdb->postmeta}
+				ON {$wpdb->postmeta}.post_id = {$wpdb->posts}.ID WHERE {$wpdb->posts}.post_parent = %d AND {$wpdb->posts}.post_status
+				IN ( {$post_status} ) AND {$wpdb->posts}.post_type = '%s' AND {$wpdb->posts}.post_type = '%s'
 				AND {$wpdb->postmeta}.meta_key = '%s';",
 					$topic_id,
 					bbp_get_reply_post_type(),

--- a/src/bp-forums/replies/template.php
+++ b/src/bp-forums/replies/template.php
@@ -2586,7 +2586,7 @@ function bbp_get_topic_pagination_count() {
 	$curr_page   = $bbp->reply_query->paged; // thread_reply
 	$total_pages = $bbp->reply_query->total_pages; // total_pages
 
-	$retstr = sprintf( __('Page %1$s of %2$s'), $curr_page, $total_pages );
+	$retstr = sprintf( __( 'Page %1$s of %2$s', 'buddyboss' ), $curr_page, $total_pages );
 
 	// Filter and return
 	return apply_filters( 'bbp_get_topic_pagination_count', esc_html( $retstr ) );

--- a/src/languages/buddyboss.pot
+++ b/src/languages/buddyboss.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BuddyBoss Platform 1.8.1\n"
 "Report-Msgid-Bugs-To: https://www.buddyboss.com/contact/\n"
-"POT-Creation-Date: 2021-11-15 06:52:09+00:00\n"
+"POT-Creation-Date: 2021-12-29 09:49:11+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -8057,13 +8057,13 @@ msgstr ""
 
 #: bp-core/deprecated/buddypress/1.5.php:376
 msgid ""
-"%1$s mentioned you in the group \"%2$s\":\r\n"
-"\r\n"
-"\"%3$s\"\r\n"
-"\r\n"
-"To view and respond to the message, log in and visit: %4$s\r\n"
-"\r\n"
-"---------------------\r\n"
+"%1$s mentioned you in the group \"%2$s\":\n"
+"\n"
+"\"%3$s\"\n"
+"\n"
+"To view and respond to the message, log in and visit: %4$s\n"
+"\n"
+"---------------------\n"
 msgstr ""
 
 #: bp-core/deprecated/buddypress/1.6.php:154
@@ -14287,29 +14287,9 @@ msgstr ""
 msgid "Split the topic from this reply"
 msgstr ""
 
-#: bp-forums/replies/template.php:2602 bp-forums/replies/template.php:2613
-msgid "Viewing %1$s reply"
-msgid_plural "Viewing %1$s replies"
-msgstr[0] ""
-msgstr[1] ""
-
-#: bp-forums/replies/template.php:2606 bp-forums/replies/template.php:2617
-msgid "Viewing %2$s of %4$s replies"
-msgid_plural "Viewing %2$s - %3$s of %4$s replies"
-msgstr[0] ""
-msgstr[1] ""
-
-#: bp-forums/replies/template.php:2625
-msgid "Viewing %1$s post"
-msgid_plural "Viewing %1$s posts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: bp-forums/replies/template.php:2629
-msgid "Viewing %2$s of %4$s posts"
-msgid_plural "Viewing %2$s - %3$s of %4$s posts"
-msgstr[0] ""
-msgstr[1] ""
+#: bp-forums/replies/template.php:2589
+msgid "Page %1$s of %2$s"
+msgstr ""
 
 #: bp-forums/search/template.php:235
 msgid "Search Results for '%s'"
@@ -29199,15 +29179,14 @@ msgstr ""
 msgctxt "extension notification"
 msgid ""
 "Your server needs %1$s installed to automatically create thumbnails after "
-"uploading videos (optional). Ask your web host.\r\n"
+"uploading videos (optional). Ask your web host.\n"
 "\t\t\t\t\t<br/><br/>If FFmpeg is already installed on your server and you "
 "still see the above warning, this means BuddyBoss Platform is unable to "
 "auto-detect the binary file path for FFmpeg. You will need to add the below "
 "FFmpeg absolute path constants into your %2$s file, replacing "
 "PATH_OF_BINARY_FILE with the actual file path to the FFmpeg binary file. "
-"Ask your web host to provide the absolute path for the FFmpeg binary "
-"file.\r\n"
-"\t\t\t\t\t<br /><br />%3$s\r\n"
+"Ask your web host to provide the absolute path for the FFmpeg binary file.\n"
+"\t\t\t\t\t<br /><br />%3$s\n"
 "\t\t\t\t\t<br />%4$s"
 msgstr ""
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Pull Requests Guidelines](https://github.com/buddyboss/buddyboss-platform/wiki/Submitting-Pull-Requests#pull-request-guidelines)?
* [x] Does your code follow the [WordPress' Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/buddyboss/buddyboss-theme/issues/1851

### How to test the changes in this Pull Request:

**Problem:**

When viewing a forum discussion, the count is wrong.... literally everywhere except for the admin:

- In the admin and database, the discussion topic is store separate from its replies. In the frontend when you view reply counts, and pagination, the discussion topic is magically included in the reply count.
- In the frontend, the pagination is only using top-level replies
- In the frontend, the scrubber uses the discussion topic, and all of its replies including nested replies in its Posts count
- In the frontend, the scrubber is resetting back to 1 on every page in pagination
- In the frontend, the scrubber is showing an incorrect total reply/post count on every page in pagination
- In the frontend, the reply count in the Forums view is always wrong (offset by 1)
- There are 4 different counts in frontend, and literally every single one is wrong always

**Solution:**

EVERYTHING needs to line up with what is in the admin and database!

1. In forum listing, the number of replies should be exactly the same number as in the admin: https://www.loom.com/share/69e3326e576a4d35a34a4bd6e85676bb

2. In single discussion, the Posts count should be renamed to Replies and it should be exactly the same number as in the admin: https://www.loom.com/share/0701884075644ea0b6a3cb4aac2cabd8

3. In single discussion, the pagination should be actually paginating by reply count, and should be the correct number of replies: https://www.loom.com/share/03c8d2a5a45a4b6ab4ddbfd345815ecb

4. In single discussion, change the scrubber text from "1 of 22 posts" to "1 of 22 replies". And then update the numbers to be inline with pagination, so like "1 of 31 replies" on top of page 1, "15 of 31 replies" at bottom of page 1, then "16 of 31 replies" on top of page 2, and then "31 of 31 replies at bottom of page 2, as an example. Ignore the first post which is not a reply. https://www.loom.com/share/bf8e77861e724d24989370eb5fbd49eb

5. We also need to look at the forums widgets and shortcodes and make sure they all are corrected along with this, to have correct reply counts and pagination etc.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
