### PR TITLE
PROD-10276: Show comments on public group activity to logged-in non-members

### DIFF
--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -3123,6 +3123,40 @@ function bp_activity_new_comment( $args = '' ) {
 		}
 	}
 
+	/**
+	 * Filters whether group membership is enforced when posting an activity comment.
+	 *
+	 * @since BuddyBoss [BBVERSION]
+	 *
+	 * @param bool                 $validate_group_membership Whether to enforce group membership.
+	 * @param array                $r                         Parsed arguments for the new comment.
+	 * @param BP_Activity_Activity $activity                  Parent (root) activity object.
+	 */
+	$validate_group_membership = apply_filters( 'bb_activity_new_comment_validate_group_membership', true, $r, $activity );
+
+	// Bail if the user is not a member of the group the activity belongs to.
+	if (
+		$validate_group_membership &&
+		bp_is_active( 'groups' ) &&
+		buddypress()->groups->id === $activity->component &&
+		! bp_user_can( (int) $r['user_id'], 'bp_moderate' ) &&
+		(
+			! groups_is_user_member( (int) $r['user_id'], $activity->item_id ) ||
+			groups_is_user_banned( (int) $r['user_id'], $activity->item_id )
+		)
+	) {
+		$error = new WP_Error( 'bb_activity_group_comment_restricted', __( 'You need to be a member of this group to comment.', 'buddyboss' ) );
+
+		if ( 'wp_error' === $r['error_type'] ) {
+			return $error;
+
+			// Backpat.
+		} else {
+			$bp->activity->errors['new_comment'] = $error;
+			return false;
+		}
+	}
+
 	// update comment privacy with parent one.
 	if ( ! empty( $activity->privacy ) ) {
 		$privacy = $activity->privacy;

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -2905,7 +2905,7 @@ function bp_get_activity_css_class() {
 		$class .= ' mini';
 	}
 
-	if ( bp_activity_get_comment_count() && bp_activity_can_comment() ) {
+	if ( bp_activity_get_comment_count() && bb_activity_can_view_comments() ) {
 		$class .= ' has-comments';
 	}
 
@@ -3327,6 +3327,98 @@ function bp_activity_can_comment_reply( $comment = false ) {
 	 * @param object $comment     Current comment object being checked on.
 	 */
 	return (bool) apply_filters( 'bp_activity_can_comment_reply', $can_comment, $comment );
+}
+
+/**
+ * Determine if the current user can view comments on an activity item.
+ *
+ * Group membership is not required to view comments on a group activity
+ * the user can read; posting still requires membership.
+ *
+ * @since BuddyBoss [BBVERSION]
+ *
+ * @global object $activities_template {@link BP_Activity_Template}
+ *
+ * @param object|null $activity Optional. Activity object. Defaults to the current activity in the loop.
+ *
+ * @return bool True if the current user can view comments on the activity item.
+ */
+function bb_activity_can_view_comments( $activity = null ) {
+	global $activities_template;
+
+	if ( ! is_object( $activity ) && ! empty( $activities_template->activity ) ) {
+		$activity = $activities_template->activity;
+	}
+
+	$can_view = bp_activity_can_comment();
+
+	// Group activities: lift only the membership veto when the user can read the activity.
+	if (
+		! $can_view &&
+		is_object( $activity ) &&
+		! empty( $activity->component ) &&
+		bp_is_active( 'groups' ) &&
+		buddypress()->groups->id === $activity->component &&
+		bp_activity_user_can_read( $activity, bp_loggedin_user_id() )
+	) {
+		remove_filter( 'bp_activity_can_comment', 'bp_groups_filter_activity_can_comment', 99 );
+		$can_view = bp_activity_can_comment();
+		add_filter( 'bp_activity_can_comment', 'bp_groups_filter_activity_can_comment', 99, 1 );
+	}
+
+	/**
+	 * Filters whether the current user can view comments on an activity item.
+	 *
+	 * @since BuddyBoss [BBVERSION]
+	 *
+	 * @param bool        $can_view Whether the current user can view comments.
+	 * @param object|null $activity Activity object.
+	 */
+	return (bool) apply_filters( 'bb_activity_can_view_comments', $can_view, $activity );
+}
+
+/**
+ * Determine if the current user can view replies to an activity comment.
+ *
+ * Reply-viewing counterpart of bb_activity_can_view_comments().
+ *
+ * @since BuddyBoss [BBVERSION]
+ *
+ * @param object|null $comment Optional. Activity comment. Defaults to the current comment in the loop.
+ *
+ * @return bool True if the current user can view replies to the comment.
+ */
+function bb_activity_can_view_comment_replies( $comment = null ) {
+
+	if ( empty( $comment ) ) {
+		$comment = bp_activity_current_comment();
+	}
+
+	$can_view = bp_activity_can_comment_reply( $comment );
+
+	// Group activities: viewing follows readability of the root activity.
+	if ( ! $can_view && ! empty( $comment->item_id ) && bp_is_active( 'groups' ) ) {
+		$root_activity = new BP_Activity_Activity( (int) $comment->item_id );
+
+		if (
+			buddypress()->groups->id === $root_activity->component &&
+			bp_activity_user_can_read( $root_activity, bp_loggedin_user_id() )
+		) {
+			remove_filter( 'bp_activity_can_comment_reply', 'bp_groups_filter_activity_can_comment_reply', 99 );
+			$can_view = bp_activity_can_comment_reply( $comment );
+			add_filter( 'bp_activity_can_comment_reply', 'bp_groups_filter_activity_can_comment_reply', 99, 2 );
+		}
+	}
+
+	/**
+	 * Filters whether the current user can view replies to an activity comment.
+	 *
+	 * @since BuddyBoss [BBVERSION]
+	 *
+	 * @param bool        $can_view Whether the current user can view replies to the comment.
+	 * @param object|null $comment  Activity comment object.
+	 */
+	return (bool) apply_filters( 'bb_activity_can_view_comment_replies', $can_view, $comment );
 }
 
 /**

--- a/src/bp-activity/classes/class-bb-activity-readylaunch.php
+++ b/src/bp-activity/classes/class-bb-activity-readylaunch.php
@@ -386,7 +386,7 @@ class BB_Activity_Readylaunch {
 			?>
 
 			<?php
-			if ( bp_activity_can_comment() ) {
+			if ( bb_activity_can_view_comments() ) {
 				$activity_state_comment_class['activity_state_comment_class'] = 'activity-state-comments';
 				if ( $comment_count > 0 ) {
 					$activity_state_comment_class['has-comments'] = 'has-comments';

--- a/src/bp-activity/classes/class-bp-activity-feed.php
+++ b/src/bp-activity/classes/class-bp-activity-feed.php
@@ -458,7 +458,7 @@ class BP_Activity_Feed {
 					<content:encoded><![CDATA[<?php $this->feed_content(); ?>]]></content:encoded>
 				<?php endif; ?>
 
-				<?php if ( bp_activity_can_comment() ) : ?>
+				<?php if ( bb_activity_can_view_comments() ) : ?>
 					<slash:comments><?php bp_activity_comment_count(); ?></slash:comments>
 				<?php endif; ?>
 

--- a/src/bp-activity/classes/class-bp-rest-activity-comment-endpoint.php
+++ b/src/bp-activity/classes/class-bp-rest-activity-comment-endpoint.php
@@ -547,6 +547,41 @@ class BP_REST_Activity_Comment_Endpoint extends WP_REST_Controller {
 						'status' => rest_authorization_required_code(),
 					)
 				);
+			} elseif ( bp_is_active( 'groups' ) ) {
+				// For a reply, resolve the root activity to check group membership against.
+				$root_activity = $activity;
+				if ( 'activity_comment' === $activity->type && ! empty( $activity->item_id ) ) {
+					$root_activity = new BP_Activity_Activity( (int) $activity->item_id );
+				}
+
+				/** This filter is documented in bp-activity/bp-activity-functions.php */
+				$validate_group_membership = apply_filters(
+					'bb_activity_new_comment_validate_group_membership',
+					true,
+					array(
+						'user_id'     => bp_loggedin_user_id(),
+						'activity_id' => $root_activity->id,
+					),
+					$root_activity
+				);
+
+				if (
+					$validate_group_membership &&
+					buddypress()->groups->id === $root_activity->component &&
+					! bp_current_user_can( 'bp_moderate' ) &&
+					(
+						! groups_is_user_member( bp_loggedin_user_id(), $root_activity->item_id ) ||
+						groups_is_user_banned( bp_loggedin_user_id(), $root_activity->item_id )
+					)
+				) {
+					$retval = new WP_Error(
+						'bp_rest_authorization_required',
+						__( 'Sorry, you need to be a member of this group to comment.', 'buddyboss' ),
+						array(
+							'status' => rest_authorization_required_code(),
+						)
+					);
+				}
 			}
 		}
 

