### PR TITLE
fix bug with replies to activity post

### DIFF
--- a/src/bp-activity/bp-activity-notifications.php
+++ b/src/bp-activity/bp-activity-notifications.php
@@ -554,6 +554,8 @@ function bb_activity_add_notification_metas( $notification ) {
 			$parent_activity = new BP_Activity_Activity( $activity->item_id );
 			if ( ! empty( $parent_activity ) && 'blogs' === $parent_activity->component ) {
 				bp_notifications_update_meta( $notification->id, 'type', 'post_comment' );
+			} elseif ($activity->secondary_item_id == $parent_activity->id) {
+				bp_notifications_update_meta($notification->id, 'type', 'post_comment');
 			} else {
 				bp_notifications_update_meta( $notification->id, 'type', 'activity_comment' );
 			}


### PR DESCRIPTION
Currently, if you reply an activity post, the notification says that it was a reply to a comment. This PR fixes the logic.

Moreover, I think lines 554-556 should be removed - I don't think these lines would ever get triggered. If you comment on a blog post, this doesn't get triggered, and blog posts in the activity feed don't seem to allow for comments. 