### PR TITLE
Cant override the default number of search results

### DIFF
--- a/src/bp-search/classes/class-bp-search.php
+++ b/src/bp-search/classes/class-bp-search.php
@@ -614,7 +614,7 @@ if ( ! class_exists( 'Bp_Search_Helper' ) ) :
 							$last_item = end( $items );
 							$end_html  = '</ul>';
 
-							if ( $total_results > 3 ) {
+							if ( $total_results > $args['number'] ) {
 								$end_html .= "<footer class='results-group-footer'>";
 								$end_html .= "<a href='" . $category_search_url . "' class='view-all-link'>" .
 											   sprintf( esc_html__( 'View (%d) more', 'buddyboss' ), $total_results - $args['number'] ) .
@@ -635,7 +635,7 @@ if ( ! class_exists( 'Bp_Search_Helper' ) ) :
 						foreach ( $ordered_items_group as $type => $grouped_items ) {
 
 							// Remove last item from list
-							if ( count( $grouped_items ) > 3 ) {
+							if ( count( $grouped_items ) > $args['number'] ) {
 								array_pop( $grouped_items );
 							}
 


### PR DESCRIPTION
We can change the default number of search results with the `bp_search_search_page_args` filter, but it breaks the search output because the default of 3 is hardcoded in a couple of places. This fixes that.

You can test with a filter like this 
```
add_filter( 'bp_search_search_page_args', function ( $args ) {
			$args['number'] = 5;
			return $args;
		} );
```

Which will break the results page (the button for "View (x) more" disappears, for example). 

If you implement these changes, everything is fine again.

### Jira Issue: [#189531 ](https://support.buddyboss.com/support/tickets/189531)