### PR TITLE
Search fix for Replies in hidden group forums

### DIFF
--- a/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
+++ b/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
@@ -94,14 +94,15 @@ if ( ! class_exists( 'Bp_Search_bbPress_Replies' ) ) :
 				$post_status = array( "'publish'" );
 			}
 
-			$where   = array();
+			$where[]   = array();
 			$where[] = '1=1';
 			$where[] = "(post_title LIKE %s OR ExtractValue(post_content, '//text()') LIKE %s)";
 			$where[] = "post_type = '{$this->type}'";
 
 			$where[] = '(' . $group_query . '
-			pm.meta_value IN ( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = \'forum\' AND post_status IN (' . join( ',', $post_status ) . ') )
+			pm.meta_value IN ( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = \'forum\' )
 			)';
+			$where_standalone = "post_status IN (' . join( ',', $post_status ) . ')";
 
 			/**
 			 * Filters the MySQL WHERE conditions for the forum's reply Search query.
@@ -115,7 +116,7 @@ if ( ! class_exists( 'Bp_Search_bbPress_Replies' ) ) :
 			$query_placeholder[] = '%' . $search_term . '%';
 			$query_placeholder[] = '%' . $search_term . '%';
 
-			$sql   = 'SELECT ' . $columns . ' FROM ' . $from . ' WHERE ' . implode( ' AND ', $where );
+			$sql   = 'SELECT ' . $columns . ' FROM ' . $from . ' WHERE ' . implode( ' AND ', $where ) . 'OR ' . $where_standalone;
 			$query = $wpdb->prepare( $sql, $query_placeholder ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 			return apply_filters(

--- a/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
+++ b/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
@@ -102,7 +102,7 @@ if ( ! class_exists( 'Bp_Search_bbPress_Replies' ) ) :
 			$where[] = '(' . $group_query . '
 			pm.meta_value IN ( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = \'forum\' )
 			)';
-			$where_standalone = "post_status IN (' . join( ',', $post_status ) . ')";
+			$where_standalone = 'post_status IN (' . join( ',', $post_status ) . ')';
 
 			/**
 			 * Filters the MySQL WHERE conditions for the forum's reply Search query.

--- a/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
+++ b/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
@@ -101,8 +101,8 @@ if ( ! class_exists( 'Bp_Search_bbPress_Replies' ) ) :
 
 			$where[] = '(' . $group_query . '
 			pm.meta_value IN ( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = \'forum\' )
-			)';
-			$where_standalone = 'post_status IN (' . join( ',', $post_status ) . ')';
+			OR post_status IN (' . join( ',', $post_status ) . ') ) ';
+			
 
 			/**
 			 * Filters the MySQL WHERE conditions for the forum's reply Search query.
@@ -116,7 +116,7 @@ if ( ! class_exists( 'Bp_Search_bbPress_Replies' ) ) :
 			$query_placeholder[] = '%' . $search_term . '%';
 			$query_placeholder[] = '%' . $search_term . '%';
 
-			$sql   = 'SELECT ' . $columns . ' FROM ' . $from . ' WHERE ' . implode( ' AND ', $where ) . 'OR ' . $where_standalone;
+			$sql   = 'SELECT ' . $columns . ' FROM ' . $from . ' WHERE ' . implode( ' AND ', $where );
 			$query = $wpdb->prepare( $sql, $query_placeholder ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 			return apply_filters(

--- a/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
+++ b/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
@@ -94,7 +94,7 @@ if ( ! class_exists( 'Bp_Search_bbPress_Replies' ) ) :
 				$post_status = array( "'publish'" );
 			}
 
-			$where[]   = array();
+			$where   = array();
 			$where[] = '1=1';
 			$where[] = "(post_title LIKE %s OR ExtractValue(post_content, '//text()') LIKE %s)";
 			$where[] = "post_type = '{$this->type}'";

--- a/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
+++ b/src/bp-search/classes/class-bp-search-bbpress-forums-replies.php
@@ -83,7 +83,7 @@ if ( ! class_exists( 'Bp_Search_bbPress_Replies' ) ) :
 
 				$in = implode( '', $in );
 
-				$group_query = ' pm.meta_value IN ( SELECT post_id FROM ' . $wpdb->postmeta . ' INNER JOIN '. $wpdb->posts .' ON ID = post_id WHERE ( meta_key = \'_bbp_group_ids\' AND meta_value IN(' . trim( $in, ',' ) . ')  OR  meta_key != \'_bbp_group_ids\' ) AND post_type = \'forum\' ) AND ';
+				$group_query = ' pm.meta_value IN ( SELECT post_id FROM ' . $wpdb->postmeta . ' INNER JOIN '. $wpdb->posts .' ON ID = post_id WHERE ( meta_key = \'_bbp_group_ids\' AND meta_value IN(' . trim( $in, ',' ) . ')  OR  meta_key != \'_bbp_group_ids\' ) AND post_type = \'forum\' ) OR ';
 			}
 
 			if ( current_user_can( 'read_hidden_forums' ) ) {
@@ -100,9 +100,8 @@ if ( ! class_exists( 'Bp_Search_bbPress_Replies' ) ) :
 			$where[] = "post_type = '{$this->type}'";
 
 			$where[] = '(' . $group_query . '
-			pm.meta_value IN ( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = \'forum\' )
-			OR post_status IN (' . join( ',', $post_status ) . ') ) ';
-			
+			pm.meta_value IN ( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = \'forum\' AND post_status IN (' . join( ',', $post_status ) . ') )
+			)';
 
 			/**
 			 * Filters the MySQL WHERE conditions for the forum's reply Search query.


### PR DESCRIPTION
### Jira Issue: [188398](https://support.buddyboss.com/support/tickets/188398)
<!-- Paste Jira issue link -->

Replies that are in a forum that is in a hidden group are not showing up in search results. This is because the query clauses for including results that are in standalone forums (which uses the wp_posts->post_status field) overrides the $group_query/$group_memberships clause due to the two clauses being concatenated with AND. It just needs to be changed to OR.