### PR TITLE
fix for search results tab html not showing up

### DIFF
--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -386,7 +386,7 @@ function bp_core_set_uri_globals() {
 	 * If a BuddyPress directory is set to the WP front page, URLs like example.com/members/?s=foo
 	 * shouldn't interfere with blog searches.
 	 */
-	if ( empty( $current_action ) && ! empty( $_GET['s'] ) && 'page' == get_option( 'show_on_front' ) && ! empty( $match->id ) ) {
+	if ( empty( $current_action ) && ( ! empty( $_GET['s'] ) || ! empty( $_POST['s']) ) && 'page' == get_option( 'show_on_front' ) && ! empty( $match->id ) ) {
 		$page_on_front = (int) get_option( 'page_on_front' );
 		if ( (int) $match->id === $page_on_front ) {
 			$bp->current_component = '';


### PR DESCRIPTION
When you click the search results tabs, it sends the query data via $_POST, not $_GET. This means that this mechanism to unset the $bp->current_component variable doesn't run, which then breaks some of the specific tabs in the search results page. This fixes it.

### Jira Issue:
[<!-- Paste Jira issue link -->](https://support.buddyboss.com/support/tickets/189662)