--- a/src/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/src/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -2169,6 +2169,9 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			'can_favorite'      => ( 'activity_comment' === $activity->type ) ? bb_activity_comment_can_favorite() : bp_activity_can_favorite(),
 			'favorite_count'    => $this->get_activity_favorite_count( $activity ),
 			'can_comment'       => ( 'activity_comment' === $activity->type ) ? bp_activity_can_comment_reply( $activity ) : bp_activity_can_comment(),
+			'can_view_comments' => function_exists( 'bb_activity_can_view_comments' )
+				? ( ( 'activity_comment' === $activity->type ) ? bb_activity_can_view_comment_replies( $activity ) : bb_activity_can_view_comments( $activity ) )
+				: ( ( 'activity_comment' === $activity->type ) ? bp_activity_can_comment_reply( $activity ) : bp_activity_can_comment() ),
 			'can_edit'          => $can_edit,
 			'is_edited'         => $activity_metas['_is_edited'][0] ?? '',
 			'can_delete'        => bp_activity_user_can_delete( $activity ),
@@ -2279,9 +2282,10 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 					! empty( $secondary_activity->privacy ) &&
 					in_array( $secondary_activity->privacy, array( 'media', 'document', 'video' ), true )
 				) {
-					$data['can_comment']  = false;
-					$data['can_edit']     = false;
-					$data['can_favorite'] = false;
+					$data['can_comment']       = false;
+					$data['can_view_comments'] = false;
+					$data['can_edit']          = false;
+					$data['can_favorite']      = false;
 				}
 			}
 		}
