### PR TITLE
Find members with escaped characters in their names

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/messages/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/ajax.php
@@ -1707,7 +1707,7 @@ function bp_nouveau_ajax_dsearch_recipients() {
 
 	$results = bp_core_get_suggestions(
 		array(
-			'term'            => sanitize_text_field( $_GET['term'] ),
+			'term'            => sanitize_text_field( wp_unslash( $_GET['term'] ) ),
 			'type'            => 'members',
 			'only_friends'    => bp_is_active( 'friends' ) && bp_force_friendship_to_message(),
 			'count_total'     => 'count_query',


### PR DESCRIPTION
Using the slashed $_GET variable means a search for members with special characters in their names (like apostrophes) never finds anyone. I added wp_unslash() to match the member names.

### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
