### PR TITLE
[PROD-9325] Fix profile type validation to allow users to keep current type when self-selection is disabled

### DIFF
--- a/src/bp-xprofile/screens/edit.php
+++ b/src/bp-xprofile/screens/edit.php
@@ -88,9 +88,12 @@ function xprofile_screen_edit_profile() {
 					? bp_member_type_post_by_type( $current_member_type )
 					: 0;
 
-				// Check if user is trying to keep their current profile type
-				// This allows users to save their profile without changing type even when self-selection is disabled
-				$is_keeping_current_type = ( ! empty( $current_profile_type_post_id ) && (int) $current_profile_type_post_id === (int) $submitted_profile_type_post_id );
+				// Check if user is trying to keep their current profile type.
+				// This allows users to save their profile without changing type even when self-selection is disabled.
+				$is_keeping_current_type = (
+					! empty( $current_profile_type_post_id ) &&
+					(int) $current_profile_type_post_id === (int) $submitted_profile_type_post_id
+				);
 
 				// Only validate self-selection restrictions if user is trying to CHANGE to a different profile type
 				if ( ! $is_keeping_current_type ) {


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-9325


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
