### PR TITLE
[PROD-8125] Hide likes/reactions activity tab dependent on activity tabs settings

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/activity/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/functions.php
@@ -334,20 +334,20 @@ function bp_nouveau_get_activity_directory_nav_items() {
 			)
 		);
 
-		// If the user has favorite create a nav item
-		if ( bp_is_activity_like_active() && bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) {
-			$nav_items['favorites'] = array(
-				'component' => 'activity',
-				'slug'      => 'favorites', // slug is used because BP_Core_Nav requires it, but it's the scope
-				'li_class'  => array(),
-				'link'      => bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/',
-				'text'      => bb_is_reaction_emotions_enabled() ? esc_html__( 'Reactions', 'buddyboss' ) : esc_html__( 'Likes', 'buddyboss' ),
-				'count'     => false,
-				'position'  => 10,
-			);
-		}
-
 		if ( bp_is_activity_tabs_active() ) {
+
+			// If the user has favorite create a nav item
+			if ( bp_is_activity_like_active() && bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) {
+				$nav_items['favorites'] = array(
+					'component' => 'activity',
+					'slug'      => 'favorites', // slug is used because BP_Core_Nav requires it, but it's the scope
+					'li_class'  => array(),
+					'link'      => bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/',
+					'text'      => bb_is_reaction_emotions_enabled() ? esc_html__( 'Reactions', 'buddyboss' ) : esc_html__( 'Likes', 'buddyboss' ),
+					'count'     => false,
+					'position'  => 10,
+				);
+			}
 
 			// The friends component is active and user has friends
 			if ( bp_is_active( 'friends' ) && bp_get_total_friend_count( bp_loggedin_user_id() ) ) {


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-8125


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
