### PR TITLE
PROD-8055 - Added “rapydapps.cloud” suffix to URLs considered as staging sites for Rapyd Customer

### DIFF
--- a/src/bp-core/admin/bp-core-admin-theme-settings.php
+++ b/src/bp-core/admin/bp-core-admin-theme-settings.php
@@ -85,6 +85,7 @@ if ( ! function_exists( 'buddyboss_theme_get_theme_sudharo' ) ) {
 			'staging.',
 			'localhost',
 			'.local',
+			'rapydapps.cloud',
 		);
 
 		foreach ( $whitelist_domain as $domain ) {


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-8051
https://buddyboss.atlassian.net/browse/PROD-8055

### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
