### PR TITLE
PROD-10339 - Fix: Group Type list not appearing in the select dropdown on the Group Settings page (frontend) when ReadyLaunch is enabled

### DIFF
--- a/src/bp-templates/bp-nouveau/readylaunch/groups/single/admin/group-settings.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/groups/single/admin/group-settings.php
@@ -221,6 +221,16 @@ if ( bp_is_group_create() ) : ?>
 				<select id="bp-groups-type" name="group-types[]" autocomplete="off">
 					<option value="" <?php selected( '', '' ); ?>><?php esc_html_e( 'Select Group Type', 'buddyboss' ); ?></option>
 					<?php
+					// `wp_kses_post()` strips `<option>`/`<select>` as they're not part of the post-content
+					// allowed-tags list, so a dedicated allowlist is used instead to keep these options intact.
+					$group_type_option_allowed_html = array(
+						'option' => array(
+							'for'      => true,
+							'value'    => true,
+							'selected' => true,
+						),
+					);
+
 					foreach ( $group_types as $group_type ) :
 
 						$group_option = sprintf(
@@ -249,19 +259,19 @@ if ( bp_is_group_create() ) : ?>
 
 									if ( ! empty( $include_group_type ) ) {
 										if ( in_array( $group_type->name, $include_group_type, true ) ) {
-											echo wp_kses_post( $group_option );
+											echo wp_kses( $group_option, $group_type_option_allowed_html );
 										}
 									} else {
-										echo wp_kses_post( $group_option );
+										echo wp_kses( $group_option, $group_type_option_allowed_html );
 									}
 								} else {
-									echo wp_kses_post( $group_option );
+									echo wp_kses( $group_option, $group_type_option_allowed_html );
 								}
 							} else {
-								echo wp_kses_post( $group_option );
+								echo wp_kses( $group_option, $group_type_option_allowed_html );
 							}
 						} else {
-							echo wp_kses_post( $group_option );
+							echo wp_kses( $group_option, $group_type_option_allowed_html );
 						}
 					endforeach;
 					?>


### PR DESCRIPTION
Group Type list not appearing in the select dropdown on the Group Settings page (frontend) when ReadyLaunch is enabled

### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-10339


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
