### PR TITLE
Solving errors with PHP 8.2

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -29,6 +29,13 @@ class BP_Activity_Component extends BP_Component {
 	public $visibility_levels = array();
 
 	/**
+	 * Initializing an empty array for the Actions
+	 * 
+	 * @var array
+	 */
+	public $actions = array();
+
+	/**
 	 * Start the activity component setup process.
 	 *
 	 * @since BuddyPress 1.5.0

--- a/src/bp-core/bp-core-avatars.php
+++ b/src/bp-core/bp-core-avatars.php
@@ -431,9 +431,11 @@ function bp_core_fetch_avatar( $args = '' ) {
 
 	// Use an alias to leave the param unchanged.
 	$avatar_classes = $params['class'];
-	if ( ! is_array( $avatar_classes ) ) {
+	if ( ! is_array( $avatar_classes ) && ! is_null( $avatar_classes ) ) {
 		$avatar_classes = explode( ' ', $avatar_classes );
-	}
+	} else {
+		$avatar_classes = array();
+	}	
 
 	// Merge classes.
 	$avatar_classes = array_merge(

--- a/src/bp-core/classes/class-bp-admin-tab.php
+++ b/src/bp-core/classes/class-bp-admin-tab.php
@@ -498,23 +498,30 @@ if ( ! class_exists( 'BP_Admin_Tab' ) ) :
 		 * @since BuddyBoss 1.0.0
 		 */
 		public function add_section( $id, $title, $callback = '__return_null', $tutorial_callback = '', $notice = '' ) {
-			global $wp_settings_sections;
-			add_settings_section( $id, $title, $callback, $this->tab_name );
-			$this->active_section = $id;
-			if ( ! empty( $tutorial_callback ) ) {
-				$wp_settings_sections[ $this->tab_name ][ $id ]['tutorial_callback'] = $tutorial_callback;
-			}
-			if ( ! empty( $notice ) ) {
-				$wp_settings_sections[ $this->tab_name ][ $id ]['notice'] = $notice;
-			}
-			if ( function_exists( 'bb_admin_icons' ) ) {
-				$meta_icon = bb_admin_icons( $id );
-				if ( ! empty( $meta_icon ) ) {
-					$wp_settings_sections[ $this->tab_name ][ $id ]['icon'] = $meta_icon;
-				}
-			}
-			return $this;
-		}
+		        global $wp_settings_sections;
+		        add_settings_section( $id, $title, $callback, $this->tab_name );
+		        $this->active_section = $id;
+		        if ( ! empty( $tutorial_callback ) ) {
+		            $wp_settings_sections[ $this->tab_name ][ $id ]['tutorial_callback'] = $tutorial_callback;
+		        }
+		        if ( ! empty( $notice ) ) {
+		            $wp_settings_sections[ $this->tab_name ][ $id ]['notice'] = $notice;
+		        }
+		        if ( function_exists( 'bb_admin_icons' ) ) {
+		            $meta_icon = bb_admin_icons( $id );
+		            if ( ! empty( $meta_icon ) ) {
+		                $wp_settings_sections[ $this->tab_name ][ $id ]['icon'] = $meta_icon;
+		            }
+		        }
+		        return $this;
+		    }
+
+		    public function __set($name, $value)
+		    {
+		        if (property_exists($this, $name)) {
+		            $this->$name = $value;
+		        }
+		    }
 
 		/**
 		 * Add a wp setting field to a wp setting section. Chainable

--- a/src/bp-core/classes/class-bp-admin-tab.php
+++ b/src/bp-core/classes/class-bp-admin-tab.php
@@ -497,31 +497,25 @@ if ( ! class_exists( 'BP_Admin_Tab' ) ) :
 		 *
 		 * @since BuddyBoss 1.0.0
 		 */
+		public $active_section;
 		public function add_section( $id, $title, $callback = '__return_null', $tutorial_callback = '', $notice = '' ) {
-		        global $wp_settings_sections;
-		        add_settings_section( $id, $title, $callback, $this->tab_name );
-		        $this->active_section = $id;
-		        if ( ! empty( $tutorial_callback ) ) {
-		            $wp_settings_sections[ $this->tab_name ][ $id ]['tutorial_callback'] = $tutorial_callback;
-		        }
-		        if ( ! empty( $notice ) ) {
-		            $wp_settings_sections[ $this->tab_name ][ $id ]['notice'] = $notice;
-		        }
-		        if ( function_exists( 'bb_admin_icons' ) ) {
-		            $meta_icon = bb_admin_icons( $id );
-		            if ( ! empty( $meta_icon ) ) {
-		                $wp_settings_sections[ $this->tab_name ][ $id ]['icon'] = $meta_icon;
-		            }
-		        }
-		        return $this;
-		    }
-
-		    public function __set($name, $value)
-		    {
-		        if (property_exists($this, $name)) {
-		            $this->$name = $value;
-		        }
-		    }
+			global $wp_settings_sections;
+			add_settings_section( $id, $title, $callback, $this->tab_name );
+			$this->active_section = $id;
+			if ( ! empty( $tutorial_callback ) ) {
+				$wp_settings_sections[ $this->tab_name ][ $id ]['tutorial_callback'] = $tutorial_callback;
+			}
+			if ( ! empty( $notice ) ) {
+				$wp_settings_sections[ $this->tab_name ][ $id ]['notice'] = $notice;
+			}
+			if ( function_exists( 'bb_admin_icons' ) ) {
+				$meta_icon = bb_admin_icons( $id );
+				if ( ! empty( $meta_icon ) ) {
+					$wp_settings_sections[ $this->tab_name ][ $id ]['icon'] = $meta_icon;
+				}
+			}
+			return $this;
+		}
 
 		/**
 		 * Add a wp setting field to a wp setting section. Chainable

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -151,9 +151,26 @@ if ( ! class_exists( 'BP_Component' ) ) :
 		 *
 		 * @var string
 		 */
