### PR TITLE
Optimizing BB Network Group Search query

### DIFF
--- a/src/bp-search/classes/class-bp-search-groups.php
+++ b/src/bp-search/classes/class-bp-search-groups.php
@@ -75,10 +75,10 @@ if ( ! class_exists( 'Bp_Search_Groups' ) ) :
 			if ( $only_totalrow_count ) {
 				$sql['select'] .= ' COUNT( DISTINCT g.id ) ';
 			} else {
-				$sql['select'] .= $wpdb->prepare( " DISTINCT g.id, 'groups' as type, g.name LIKE %s AS relevance, gm2.meta_value as entry_date  ", '%' . $wpdb->esc_like( $search_term ) . '%' );
+				$sql['select'] .= $wpdb->prepare( " DISTINCT g.id, 'groups' as type, g.name LIKE %s AS relevance, gm.meta_value as entry_date  ", '%' . $wpdb->esc_like( $search_term ) . '%' );
 			}
 
-			$sql['from'] = "FROM {$bp->groups->table_name_groupmeta} gm1, {$bp->groups->table_name_groupmeta} gm2, {$bp->groups->table_name} g";
+			$sql['from'] = " FROM {$bp->groups->table_name} g LEFT JOIN {$bp->groups->table_name_groupmeta} gm ON g.id = gm.group_id ";
 
 			/**
 			 * Filter the MySQL JOIN clause for the group Search query.
@@ -90,10 +90,7 @@ if ( ! class_exists( 'Bp_Search_Groups' ) ) :
 			$sql['from'] = apply_filters( 'bp_group_search_join_sql', $sql['from'] );
 
 			$where_conditions                 = array( '1=1' );
-			$where_conditions['search_query'] = "g.id = gm1.group_id 
-						AND g.id = gm2.group_id 
-						AND gm2.meta_key = 'last_activity' 
-						AND gm1.meta_key = 'total_member_count' 
+			$where_conditions['search_query'] = "gm.meta_key = 'last_activity' 						
 						AND ( g.name LIKE %s OR g.description LIKE %s )
 				";
 

--- a/src/bp-search/classes/class-bp-search-groups.php
+++ b/src/bp-search/classes/class-bp-search-groups.php
@@ -132,15 +132,15 @@ if ( ! class_exists( 'Bp_Search_Groups' ) ) :
 					// get all hidden groups where i am a member of
 					$hidden_groups_sql = $wpdb->prepare( "SELECT DISTINCT gm.group_id FROM {$bp->groups->table_name_members} gm JOIN {$bp->groups->table_name} g ON gm.group_id = g.id WHERE gm.user_id = %d AND gm.is_confirmed = 1 AND gm.is_banned = 0 AND g.status='hidden' ", bp_loggedin_user_id() );
 					$hidden_groups_ids = $wpdb->get_col( $hidden_groups_sql );
-					if ( empty( $hidden_groups_ids ) ) {
-						$hidden_groups_ids = array( 99999999 );// arbitrarily large number
-					}
-
-					$hidden_groups_ids_csv = implode( ',', $hidden_groups_ids );
-
-					// either gruops which are not hidden,
+					
+					// either groups which are not hidden,
 					// or if hidden, only those where i am a member.
-					$where_conditions['search_query'] .= " AND ( g.status != 'hidden' OR g.id IN ( {$hidden_groups_ids_csv} ) ) ";
+					
+					if ( !empty( $hidden_groups_ids ) ) {
+						$hidden_groups_csv = implode( ',', $hidden_groups_ids );
+						$hidden_groups_condition = " OR g.id IN ( {$hidden_groups_csv} )";
+					} 
+					$where_conditions['search_query'] .= " AND ( g.status != 'hidden' {$hidden_groups_condition} ) ";
 				}
 			} else {
 				$where_conditions['search_query'] .= "AND g.status != 'hidden' ";


### PR DESCRIPTION
### Jira Issue:
https://support.buddyboss.com/support/tickets/182289

The BB Network Search group search helper uses a very non-optimal way of building the query. It joins the groupmeta table twice, because it wants to include groups who have the `last_activity` and `total_member_count` meta_keys and if it isn't done like this, then double the results are returned - one for each meta_key.

However, all groups have these two keys set upon group creation, so it is only necessary to check one of them. Since the query returns `last_activity as entry_date`, it makes sense to remove the `total_member_count` from the query. 

Moreover, the group_meta table can be moved to a LEFT JOIN ON rather than FROM WHERE, in order to be consistent with the other search helpers.

Finally, I've fixed a silly mechanism that added an arbitrarily large group ID when the user isn't a member of any hidden groups - better to just not add that clause at all... 

Here are two query ANALYZE outputs, showing how the original method does a `ALL`(full table scan) whereas the new one does and `Index `scan

Old
![image](https://user-images.githubusercontent.com/88559987/177071666-307a027e-006b-44cb-8ee3-6abd97ea1dd6.png)
New
![image](https://user-images.githubusercontent.com/88559987/177071651-e593eb7b-1af2-442b-9525-3d7f51e7e555.png)
