### PR TITLE
Optimize wp_query request for BB Network Search bbpress search helper

### DIFF
--- a/src/bp-search/classes/class-bp-search-bbpress.php
+++ b/src/bp-search/classes/class-bp-search-bbpress.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Bp_Search_bbPress' ) ) :
 			// lets do a wp_query and generate html for all posts
 			$qry = new WP_Query(
 				array(
-					'post_type'     => array( 'forum', 'topic', 'reply' ),
+					'post_type'     => $this->type,
 					'post__in'      => $post_ids,
 					'post_status'   => array( 'publish', 'private', 'hidden', 'closed' ),
 					'no_found_rows' => true,


### PR DESCRIPTION
The bbpress search helper generate_html mechanism passes an array of `'forum', 'topic', 'reply'` to wp_query for each of the 3 types, generating considerably larger queries than needed. This changes it to only pass a post_type argument that uses the current type.

### Jira Issue: https://support.buddyboss.com/support/tickets/190531
<!-- Paste Jira issue link -->

Here is the query that is currently generated (3 times!) - notice that it joins forum, topic and reply, but ultimately only returns one of those, based on the IDs already retrieved and passed in. 
```
SELECT
    wp_posts.*
FROM
    wp_posts
    LEFT JOIN wp_bp_suspend sf ON (
        sf.item_type = 'forum'
        AND sf.item_id = wp_posts.ID
    )
    LEFT JOIN wp_bp_suspend sft ON (
        sft.item_type = 'forum_topic'
        AND sft.item_id = wp_posts.ID
    )
    LEFT JOIN wp_bp_suspend sfr ON (
        sfr.item_type = 'forum_reply'
        AND sfr.item_id = wp_posts.ID
    )
WHERE
    1 = 1
    AND wp_posts.ID IN (3766, 3764, 3739)
    AND wp_posts.post_type IN ('forum', 'topic', 'reply')
    AND (
        (
            wp_posts.post_status = 'publish'
            OR wp_posts.post_status = 'closed'
            OR wp_posts.post_status = 'hidden'
            OR wp_posts.post_status = 'private'
        )
    )
    AND (
        (
            sf.user_suspended = 0
            OR sf.user_suspended IS NULL
        )
        AND (
            sf.hide_parent = 0
            OR sf.hide_parent IS NULL
        )
        AND (
            sf.hide_sitewide = 0
            OR sf.hide_sitewide IS NULL
        )
    )
    AND (
        (
            sft.user_suspended = 0
            OR sft.user_suspended IS NULL
        )
        AND (
            sft.hide_parent = 0
            OR sft.hide_parent IS NULL
        )
        AND (
            sft.hide_sitewide = 0
            OR sft.hide_sitewide IS NULL
        )
    )
    AND (
        (
            sfr.user_suspended = 0
            OR sfr.user_suspended IS NULL
        )
        AND (
            sfr.hide_parent = 0
            OR sfr.hide_parent IS NULL
        )
        AND (
            sfr.hide_sitewide = 0
            OR sfr.hide_sitewide IS NULL
        )
    )
ORDER BY
    wp_posts.post_date DESC
```

If you change `'post_type'     => array( 'forum', 'topic', 'reply' ),` to `'post_type' 	=> $this->type,`, here is the query that is generated for each of the types.

```
SELECT
    wp_posts.*
FROM
    wp_posts
    LEFT JOIN wp_bp_suspend sft ON (
        sft.item_type = 'forum_topic'
        AND sft.item_id = wp_posts.ID
    )
WHERE
    1 = 1
    AND wp_posts.ID IN (3766, 3764, 3739)
    AND wp_posts.post_type = 'topic'
    AND (
        (
            wp_posts.post_status = 'publish'
            OR wp_posts.post_status = 'closed'
            OR wp_posts.post_status = 'hidden'
            OR wp_posts.post_status = 'private'
        )
    )
    AND (
        (
            sft.user_suspended = 0
            OR sft.user_suspended IS NULL
        )
        AND (
            sft.hide_parent = 0
            OR sft.hide_parent IS NULL
        )
        AND (
            sft.hide_sitewide = 0
            OR sft.hide_sitewide IS NULL
        )
    )
ORDER BY
    wp_posts.post_date DESC
```