@@ -3047,6 +3051,12 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 				'can_comment'       => array(
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'description' => __( 'Whether or not user have the comment access for the activity object.', 'buddyboss' ),
+					'type'        => 'boolean',
+					'readonly'    => true,
+				),
+				'can_view_comments' => array(
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'description' => __( 'Whether or not the user can view comments on the activity object.', 'buddyboss' ),
 					'type'        => 'boolean',
 					'readonly'    => true,
 				),

--- a/src/bp-templates/bp-nouveau/buddypress/activity/entry.php
+++ b/src/bp-templates/bp-nouveau/buddypress/activity/entry.php
@@ -297,7 +297,7 @@ $activity_popup_title = sprintf( esc_html__( '%s\'s post', 'buddyboss' ), bp_cor
 		<?php
 	}
 
-	if ( bp_activity_can_comment() ) {
+	if ( bb_activity_can_view_comments() ) {
 		$class = 'activity-comments';
 		if ( 'blogs' === bp_get_activity_object_name() ) {
 			$class .= get_option( 'thread_comments' ) ? ' threaded-comments threaded-level-' . get_option( 'thread_comments_depth' ) : '';
@@ -315,7 +315,7 @@ $activity_popup_title = sprintf( esc_html__( '%s\'s post', 'buddyboss' ), bp_cor
 				echo '<ul data-activity_id="' . esc_attr( $activity_id ) . '" data-parent_comment_id="' . esc_attr( $activity_id ) . '"></ul>';
 			}
 
-			if ( is_user_logged_in() ) {
+			if ( is_user_logged_in() && bp_activity_can_comment() ) {
 				bp_nouveau_activity_comment_form();
 			}
 			?>

--- a/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -311,7 +311,7 @@ function bp_nouveau_activity_state() {
 		do_action( 'bp_activity_state_after_reactions', $activity_id );
 		?>
 
-		<?php if ( bp_activity_can_comment() ) :
+		<?php if ( bb_activity_can_view_comments() ) :
 			?>
 			<?php
 			$activity_state_comment_class['activity_state_comment_class'] = 'activity-state-comments';

--- a/src/bp-templates/bp-nouveau/readylaunch/activity/comment.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/activity/comment.php
@@ -56,7 +56,7 @@ $activity_comment_id = bp_get_activity_comment_id();
 							if ( bb_is_reaction_activity_comments_enabled() && function_exists( 'bb_get_activity_post_user_reactions_html' ) ) {
 								echo wp_kses_post( bb_get_activity_post_user_reactions_html( $activity_comment_id, 'activity_comment' ) );
 							}
-							if ( bp_activity_can_comment_reply() ) {
+							if ( bb_activity_can_view_comment_replies() ) {
 								$activity_id   = bp_get_activity_id();
 								$replies_count = BP_Activity_Activity::bb_get_all_activity_comment_children_count(
 									array(

--- a/src/bp-templates/bp-nouveau/readylaunch/activity/entry.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/activity/entry.php
@@ -324,7 +324,7 @@ $bb_rl_activity_class_exists = class_exists( 'BB_Activity_Readylaunch' ) ? BB_Ac
 		<?php
 		bp_nouveau_activity_hook( 'before', 'entry_comments' );
 
-		if ( bp_activity_can_comment() ) {
+		if ( bb_activity_can_view_comments() ) {
 			$class = 'bb-rl-activity-comments';
 			if ( 'blogs' === bp_get_activity_object_name() ) {
 				$class .= get_option( 'thread_comments' ) ? ' bb-rl-threaded-comments bb-rl-threaded-level-' . get_option( 'thread_comments_depth' ) : '';
@@ -342,6 +342,7 @@ $bb_rl_activity_class_exists = class_exists( 'BB_Activity_Readylaunch' ) ? BB_Ac
 				$comment_count = $bb_rl_activity_class_exists->bb_rl_get_activity_comment_count( $activity_id );
 				if (
 					is_user_logged_in() &&
+					bp_activity_can_comment() &&
 					(
 						! $comment_count ||
 						bp_is_single_activity()


### PR DESCRIPTION
PROD link: https://buddyboss.atlassian.net/browse/PROD-10276

> **Two-repo fix — this is the `buddyboss-platform` half.** The active theme (`buddyboss-theme`) ships its own copy of the activity entry template that overrides this repo's bundled one, and needs the identical gate swap. Companion PR: buddyboss/buddyboss-theme#2816. **This PR alone does not fix the bug on a site running `buddyboss-theme`** (the standard theme for this plugin) — both PRs are required together on such a site. This PR is sufficient by itself only for a site running neither `buddyboss-theme` nor another theme with its own activity template override.

## Issue

A logged-in member who is **not** a member of a Public group cannot see existing comments on that group's activity posts — no comment list, no comment count, no Comment button — on any surface: News Feed, the poster's profile timeline, the group feed, or the single-activity permalink. The same post viewed **logged-out** shows the comments fine, which is the inconsistency: an anonymous visitor sees more than a signed-in member who simply hasn't joined the group.

Writing a comment is correctly members-only; this ticket is specifically about *viewing* existing comments, which should follow the same visibility as the post itself.

## Root cause

`bp_groups_filter_activity_can_comment()` (`src/bp-groups/bp-groups-activity.php:589`, hooked to `bp_activity_can_comment` at priority 99, inherited from BuddyPress core) returns false for **any** group activity — public groups included — unless the viewer is a group member or has `bp_moderate`. Critically, it bails out early when `! is_user_logged_in()` (`:591`), leaving the filter's incoming value untouched — which is what produces the inconsistency: a logged-out visitor never hits the membership veto at all, while a logged-in non-member always does.

Every entry template then gates the **entire** comments block — the existing comment list, the count, and the write form — behind that single `bp_activity_can_comment()` check, conflating two different permissions ("can I see what's already here" vs. "can I add to it") into one boolean.

## Fix

Split "can view" from "can write" instead of changing the membership check itself:

- Added `bb_activity_can_view_comments( $activity )` and its reply counterpart `bb_activity_can_view_comment_replies( $comment )` (`src/bp-activity/bp-activity-template.php`). Each starts from the existing `bp_activity_can_comment()` / `bp_activity_can_comment_reply()` result, and **only** for a group activity that the viewer can already read (`bp_activity_user_can_read()`), temporarily unhooks `bp_groups_filter_activity_can_comment[_reply]` to recompute the value without the membership veto. The membership check itself is untouched — this only decides whether it gets *applied* to the view-permission question.
- Swapped every display-only `bp_activity_can_comment()` / `bp_activity_can_comment_reply()` call site to the new `bb_activity_can_view_comments()` / `bb_activity_can_view_comment_replies()` — the comments-block wrapper in both Nouveau templates (`buddypress/activity/entry.php`, `readylaunch/activity/entry.php`), the ReadyLaunch comment-reply block (`readylaunch/activity/comment.php`), the `has-comments` CSS class helper, the RSS feed's `<slash:comments>` output, and the ReadyLaunch activity-state helper class.
- Every comment/reply **form** call site keeps the original `bp_activity_can_comment()` gate unchanged (in Nouveau `entry.php` and ReadyLaunch `entry.php`, now `is_user_logged_in() && bp_activity_can_comment()`), so posting still requires group membership through the UI.
- Added server-side enforcement so posting is blocked even if a client bypasses the UI entirely: a new `bb_activity_new_comment_validate_group_membership` filter plus a group-membership check directly in `bp_activity_new_comment()` (`src/bp-activity/bp-activity-functions.php`), and the equivalent check in `BP_REST_Activity_Comment_Endpoint::create_item_permissions_check()` for the REST path — both reject with "You need to be a member of this group to comment." if the poster isn't a member (or is banned) and lacks `bp_moderate`.
- Added a `can_view_comments` field to the REST activity response (`class-bp-rest-activity-endpoint.php`), separate from the existing `can_comment` field, wrapped in `function_exists( 'bb_activity_can_view_comments' )` so older/mismatched builds degrade to the previous `can_comment` value rather than fatal.

Note: the commit message on this branch mentions mirroring the REST changes into `buddyboss-platform-api` — that repo is **out of scope** for this PR and is not part of this fix.
