### PR TITLE
Fixing bug that results in object cache not being used for check_user_suspend, resulting in hundreds of duplicate queries

### DIFF
--- a/src/bp-moderation/classes/suspend/class-bp-core-suspend.php
+++ b/src/bp-moderation/classes/suspend/class-bp-core-suspend.php
@@ -526,7 +526,7 @@ class BP_Core_Suspend {
 		if ( false === $result ) {
 			$user_ids = sprintf( 'item_id IN(\'%s\')', implode( "','", $user_id ) );
 			$result   = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT id FROM {$bp->moderation->table_name} WHERE {$user_ids} AND item_type = %s AND user_suspended = 1", BP_Suspend_Member::$type ) ); // phpcs:ignore
-			wp_cache_set( $cache_key, $result, 'bp_moderation' );
+			wp_cache_set( $cache_key, is_null($result) ? 0 : $result , 'bp_moderation' );
 		}
 
 		return ! empty( $result );


### PR DESCRIPTION
I am getting hundreds of duplicate queries as a result of this function. When a user is not suspended, the wpdb query returns `null`, which the wp_cache_get mechanism in some object caching plugins treat as not existing. 

The plugin that I am using is Redis Object Cache, and I submitted a pull request to them which was already merged. But there are surely other plugins that BB users are using that behave similarly and they'll never know. 

If we instead store `0` when the user is not suspended, then it will work appropriately with any object caching plugin. 

### Jira Issue: 


