### PR TITLE
Remove unnecessary postmeta JOIN from Topic Search

### DIFF
--- a/src/bp-search/classes/class-bp-search-bbpress-forums-topics.php
+++ b/src/bp-search/classes/class-bp-search-bbpress-forums-topics.php
@@ -32,7 +32,9 @@ if ( ! class_exists( 'Bp_Search_bbPress_Topics' ) ) :
 				$columns             = " DISTINCT p.id , '{$this->type}' as type, p.post_title LIKE %s AS relevance, p.post_date as entry_date  ";
 				$query_placeholder[] = '%' . $search_term . '%';
 			}
-
+			
+			$from = "{$wpdb->posts} p ";
+			
 			/**
 			 * Filter the MySQL JOIN clause for the topic Search query.
 			 *

--- a/src/bp-search/classes/class-bp-search-bbpress-forums-topics.php
+++ b/src/bp-search/classes/class-bp-search-bbpress-forums-topics.php
@@ -33,8 +33,6 @@ if ( ! class_exists( 'Bp_Search_bbPress_Topics' ) ) :
 				$query_placeholder[] = '%' . $search_term . '%';
 			}
 
-			$from = "{$wpdb->posts} p LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID AND pm.meta_key = '_bbp_forum_id'";
-
 			/**
 			 * Filter the MySQL JOIN clause for the topic Search query.
 			 *
@@ -195,7 +193,7 @@ if ( ! class_exists( 'Bp_Search_bbPress_Topics' ) ) :
 
 			if ( ! empty( $forum_ids ) ) {
 				$forum_id_in = implode( ',', $forum_ids );
-				$where[]     = " pm.meta_value IN ( $forum_id_in ) ";
+				$where[]     = " p.post_parent IN ( $forum_id_in ) ";
 			}
 
 			$query_placeholder[] = '%' . $search_term . '%';


### PR DESCRIPTION
### Jira Issue: https://support.buddyboss.com/support/tickets/182268

It is unnecessary to JOIN the postmeta table in the BB Network Search topics helper - it is only used to add a WHERE condition for the parent forum, but this value is already stored in `wp_posts->post_parent`. 

This PR removes that redundancy.