### PR TITLE
Fix null activity objects causing PHP warnings

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -1002,7 +1002,9 @@ class BP_Activity_Activity {
 				}
 			}
 
-			$activities[] = $activity;
+			if ( ! empty( $activity ) ) {
+				$activities[] = $activity;
+			}
 		}
 
 		$user_ids  = wp_list_pluck( $activities, 'user_id' );

--- a/src/bp-friends/bp-friends-activity.php
+++ b/src/bp-friends/bp-friends-activity.php
@@ -218,6 +218,10 @@ function bp_friends_prefetch_activity_object_data( $activities ) {
 	$friend_ids = array();
 
 	foreach ( $activities as $activity ) {
+		if ( ! is_object( $activity ) ) {
+			continue;
+		}
+
 		if ( buddypress()->friends->id !== $activity->component ) {
 			continue;
 		}


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-9861 

## Problem

When activity rows are deleted from the database but their IDs are still
referenced (e.g. in cached query results), `BP_Activity_Activity::get_activity_data()`
adds `false` entries to the `$activities` array. This happens because
`wp_cache_get()` returns `false` for missing cache keys, and the result
is unconditionally appended to the array regardless of validity.

Downstream code then iterates over these null entries and attempts
property access, producing three PHP warnings:

```
PHP Warning: Attempt to read property "id" on null in .../class-bp-activity-activity.php on line 895
PHP Warning: Attempt to read property "mptt_right" on null in .../class-bp-activity-activity.php on line 1641
PHP Warning: Attempt to read property "component" on null in .../bp-friends-activity.php on line 221
```

## Fix

1. **`get_activity_data()`** — wrap the `$activities[] = $activity`
   assignment with `if ( ! empty( $activity ) )` so that only valid
   objects are added to the return array. This is the root cause fix
   and prevents all three warnings.

2. **`bp_friends_prefetch_activity_object_data()`** — add a defensive
   `is_object()` check to skip non-object entries, protecting against
   any code path that might pass invalid data into this function.

## Testing

1. Delete an activity from the `bp_activity` table without clearing
   the object cache or any referencing queries
2. Load the activity feed — the three warnings above should no longer
   appear
3. Normal activity feed behaviour is unaffected