### PR TITLE
PROD-5054  Fix - WordPress database error: you can't UPDATE the same table which you use in the SELECT part

### DIFF
--- a/src/bp-notifications/bp-notifications-functions.php
+++ b/src/bp-notifications/bp-notifications-functions.php
@@ -1948,7 +1948,7 @@ function bb_notification_read_for_moderated_members() {
 	}
 
 	global $bp, $wpdb;
-	$select_sql  = "SELECT DISTINCT id FROM {$bp->notifications->table_name}";
+	$select_sql  = "SELECT nid FROM ( SELECT DISTINCT id AS nid FROM {$bp->notifications->table_name}";
 	$select_sql .= ' WHERE is_new = 1 AND user_id = ' . bp_loggedin_user_id();
 
 	$select_sql_where = array();
@@ -1960,7 +1960,7 @@ function bb_notification_read_for_moderated_members() {
 	}
 	$select_sql_where[] = "secondary_item_id NOT IN ( SELECT DISTINCT ID from {$wpdb->users} )";
 
-	$select_sql .= ' AND ( ' . implode( ' OR ', $select_sql_where ) . ' )';
+	$select_sql .= ' AND ( ' . implode( ' OR ', $select_sql_where ) . ' ) ) AS n';
 
 	$update_query = "UPDATE {$bp->notifications->table_name} SET `is_new` = 0 WHERE id IN ({$select_sql})";
 	$wpdb->query( $update_query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-5054


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
