### PR TITLE
PROD-3741 : BuddyBoss core pages - menus are not working with 2022 WordPress Theme

### DIFF
--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -403,7 +403,7 @@ function bp_get_query_template( $type, $templates = array() ) {
 	 * The current theme is using the WordPress Full Site Editing feature.
 	 * BuddyPress then needs to use the WordPress template canvas to retrieve the community content.
 	 */
-	if ( current_theme_supports( 'block-templates' ) ) {
+	if ( current_theme_supports( 'block-templates' ) && get_theme_file_path( 'index.php' ) === $template ) {
 		$template = ABSPATH . WPINC . '/template-canvas.php';
 	}
 

--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -392,11 +392,22 @@ function bp_get_query_template( $type, $templates = array() ) {
 	 */
 	$templates = apply_filters( "bp_get_{$type}_template", $templates );
 
-	// Filter possible templates, try to match one, and set any BuddyPress theme
-	// compat properties so they can be cross-checked later.
+	/*
+	 * Filter possible templates, try to match one, and set any BuddyPress theme
+	 * compat properties so they can be cross-checked later.
+	 */
 	$templates = bp_set_theme_compat_templates( $templates );
 	$template  = bp_locate_template( $templates );
-	$template  = bp_set_theme_compat_template( $template );
+
+	/*
+	 * The current theme is using the WordPress Full Site Editing feature.
+	 * BuddyPress then needs to use the WordPress template canvas to retrieve the community content.
+	 */
+	if ( current_theme_supports( 'block-templates' ) ) {
+		$template = ABSPATH . WPINC . '/template-canvas.php';
+	}
+
+	$template = bp_set_theme_compat_template( $template );
 
 	/**
 	 * Filters the path to a template file.

--- a/src/bp-forums/core/template-functions.php
+++ b/src/bp-forums/core/template-functions.php
@@ -410,7 +410,16 @@ function bbp_get_query_template( $type, $templates = array() ) {
 	$templates = apply_filters( "bbp_get_{$type}_template", $templates );
 	$templates = bbp_set_theme_compat_templates( $templates );
 	$template  = bbp_locate_template( $templates );
-	$template  = bbp_set_theme_compat_template( $template );
+
+	/*
+	 * The current theme is using the WordPress Full Site Editing feature.
+	 * BuddyPress then needs to use the WordPress template canvas to retrieve the community content.
+	 */
+	if ( current_theme_supports( 'block-templates' ) ) {
+		$template = ABSPATH . WPINC . '/template-canvas.php';
+	}
+
+	$template = bbp_set_theme_compat_template( $template );
 
 	return apply_filters( "bbp_{$type}_template", $template );
 }


### PR DESCRIPTION
### Jira Issue:
<!-- Paste Jira issue link -->
https://buddyboss.atlassian.net/browse/PROD-3741

### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