+		public $table_name = '';
 		public $table_name_meta = '';
     	public $table_name_friends = '';
     	public $table_name_friendship_meta = '';
+		public $table_name_recipients = '';
+		public $table_name_notices = '';
+		public $table_name_messages = '';
+		public $table_name_membermeta = '';
+		public $table_name_groupmeta = '';
+		public $table_name_follow = '';
+		public $table_name_reports = '';
+		public $table_name_last_activity = '';
+		public $table_name_signups = '';
+		public $table_name_data = '';
+		public $table_name_groups = '';
+		public $table_name_fields = '';
+		public $table_name_albums = '';
+		public $table_name_folder = '';
+		public $table_name_folder_meta = '';
+		public $table_name_members = '';
 
 
 		/** Methods ***************************************************************/

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -138,6 +138,14 @@ if ( ! class_exists( 'BP_Component' ) ) :
 		 * @var string
 		 */
 		public $search_query_arg = 's';
+		
+		/**
+		 * Static property for the Directory Title
+		 *
+		 * @var string
+		 */
+		public $directory_title = '';
+
 
 		/** Methods ***************************************************************/
 

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -138,13 +138,22 @@ if ( ! class_exists( 'BP_Component' ) ) :
 		 * @var string
 		 */
 		public $search_query_arg = 's';
-		
+
 		/**
-		 * Static property for the Directory Title
+		 * Public property for the Directory Title
 		 *
 		 * @var string
 		 */
 		public $directory_title = '';
