### PR TITLE
PROD-9032: Hide existing member content on block, not just new content

### DIFF
--- a/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
+++ b/src/bp-moderation/classes/suspend/class-bp-suspend-member.php
@@ -436,6 +436,10 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 		}
 		bb_suspend_update_meta( $suspend_id, $meta_key, $meta_value );
 
+		if ( ! isset( $args['blocked_user'] ) ) {
+			$args['blocked_user'] = $member_id;
+		}
+
 		if ( $this->background_disabled || ! $force_bg_process ) {
 			$this->hide_related_content( $member_id, $hide_sitewide, $args );
 		} else {
@@ -525,6 +529,10 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 			$meta_value[] = $current_process;
 		}
 		bb_suspend_update_meta( $suspend_id, $meta_key, $meta_value );
+
+		if ( ! isset( $args['blocked_user'] ) ) {
+			$args['blocked_user'] = $member_id;
+		}
 
 		if ( $this->background_disabled || ! $force_bg_process ) {
 			$this->unhide_related_content( $member_id, $hide_sitewide, $force_all, $args );
@@ -766,17 +774,6 @@ class BP_Suspend_Member extends BP_Suspend_Abstract {
 				$current_total_friend_count = count( $current_friend_ids );
 				bp_update_user_meta( $member_id, 'total_friend_count', (int) $current_total_friend_count );
 			}
-		}
-
-		// Return the loop when the user is blocked/unblocked but not suspended/unsuspended.
-		if (
-			! empty( $args['blocked_user'] ) &&
-			empty( $args['action_suspend'] ) &&
-			empty( $args['user_suspended'] ) &&
-			! empty( $args['parent_id'] ) &&
-			self::$type . '_' . $member_id === $args['parent_id']
-		) {
-			return $related_contents;
 		}
 
 		$meta_key = (


### PR DESCRIPTION
PROD link: https://buddyboss.atlassian.net/browse/PROD-9032

## Issue

When a member blocks another member (with auto-suspend disabled in Member Moderation settings), the blocked member's **pre-existing** content — activity posts, media, documents, videos, forum posts — remains visible to the blocker. Only content the blocked member posts *after* the block takes effect gets hidden (via a separate, independent `*_after_save` path). Introduced by PROD-7948.

## Root cause

Two separate defects in `class-bp-suspend-member.php` combined to produce this:

1. **`get_related_contents()` short-circuited the entire per-content-type walk for block-only actions.** PROD-7948 added an early return: whenever `$args['blocked_user']` was set but the action wasn't a suspend/unsuspend, the function returned immediately instead of walking activity/documents/media/video/forums/folders to find the member's existing content. This return matched on *every* paginated call for a block action, not just an initial one, so a block never got past the first check.

2. **Even where the walk did run, per-item handlers never actually received `blocked_user`.** `manage_hidden_member()` / `manage_unhidden_member()` each build a `$suspend_args` array a few lines earlier via `bp_parse_args( $args, array( ..., 'blocked_user' => $member_id, ... ) )` — but that computed array is only used for the member's own suspend-meta bookkeeping. The call into `hide_related_content()` / `unhide_related_content()` a few lines later passes the original `$args`, which callers don't otherwise populate with `blocked_user`. So even setting aside defect 1, the per-item hide/unhide calls had no way to know this was a block action, and never wrote the `wp_bp_suspend_details` rows that actually hide content from the blocking user.

## Fix

- Removed the early return in `get_related_contents()`, so the per-content-type walk always runs regardless of whether the action is a suspend or a block-only action.
- In both `manage_hidden_member()` and `manage_unhidden_member()`, added `if ( ! isset( $args['blocked_user'] ) ) { $args['blocked_user'] = $member_id; }` immediately before the calls into `hide_related_content()` / `unhide_related_content()`, so the array actually forwarded downstream carries the same default `$suspend_args` already computed for it.

Verified on a local dev site by direct DB inspection: after the fix, re-blocking a test member correctly populated `wp_bp_suspend_details` for ~26 pre-existing activity items, several forum replies/topics, and a media item — not just the newest post.

**Note for reviewers:** this reinstates the per-component walk for block-only actions that PROD-7948 (Kartik Suthar / Jitendra Banjara) intentionally skipped for performance. No rationale specific to correctness was found tying that skip to the block case specifically — flagging here since removing it does restore the pre-PROD-7948 cost profile for block/unblock actions on members with a lot of content.
