### PR TITLE
#PROD-3581 Fix PHP8 deprecation notice

### DIFF
--- a/src/bp-notifications/bp-notifications-functions.php
+++ b/src/bp-notifications/bp-notifications-functions.php
@@ -1072,7 +1072,7 @@ function bb_notification_avatar() {
 	if ( isset( $item_id, $object ) ) {
 
 		if ( 'notification' === $object ) {
-			bb_get_default_notification_avatar( 'thumb', $notification );
+			bb_get_default_notification_avatar( 'thumb' );
 			// Get the small icon for the notification which will print beside the avatar.
 			echo wp_kses_post( bb_notification_small_icon( $component_action, true, $notification ) );
 		} else {
@@ -1191,11 +1191,10 @@ function bb_notification_avatar_url( $notification = '' ) {
  * @since BuddyBoss 2.0.2
  *
  * @param string $size         Size of the notification icon, 'full' or 'thumb'.
- * @param object $notification Notification object.
  *
  * @return void
  */
-function bb_get_default_notification_avatar( $size = 'full', $notification ) {
+function bb_get_default_notification_avatar( $size = 'full' ) {
 	if ( ! in_array( $size, array( 'thumb', 'full' ), true ) ) {
 		$size = 'full';
 	}


### PR DESCRIPTION
Related to #2000.

Remove unused parameter and fix the deprecation notice:
`PHP Deprecated:  Required parameter $notification follows optional parameter $size in /var/www/html/wp-content/plugins/buddyboss-platform/bp-notifications/bp-notifications-functions.php on line 1198`

### Jira Issue:
I don't know if there is one.