### PR TITLE
[PROD-10225] - Fix the app crash if the BuddyBoss Addon plugin is not activated but the BuddyBoss Platform Pro plugin is active

### DIFF
--- a/src/bp-core/bp-core-options.php
+++ b/src/bp-core/bp-core-options.php
@@ -2751,10 +2751,25 @@ function bb_get_reaction_mode( $default = 'likes' ) {
 		// 'emotions' setting on every request where the provider had not booted
 		// yet (and, on addon-only sites, permanently), which made the Reactions
 		// mode appear un-saveable.
+		//
+		// The Pro term must prove Pro still SHIPS the layer, not merely that it is
+		// licensed. Current Pro builds carry no reaction code at all — only a
+		// deprecated bb_pro_get_reactions() shim — so a bare licence check reported
+		// the layer available on every Pro site with the add-on inactive. That left
+		// the mode stuck on 'emotions' with no provider behind it, which locked the
+		// admin toggle (the Emotions option renders selected but disabled) and made
+		// the REST settings advertise a mode the App cannot render.
+		// bp_register_reaction() is the marker for a Pro build that still owns the
+		// emotion layer — the same signal the add-on's loader uses to stay dormant.
+		// Do NOT probe bb_pro_get_reactions(): current Pro defines it as a stub.
 		$emotion_layer_available =
 			class_exists( 'BB_Reactions' )
 			|| ( function_exists( 'bb_addons_should_lock_features' ) && ! bb_addons_should_lock_features() )
-			|| ( function_exists( 'bbp_pro_is_license_valid' ) && bbp_pro_is_license_valid() );
+			|| (
+				function_exists( 'bp_register_reaction' )
+				&& function_exists( 'bbp_pro_is_license_valid' )
+				&& bbp_pro_is_license_valid()
+			);
 
 		if ( ! $emotion_layer_available ) {
 			$mode = 'likes';


### PR DESCRIPTION
[PROD-10225] - Fix the app crash if the BuddyBoss Addon plugin is not activated and BuddyBoss platform pro is activated

### Jira Issue:

https://buddyboss.atlassian.net/browse/PROD-10225

### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)


[PROD-10225]: https://buddyboss.atlassian.net/browse/PROD-10225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