### PR TITLE
PROD-3952 : Sometimes users are getting the same thread_id when multiple different users composing messages at the same timestamp

### DIFF
--- a/src/bp-messages/classes/class-bp-messages-message.php
+++ b/src/bp-messages/classes/class-bp-messages-message.php
@@ -154,15 +154,7 @@ class BP_Messages_Message {
 
 		// If we have no thread_id then this is the first message of a new thread.
 		if ( empty( $this->thread_id ) ) {
-			$max_thread      = self::get(
-				array(
-					'fields'   => 'thread_ids',
-					'per_page' => 1,
-					'page'     => 1,
-					'orderby'  => 'thread_id',
-				)
-			);
-			$this->thread_id = ( ! empty( $max_thread['messages'] ) ? (int) current( $max_thread['messages'] ) + 1 : 1 );
+			$this->thread_id = (int) $wpdb->get_var( "SELECT MAX(thread_id) FROM {$bp->messages->table_name_messages}" ) + 1;
 			$new_thread      = true;
 		}
 


### PR DESCRIPTION
### Jira Issue:
<!-- Paste Jira issue link -->
https://buddyboss.atlassian.net/browse/PROD-3952

### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
