### PR TITLE
Cant search activity posts in private/hidden groups

### DIFF
--- a/src/bp-search/classes/class-bp-search-activities.php
+++ b/src/bp-search/classes/class-bp-search-activities.php
@@ -132,8 +132,7 @@ if ( ! class_exists( 'Bp_Search_Activities' ) ) :
 			// searching only activity updates, others don't make sense
 			$where_conditions   = array( '1=1' );
 			$where_conditions[] = "is_spam = 0
-						AND ExtractValue(a.content, '//text()') LIKE %s
-						AND a.hide_sitewide = 0
+						AND ExtractValue(a.content, '//text()') LIKE %s						
 						AND a.type = 'activity_update'
 						AND
 						(


### PR DESCRIPTION
### Jira Issue: 
https://buddyboss.atlassian.net/browse/PROD-4470

Activity posts in private and hidden groups do not show up in search results because the SQL query has a clause to only include activities that have `a.hide_sitewide = 0`. However, `hide_sitewide` in the activity db table is only used to hide posts that are in private and hidden groups from other activity feeds - it has nothing to do with moderation (which is handled later in the sql query by the s.hide_sitewide clause). 

Also, there are mechanisms in the activity post query to only show posts from private/hidden groups that the user is a member of.

Moreover, if you look at the search helper for activity **comments**, it does not have the `AND a.hide_sitewide = 0` clause. This means that comments from private and hidden groups show up in search results. 