### PR TITLE
PROD-10239 - Fix: activity date showing wrong time/day in Settings 2.0 admin list

### DIFF
--- a/src/js/admin/settings/screens/ActivityListScreen.js
+++ b/src/js/admin/settings/screens/ActivityListScreen.js
@@ -412,8 +412,10 @@ export function ActivityListScreen( { onNavigate } ) {
 	 *
 	 * Uses dateI18n() from @wordpress/date so the output respects the
 	 * WordPress timezone setting and translates month names.
-	 * date_recorded is stored as UTC in the database; passing the raw
-	 * string lets dateI18n convert it to the site's local time.
+	 * date_recorded is stored as a naive UTC datetime string (no
+	 * timezone designator), so it must be normalized to an explicit
+	 * UTC ISO string first — otherwise dateI18n()/moment() parses it
+	 * as the browser's local time instead of UTC before converting.
 	 *
 	 * @param {string} dateStr UTC date string (e.g. "2026-02-27 14:23:45").
 	 * @returns {string} Formatted date in site timezone.
@@ -422,7 +424,7 @@ export function ActivityListScreen( { onNavigate } ) {
 		if ( ! dateStr ) {
 			return '';
 		}
-		return dateI18n( 'j M, H:i:s', dateStr );
+		return dateI18n( 'j M, H:i:s', dateStr.replace( ' ', 'T' ) + 'Z' );
 	};
 
 	// Build action type options for select.


### PR DESCRIPTION
date_recorded is stored as a naive UTC datetime string with no
  timezone designator (e.g. "2026-08-10 05:25:01"). ActivityListScreen's
  formatDate() passed that raw string straight into dateI18n(), which
  via moment() parses an unmarked string as the browser's local time
  rather than UTC. This silently shifted the displayed timestamp by
  the viewing browser's own UTC offset (and could roll it back a
  calendar day), independent of the WordPress site's configured
  timezone.

  Normalize the string to explicit ISO-8601 UTC (append "T"/"Z")
  before formatting, matching the existing correct pattern already
  used for the same class of value in GroupsListScreen.js.

### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-10239


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
