### PR TITLE
PROD-9622 - In readylaunch the comments section is been added to activity instead of popup and UI is broken under the activity when we edit the activity or delete the activity medias

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -1127,13 +1127,26 @@ function bp_nouveau_ajax_post_update() {
 	// Delete draft activity.
 	delete_user_meta( bp_loggedin_user_id(), $draft_activity_meta_key );
 
+	$activity_args = array(
+		'include'     => $activity_id,
+		'show_hidden' => $is_private,
+	);
+
+	/*
+	 * In ReadyLaunch, activity comments are displayed only inside the activity modal
+	 * (or on the single activity screen), never inline in the feed. The feed loop
+	 * enforces this with 'display_comments=false' (see readylaunch/activity/activity-loop.php).
+	 *
+	 * Mirror that here so a re-rendered (newly posted or edited) activity injected back
+	 * into the stream stays consistent and doesn't render a comment thread whose reply
+	 * form is absent in this context, which would leave the "Comment"/"Reply" buttons dead.
+	 */
+	if ( bb_is_readylaunch_enabled() && ! bp_is_single_activity() ) {
+		$activity_args['display_comments'] = false;
+	}
+
 	ob_start();
-	if ( bp_has_activities(
-		array(
-			'include'     => $activity_id,
-			'show_hidden' => $is_private,
-		)
-	) ) {
+	if ( bp_has_activities( $activity_args ) ) {
 		while ( bp_activities() ) {
 			bp_the_activity();
 			bp_get_template_part( 'activity/entry' );


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-9622


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