+
+		/**
+		 * Public property for the Table names
+		 *
+		 * @var string
+		 */
+		public $table_name_meta = '';
+    	public $table_name_friends = '';
+    	public $table_name_friendship_meta = '';
 
 
 		/** Methods ***************************************************************/

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -17,6 +17,12 @@ defined( 'ABSPATH' ) || exit;
 class BP_Members_Component extends BP_Component {
 
 	/**
+	 * Adding the nav as a public property
+	 *
+	 */
+	public $nav;
+
+	/**
 	 * Profile types.
 	 *
 	 * @see bp_register_member_type()

--- a/src/bp-moderation/bp-moderation-filters.php
+++ b/src/bp-moderation/bp-moderation-filters.php
@@ -864,7 +864,7 @@ add_filter( 'manage_edit-bpm_category_columns', 'bb_category_show_when_reporting
  *
  * @return mixed Term meta data.
  */
-function bb_category_show_when_reporting_column_display( $string = '', $column_name, $term_id ) {
+function bb_category_show_when_reporting_column_display( $column_name, $term_id, $string = '' ) {
 	$value             = get_term_meta( $term_id, $column_name, true );
 	$show_when_options = bb_moderation_get_reporting_category_fields_array();
 	return ( isset( $show_when_options[ $value ] ) ? esc_attr( $show_when_options[ $value ] ) : esc_attr__( 'Content', 'buddyboss' ) );

--- a/src/bp-notifications/bp-notifications-template.php
+++ b/src/bp-notifications/bp-notifications-template.php
@@ -247,7 +247,9 @@ function bp_has_notifications( $args = '' ) {
 	$query_loop = new BP_Notifications_Template( $r );
 
 	// Setup the global query loop.
-	buddypress()->notifications->query_loop = $query_loop;
+	$bp_notifications = new BP_Notifications_Component();
+	$bp_notifications->set_query_loop($query_loop);
+
 
 	/**
 	 * Filters whether or not the user has notifications to display.
@@ -259,7 +261,7 @@ function bp_has_notifications( $args = '' ) {
 	 * @param BP_Notifications_Template $query_loop BP_Notifications_Template object instance.
 	 * @param array                     $r          Array of arguments passed into the BP_Notifications_Template class.
 	 */
-	return apply_filters( 'bp_has_notifications', $query_loop->has_notifications(), $query_loop, $r );
+	return apply_filters( 'bp_has_notifications', $bp_notifications->get_query_loop()->has_notifications(), $bp_notifications->get_query_loop(), $r );
 }
 
 /**

--- a/src/bp-notifications/classes/class-bp-notifications-component.php
+++ b/src/bp-notifications/classes/class-bp-notifications-component.php
@@ -319,6 +319,20 @@ class BP_Notifications_Component extends BP_Component {
 	}
 
 	/**
+	 * Defining the "query_loop" property.
+	 *
+	 */
+	protected $query_loop;
+
+    public function set_query_loop($query_loop) {
+        $this->query_loop = $query_loop;
+    }
+
+    public function get_query_loop() {
+        return $this->query_loop;
+    }
+
+	/**
 	 * Init the BuddyBoss REST API.
 	 *
 	 * @param array $controllers Optional. See BP_Component::rest_api_init() for description.

--- a/src/bp-notifications/classes/class-bp-notifications-template.php
+++ b/src/bp-notifications/classes/class-bp-notifications-template.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * @since BuddyPress 1.9.0
  */
 class BP_Notifications_Template {
+	public $notification_count;
 
 	/**
 	 * The loop iterator.
@@ -215,7 +216,7 @@ class BP_Notifications_Template {
 		$this->notifications            = BP_Notifications_Notification::get( $this->query_vars );
 		$this->total_notification_count = BP_Notifications_Notification::get_total_count( $this->query_vars );
 
-		if ( empty( $this->notifications ) ) {
+		if ( property_exists($this, 'notifications') && empty( $this->notifications ) ) {
 			$this->notification_count       = 0;
 			$this->total_notification_count = 0;
 

--- a/src/bp-notifications/classes/class-bp-notifications-template.php
+++ b/src/bp-notifications/classes/class-bp-notifications-template.php
@@ -140,6 +140,13 @@ class BP_Notifications_Template {
 	public $query_vars;
 
 	/**
+	 * Boolean of a notification being new or not
+	 *
+	 * @var bool
+	 */
+	public $is_new;
+
+	/**
 	 * Constructor method.
 	 *
 	 * @see bp_has_notifications() For information on the array format.

--- a/src/bp-video/bp-video-functions.php
+++ b/src/bp-video/bp-video-functions.php
@@ -2260,10 +2260,10 @@ function bp_video_download_link( $attachment_id, $video_id ) {
  * @since BuddyBoss 1.7.0
  */
 function bp_video_download_url_file() {
-	$attachment_id       = filter_input( INPUT_GET, 'attachment_id', FILTER_SANITIZE_STRING );
-	$download_video_file = filter_input( INPUT_GET, 'download_video_file', FILTER_SANITIZE_STRING );
-	$video_file          = filter_input( INPUT_GET, 'video_file', FILTER_SANITIZE_STRING );
-	$video_type          = filter_input( INPUT_GET, 'video_type', FILTER_SANITIZE_STRING );
+	$attachment_id       = filter_input( INPUT_GET, 'attachment_id', FILTER_SANITIZE_SPECIAL_CHARS );
+	$download_video_file = filter_input( INPUT_GET, 'download_video_file', FILTER_SANITIZE_SPECIAL_CHARS );
+	$video_file          = filter_input( INPUT_GET, 'video_file', FILTER_SANITIZE_SPECIAL_CHARS );
+	$video_type          = filter_input( INPUT_GET, 'video_type', FILTER_SANITIZE_SPECIAL_CHARS );
 	$can_download_btn    = false;
 
 	if ( isset( $attachment_id ) && isset( $download_video_file ) && isset( $video_file ) && isset( $video_type ) ) { // phpcs:ignore WordPress.Security.NonceVerification


### PR DESCRIPTION

**PHP: 8.2 compatibility issue**

File: /wp-content/plugins/buddyboss-platform/src/bp-core/classes/class-bp-admin-tab.php
Line: 503
Fix for: 
1. Creation of dynamic property BB_Pusher_Admin_Integration_Tab::$active_section is deprecated
2. Creation of dynamic property BP_Zoom_Admin_Integration_Tab::$active_section is deprecated
3. Creation of dynamic property BB_OneSignal_Admin_Integration_Tab::$active_section is deprecated
4. explode(): Passing null to parameter 2 ($string) of type string is deprecated
5. Constant FILTER_SANITIZE_STRING is deprecated
6. Creation of dynamic property BP_Notifications_Template
7. Creation of dynamic property BP_Search_Component
8. Creation of dynamic property BP_Friends_Component
9. Creation of dynamic property BP_Activity_Component
10. Creation of dynamic property BP_Document_Component
11. Creation of dynamic property BP_XProfile_Component
12. Deprecated: Required parameter $column_name follows optional parameter $string
13. Deprecated: Required parameter $term_id follows optional parameter $string

### Spreadsheet:
https://docs.google.com/spreadsheets/d/1LbPB_o-234J7DBwouNk9ADULQHZ9LMlgqRzekAIHqsQ/edit#gid=0

### Jira ID:
PROD-4362