### PR TITLE
PROD-9981 - Activity not found error when clicking reaction count on activity comments

### DIFF
--- a/src/bb-features/community/reactions/bb-activity-reactions.php
+++ b/src/bb-features/community/reactions/bb-activity-reactions.php
@@ -494,9 +494,19 @@ function bb_get_activity_reaction_ajax_callback() {
 	$reaction_id = ! empty( $_POST['reaction_id'] ) ? absint( wp_unslash( $_POST['reaction_id'] ) ) : 0;
 	$before      = ! empty( $_POST['before'] ) ? absint( wp_unslash( $_POST['before'] ) ) : 0;
 
-	// Verify the activity exists and is visible to the current user.
-	$activity_result = bp_activity_get_specific( array( 'activity_ids' => array( $item_id ) ) );
-	if ( empty( $activity_result['activities'] ) ) {
+	// Verify the item exists and is visible to the current user.
+	// Activity comments are stored in the activity table but are excluded from
+	// BP_Activity_Activity::get() (used by bp_activity_get_specific()), so load them
+	// directly to avoid a false "Activity not found." for comment reactions.
+	if ( 'activity_comment' === $item_type ) {
+		$activity_item = new BP_Activity_Activity( $item_id );
+		$item_exists   = ! empty( $activity_item->id );
+	} else {
+		$activity_result = bp_activity_get_specific( array( 'activity_ids' => array( $item_id ) ) );
+		$item_exists     = ! empty( $activity_result['activities'] );
+	}
+
+	if ( ! $item_exists ) {
 		wp_send_json_error(
 			array(
 				'message' => __( 'Activity not found.', 'buddyboss' ),


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-9981

### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
