### PR TITLE
Video suspend query clauses override Photo suspend query clauses in searches

### DIFF
--- a/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-video.php
@@ -59,9 +59,6 @@ class BP_Suspend_Video extends BP_Suspend_Abstract {
 		add_filter( 'bp_media_get_join_count_sql', array( $this, 'update_join_media_sql' ), 10, 2 );
 		add_filter( 'bp_media_get_where_count_conditions', array( $this, 'update_where_media_sql' ), 10, 2 );
 
-		add_filter( 'bp_media_search_join_sql_photo', array( $this, 'update_join_sql' ), 10 );
-		add_filter( 'bp_media_search_where_conditions_photo', array( $this, 'update_where_sql' ), 10, 2 );
-
 		add_filter( 'bp_video_get_join_sql', array( $this, 'update_join_sql' ), 10, 2 );
 		add_filter( 'bp_video_get_where_conditions', array( $this, 'update_where_sql' ), 10, 2 );
 


### PR DESCRIPTION
### BB Support Ticket: https://support.buddyboss.com/support/tickets/182257


When you do a BB Search, the Video Suspend Query Clauses override the Photo Suspend Query Clauses due to a couple misplaced add_actions. 

Here are excerpts from some of the queries to illustrate the issue. You can see that Photos joins the wp_bp_suspend table twice, the second being on item_type 'video' with the alias `sv`. Then, the where conditions only use the `sv ` alias rather than the `s` alias, meaning that any suspensions related to photos will not apply to searches. Presumably the video suspensions applied to the photos here will do nothing since the results of the query would never touch the video items in the wp_bp_media table.

You just need to remove the two excess add_action hooks, which I've done with this PR.

```

SELECT
    DISTINCT m.id,'photos' as type,m.title LIKE 'test' AS relevance,m.date_created as entry_date
FROM wp_bp_media m
    LEFT JOIN wp_bp_suspend s ON (
        s.item_type = 'media' AND s.item_id = m.id
    )
    LEFT JOIN wp_bp_suspend sv ON (
        sv.item_type = 'video' AND sv.item_id = m.id
    )
WHERE
    1 = 1        
    AND ( (
            sv.user_suspended = 0
            OR sv.user_suspended IS NULL
        )
        AND (
            sv.hide_parent = 0
            OR sv.hide_parent IS NULL
        )
        AND (
            sv.hide_sitewide = 0
            OR sv.hide_sitewide IS NULL
        )
    )
)
UNION (
    SELECT
        DISTINCT d.id,'documents' as type,d.title LIKE 'test' AS relevance,d.date_created as entry_date
    FROM wp_bp_document d
        INNER JOIN wp_bp_document_meta dm ON (d.id = dm.document_id)
        LEFT JOIN wp_bp_suspend s ON (
            s.item_type = 'document' AND s.item_id = d.id
        )
    WHERE
        1 = 1         
        AND ( (
                s.user_suspended = 0
                OR s.user_suspended IS NULL
            )
            AND (
                s.hide_parent = 0
                OR s.hide_parent IS NULL
            )
            AND (
                s.hide_sitewide = 0
                OR s.hide_sitewide IS NULL
            )
        )
)
UNION (
    SELECT
        DISTINCT m.id,'videos' as type,m.title LIKE 'test' AS relevance,m.date_created as entry_date
    FROM wp_bp_media m
        LEFT JOIN wp_bp_suspend sv ON (
            sv.item_type = 'video' AND sv.item_id = m.id
        )
    WHERE
        1 = 1
        AND ( (
                sv.user_suspended = 0
                OR sv.user_suspended IS NULL
            )
            AND (
                sv.hide_parent = 0
                OR sv.hide_parent IS NULL
            )
            AND (
                sv.hide_sitewide = 0
                OR sv.hide_sitewide IS NULL
            )
        )
)
UNION (
    SELECT
        DISTINCT a.id,'activity' as type,a.content LIKE 'test' AS relevance,a.date_recorded as entry_date
    FROM wp_bp_activity a
        LEFT JOIN wp_bp_suspend s ON (
            s.item_type = 'activity' AND s.item_id = a.id
        )
    WHERE
        1 = 1
        AND ( (
                s.user_suspended = 0
                OR s.user_suspended IS NULL
            )
            AND (
                s.hide_parent = 0
                OR s.hide_parent IS NULL
            )
            AND (
                s.hide_sitewide = 0
                OR s.hide_sitewide IS NULL
            )
        )
)



```
