### PR TITLE
PROD-10086 - When Reactions for Activity posts is disabled comment reactions stops working

### DIFF
--- a/src/bb-features/community/reactions/loader.php
+++ b/src/bb-features/community/reactions/loader.php
@@ -27,8 +27,17 @@ defined( 'ABSPATH' ) || exit;
  * This runs inline (not deferred) because the feature loader already gates this file
  * behind bb_is_feature_active('reactions'). We only need the additional activity check
  * for the sub-feature level (individual content type toggles).
+ *
+ * Gate on EITHER content-type toggle (posts OR comments). bp_is_activity_like_active()
+ * reflects only the posts toggle, so relying on it would unload the entire reaction
+ * runtime (BB_Reaction class, AJAX handlers, REST routes) whenever post reactions are
+ * disabled — even if comment reactions are still enabled. That broke comment reactions
+ * and the reactions listing ("Reactions are not available.").
  */
-if ( bp_is_active( 'activity' ) && bp_is_activity_like_active() ) {
+if (
+	bp_is_active( 'activity' ) &&
+	( bb_is_reaction_activity_posts_enabled() || bb_is_reaction_activity_comments_enabled() )
+) {
 
 	$bb_reactions_feature_dir = __DIR__;
 


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-10086
https://buddyboss.atlassian.net/browse/PROD-10082


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
