### PR TITLE
PROD-4359 : Document Folder > The document folder meta doesn't save in the database using this function bp_document_folder_add_meta

### DIFF
--- a/src/bp-document/classes/class-bp-document-component.php
+++ b/src/bp-document/classes/class-bp-document-component.php
@@ -177,10 +177,9 @@ class BP_Document_Component extends BP_Component {
 
 		// Metadata tables for groups component.
 		$meta_tables = array(
-			'document'        => $bp->table_prefix . 'bp_document_meta',
-			'document_folder' => $bp->table_prefix . 'bp_document_folder_meta',
+			'document' => $bp->table_prefix . 'bp_document_meta',
+			'folder'   => $bp->table_prefix . 'bp_document_folder_meta',
 		);
-
 
 		// Fetch the default directory title.
 		$default_directory_titles = bp_core_get_directory_page_default_titles();


### PR DESCRIPTION
### Jira Issue:
<!-- Paste Jira issue link -->
https://buddyboss.atlassian.net/browse/PROD-4359

### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
