### PR TITLE
[PROD-7927] Check for empty parent group before displaying membership request message

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress/groups/single/request-membership.php
+++ b/src/bp-templates/bp-nouveau/buddypress/groups/single/request-membership.php
@@ -85,7 +85,9 @@ if ( groups_check_user_has_invite( $loggedin_user_id, $current_group_id ) ) {
 			esc_html( bp_get_group_name( $parent_group ) )
 		);
 
-		printf( __( 'You must first be a member of the parent group "%s" before you can join this group.', 'buddyboss' ), $parent_group_name );
+		if ( ! empty( $parent_group_id ) ) {
+			printf( __( 'You must first be a member of the parent group "%s" before you can join this group.', 'buddyboss' ), $parent_group_name );
+		}
 	}
 } else {
 	bp_nouveau_user_feedback( 'group-requested-membership' );


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-7927


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
