### PR TITLE
PROD-10182 - Fix: `bb_digest_email_notifications_hook` cron event is not re-scheduled when "Delay Email Notifications" is re-enabled

### DIFF
--- a/src/bp-core/classes/class-bp-core-cron.php
+++ b/src/bp-core/classes/class-bp-core-cron.php
@@ -76,12 +76,24 @@ class BP_Core_Cron {
 			return false;
 		}
 
-		$this->crons[] = array(
+		$cron = array(
 			'hook'       => 'bb_' . $hook . '_hook',
 			'recurrence' => $recurrence,
 		);
 
+		$this->crons[] = $cron;
+
 		add_action( 'bb_' . $hook . '_hook', $callback );
+
+		/*
+		 * schedule() only runs on the bp_init hook. If bp_init has already
+		 * fired for this request (e.g. this is being added from an AJAX/REST
+		 * save handler that runs after boot), schedule() will not run again
+		 * and this cron would otherwise never actually get scheduled.
+		 */
+		if ( did_action( 'bp_init' ) ) {
+			$this->schedule_single( $cron );
+		}
 
 		return true;
 	}
@@ -93,10 +105,21 @@ class BP_Core_Cron {
 	 */
 	public function schedule() {
 		foreach ( $this->crons as $cron ) {
-			// Schedule if not scheduled already.
-			if ( ! wp_next_scheduled( $cron['hook'] ) && apply_filters( 'bp_core_cron_schedule_' . $cron['hook'], true ) ) {
-				wp_schedule_event( time(), $cron['recurrence'], $cron['hook'] );
-			}
+			$this->schedule_single( $cron );
+		}
+	}
+
+	/**
+	 * Schedule a single cron event if it isn't already scheduled.
+	 *
+	 * @since BuddyBoss [BBVERSION]
+	 *
+	 * @param array $cron Cron array with 'hook' and 'recurrence' keys.
+	 */
+	protected function schedule_single( $cron ) {
+		// Schedule if not scheduled already.
+		if ( ! wp_next_scheduled( $cron['hook'] ) && apply_filters( 'bp_core_cron_schedule_' . $cron['hook'], true ) ) {
+			wp_schedule_event( time(), $cron['recurrence'], $cron['hook'] );
 		}
 	}
 }

--- a/src/bp-core/classes/class-bp-core-cron.php
+++ b/src/bp-core/classes/class-bp-core-cron.php
@@ -118,7 +118,10 @@ class BP_Core_Cron {
 	 */
 	protected function schedule_single( $cron ) {
 		// Schedule if not scheduled already.
-		if ( ! wp_next_scheduled( $cron['hook'] ) && apply_filters( 'bp_core_cron_schedule_' . $cron['hook'], true ) ) {
+		if (
+			! wp_next_scheduled( $cron['hook'] )
+			&& apply_filters( 'bp_core_cron_schedule_' . $cron['hook'], true )
+		) {
 			wp_schedule_event( time(), $cron['recurrence'], $cron['hook'] );
 		}
 	}


### PR DESCRIPTION
…-scheduled when "Delay Email Notifications" is re-enabled

### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-10182


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
