### PR TITLE
Return commenter mention name and profile URL in activit…

### DIFF
--- a/src/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/src/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -2345,6 +2345,12 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			$data['comment_depth'] = $activity->depth;
 		}
 
+		// Commenter's mention name and profile URL to build the auto-mention when replying.
+		if ( 'activity_comment' === $activity->type ) {
+			$data['mention_name'] = bp_activity_get_user_mentionname( $activity->user_id );
+			$data['user_link']    = bp_core_get_user_domain( $activity->user_id );
+		}
+
 		// Get comments (count).
 		if ( ! empty( $activity->children ) ) {
 			$data['comment_count'] = isset( $activity->all_child_count ) ? $activity->all_child_count : bp_activity_recurse_comment_count( $activity );
@@ -2891,6 +2897,19 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'description' => __( 'User\'s display name for the activity.', 'buddyboss' ),
 					'type'        => 'string',
+				),
+				'mention_name'                   => array(
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'description' => __( 'User\'s mention name for the activity comment.', 'buddyboss' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'user_link'                      => array(
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'description' => __( 'Profile URL of the activity comment author.', 'buddyboss' ),
+					'format'      => 'uri',
+					'type'        => 'string',
+					'readonly'    => true,
 				),
 				'link'                           => array(
 					'context'     => array( 'embed', 'view', 'edit' ),


### PR DESCRIPTION
…y comment REST response

The Next Gen app could not auto-tag the original commenter when replying to an activity comment because the activity comment REST response only exposed the commenter's user ID and display name. Add mention_name and user_link fields to activity comment items so the app can build the auto-mention without extra round trips, mirroring the data the web fix (PROD-7604) exposes via bb_activity_comment_get_edit_data().

### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-10204


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
