### PR TITLE
fix bp_document_folder_update_meta() not working

### DIFF
--- a/src/bp-document/bp-document-functions.php
+++ b/src/bp-document/bp-document-functions.php
@@ -225,7 +225,7 @@ function bp_document_folder_get_meta( $folder_id = 0, $meta_key = '', $single = 
  */
 function bp_document_folder_update_meta( $folder_id, $meta_key, $meta_value, $prev_value = '' ) {
 	add_filter( 'query', 'bp_filter_metaid_column_name' );
-	$retval = update_metadata( 'folder', $folder_id, $meta_key, $meta_value, $prev_value );
+	$retval = update_metadata( 'document_folder', $folder_id, $meta_key, $meta_value, $prev_value );
 	remove_filter( 'query', 'bp_filter_metaid_column_name' );
 
 	return $retval;


### PR DESCRIPTION
The bp_document_folder_update_meta() function doesn't work. The reason is that it passes 'folder' to update_metadata(), but the BP_Document_Component::setup_globals() function creates a wpdb metatable with the name of "document_folder" here:

https://github.com/buddyboss/buddyboss-platform/blob/6eea69f22d0453a7d6344b67eacbc52c3a39334d/src/bp-document/classes/class-bp-document-component.php#L180

