### PR TITLE
Add missing underscores to bb search cache_keys

### DIFF
--- a/src/bp-search/classes/class-bp-search-members.php
+++ b/src/bp-search/classes/class-bp-search-members.php
@@ -205,8 +205,8 @@ if ( ! class_exists( 'Bp_Search_Members' ) ) :
 					if ( ! empty( $selected_xprofile_fields ) ) {
 
 						$cache_key = maybe_serialize( $selected_xprofile_fields['char_search'] );
-						$cache_key .= $search_term;
-						$cache_key .= maybe_serialize( $selected_xprofile_fields['word_search'] );
+						$cache_key .= '_' . $search_term;
+						$cache_key .= '_' . maybe_serialize( $selected_xprofile_fields['word_search'] );
 						$cache_key = md5( $cache_key );
 						$user_ids = array();
 						if ( ! isset( $selected_xprofile_fields_cache[ $cache_key ] ) ) {

--- a/src/bp-search/classes/class-bp-search-posts.php
+++ b/src/bp-search/classes/class-bp-search-posts.php
@@ -314,7 +314,7 @@ if ( ! class_exists( 'Bp_Search_Posts' ) ) :
 			$cache_key              = 'bb_search_term_total_match_count_' . $this->pt_name . '_' . sanitize_title( $search_term );
 
 			if ( ! empty( $search_type ) ) {
-				$cache_key .= sanitize_title( $search_type );
+				$cache_key .= '_' . sanitize_title( $search_type );
 			}
 			if ( ! isset( $bbp_search_term[ $cache_key ] ) ) {
 				$sql    = $this->sql( $search_term, true );

--- a/src/bp-search/classes/class-bp-search-types.php
+++ b/src/bp-search/classes/class-bp-search-types.php
@@ -101,7 +101,7 @@ if ( ! class_exists( 'Bp_Search_Type' ) ) :
 			static $bbp_search_term = array();
 			$cache_key = 'bb_search_term_total_match_count_' . sanitize_title( $search_term );
 			if ( ! empty( $search_type ) ) {
-				$cache_key .= sanitize_title( $search_type );
+				$cache_key .= '_' . sanitize_title( $search_type );
 			}
 			if ( ! isset( $bbp_search_term[ $cache_key ] ) ) {
 				$sql    = $this->sql( $search_term, true );


### PR DESCRIPTION
### Jira Issue:
https://support.buddyboss.com/support/tickets/182781

In a few places within the BB Search Component, there is a missing `_` in the cache_key. This results in some cache_keys looking like this:

"bb_search_term_total_match_count_searchtermtopic"
"bb_search_term_total_match_count_searchtermforum"
"bb_search_term_total_match_count_searchtermreply"
etc... 

Rather than:
"bb_search_term_total_match_count_searchterm_topic"
"bb_search_term_total_match_count_searchterm_forum"
"bb_search_term_total_match_count_searchterm_reply"

It might not make any difference to the search performance/results, but it makes it difficult to read/browse the cache while debugging things

The same thing appears to happen in a couple other spots within the BB Network Search component. I've added a bit of code to add underscores where necessary. However, there may very well be other parts of the broader BB codebase where this problem still occurs.

