### PR TITLE
PROD-9998: cache xProfile visibility check, cap ReadyLaunch dropdown

### DIFF
--- a/src/bp-templates/bp-nouveau/readylaunch/header/unread-messages.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/header/unread-messages.php
@@ -184,40 +184,51 @@ if ( bp_has_message_threads( bp_ajax_querystring( 'messages' ) . '&user_id=' . g
 			$un_access_users    = false;
 		}
 
-		$recipients       = array();
-		$other_recipients = array();
-		$current_user     = false;
+		$recipients             = array();
+		$other_recipients       = array();
+		$current_user           = false;
+		$other_recipient_total  = 0;
 		if ( is_array( $messages_template->thread->recipients ) && ! $is_group_thread ) {
 			foreach ( $messages_template->thread->recipients as $recipient ) {
 				if ( empty( $recipient->is_deleted ) ) {
-					$is_you         = bp_loggedin_user_id() === $recipient->user_id;
-					$recipient_data = array(
-						'avatar'             => esc_url(
-							bp_core_fetch_avatar(
-								array(
-									'item_id' => $recipient->user_id,
-									'object'  => 'user',
-									'type'    => 'thumb',
-									'width'   => BP_AVATAR_THUMB_WIDTH,
-									'height'  => BP_AVATAR_THUMB_HEIGHT,
-									'html'    => false,
-								)
-							)
-						),
-						'user_link'          => bp_core_get_userlink( $recipient->user_id, false, true ),
-						'user_name'          => bp_core_get_user_displayname( $recipient->user_id ),
-						'is_you'             => $is_you,
-						'is_user_suspended'  => function_exists( 'bp_moderation_is_user_suspended' ) ? bp_moderation_is_user_suspended( $recipient->user_id ) : false,
-						'is_user_blocked'    => function_exists( 'bp_moderation_is_user_blocked' ) ? bp_moderation_is_user_blocked( $recipient->user_id ) : false,
-						'is_user_blocked_by' => function_exists( 'bb_moderation_is_user_blocked_by' ) ? bb_moderation_is_user_blocked_by( $recipient->user_id ) : false,
-						'is_deleted'         => empty( get_userdata( $recipient->user_id ) ) ? 1 : 0,
-					);
-					$recipients[]   = $recipient_data;
+					$is_you = bp_loggedin_user_id() === $recipient->user_id;
 
 					if ( ! $is_you ) {
-						$other_recipients[] = $recipient_data;
-					} else {
-						$current_user = $recipient_data;
+						$other_recipient_total++;
+					}
+
+					// Only resolve avatar/display-name/moderation data for the logged-in
+					// user and the first few "other" recipients that actually get
+					// rendered — large threads (e.g. an announcement to the whole
+					// membership) would otherwise resolve every recipient's profile.
+					if ( $is_you || $other_recipient_total <= 3 ) {
+						$recipient_data = array(
+							'avatar'             => esc_url(
+								bp_core_fetch_avatar(
+									array(
+										'item_id' => $recipient->user_id,
+										'object'  => 'user',
+										'type'    => 'thumb',
+										'width'   => BP_AVATAR_THUMB_WIDTH,
+										'height'  => BP_AVATAR_THUMB_HEIGHT,
+										'html'    => false,
+									)
+								)
+							),
+							'user_link'          => bp_core_get_userlink( $recipient->user_id, false, true ),
+							'user_name'          => bp_core_get_user_displayname( $recipient->user_id ),
+							'is_you'             => $is_you,
+							'is_user_suspended'  => function_exists( 'bp_moderation_is_user_suspended' ) ? bp_moderation_is_user_suspended( $recipient->user_id ) : false,
+							'is_user_blocked'    => function_exists( 'bp_moderation_is_user_blocked' ) ? bp_moderation_is_user_blocked( $recipient->user_id ) : false,
+							'is_user_blocked_by' => function_exists( 'bb_moderation_is_user_blocked_by' ) ? bb_moderation_is_user_blocked_by( $recipient->user_id ) : false,
+							'is_deleted'         => empty( get_userdata( $recipient->user_id ) ) ? 1 : 0,
+						);
+
+						if ( $is_you ) {
+							$current_user = $recipient_data;
+						} else {
+							$other_recipients[] = $recipient_data;
+						}
 					}
 
 					if (
@@ -238,7 +249,7 @@ if ( bp_has_message_threads( bp_ajax_querystring( 'messages' ) . '&user_id=' . g
 			$can_message = false;
 		}
 
-		$include_you = count( $other_recipients ) >= 2;
+		$include_you = $other_recipient_total >= 2;
 		$first_three = array_slice( $other_recipients, 0, 3 );
 		if ( count( $first_three ) === 0 ) {
 			$include_you = true;
@@ -307,7 +318,7 @@ if ( bp_has_message_threads( bp_ajax_querystring( 'messages' ) . '&user_id=' . g
 				?>
 				<div class="notification-avatar">
 					<?php
-					if ( count( $other_recipients ) > 1 ) {
+					if ( $other_recipient_total > 1 ) {
 						?>
 						<a href="<?php echo esc_url( bp_core_get_user_domain( $messages_template->thread->last_sender_id ) ); ?>">
 							<?php bp_message_thread_avatar(); ?>
@@ -505,7 +516,7 @@ if ( bp_has_message_threads( bp_ajax_querystring( 'messages' ) . '&user_id=' . g
 							}
 						}
 						// For conversations with a single recipient - Don't include the name of the last person to message before the message content.
-						if ( ! $is_group_thread && ! empty( $recipients ) && count( $other_recipients ) === 1 ) {
+						if ( ! $is_group_thread && ! empty( $recipients ) && 1 === $other_recipient_total ) {
 							$last_sender = '';
 						}
 						if ( $last_sender ) {

--- a/src/bp-xprofile/classes/class-bb-xprofile-visibility.php
+++ b/src/bp-xprofile/classes/class-bb-xprofile-visibility.php
@@ -165,9 +165,22 @@ class BB_XProfile_Visibility {
 		static $cache = array();
 		static $table_exists = '';
 
-		// Check if the result for this user is already cached.
+		// Check if the result for this user is already cached for this request.
 		if ( isset( $cache[ $user_id ] ) ) {
 			return $cache[ $user_id ];
+		}
+
+		// Check the persistent object cache before hitting the database — this is
+		// what is looked up once per recipient by display-name resolution, so on a
+		// large member/thread it can otherwise mean thousands of uncached queries
+		// per page load.
+		$cache_key = 'bb_xprofile_visibility_user_data_exists_' . $user_id;
+		$cached    = wp_cache_get( $cache_key, 'bp_xprofile' );
+		if ( false !== $cached ) {
+			$cache[ $user_id ] = (bool) $cached;
+
+			/** This filter is documented above. */
+			return apply_filters_ref_array( 'xprofile_visibility_user_data_exists', array( $cache[ $user_id ], $user_id ) );
 		}
 
 		// Resolve visibility table name with a safe fallback when xprofile globals
@@ -196,6 +209,8 @@ class BB_XProfile_Visibility {
 			$retval            = false;
 		}
 
+		wp_cache_set( $cache_key, $cache[ $user_id ] ? 1 : 0, 'bp_xprofile' );
+
 		/**
 		 * Filters whether any data already exists for the user.
 		 *
@@ -205,6 +220,17 @@ class BB_XProfile_Visibility {
 		 * @param int  $user_id User id.
 		 */
 		return apply_filters_ref_array( 'xprofile_visibility_user_data_exists', array( ! empty( $retval ), $user_id ) );
+	}
+
+	/**
+	 * Delete the cached "does this user have any visibility data" result.
+	 *
+	 * @since BuddyBoss [BBVERSION]
+	 *
+	 * @param int $user_id User id.
+	 */
+	public static function delete_user_data_exists_cache( $user_id ) {
+		wp_cache_delete( 'bb_xprofile_visibility_user_data_exists_' . $user_id, 'bp_xprofile' );
 	}
 
 	/**
@@ -349,6 +375,8 @@ class BB_XProfile_Visibility {
 			 */
 			do_action_ref_array( 'xprofile_visibility_after_save', array( $this ) );
 
+			self::delete_user_data_exists_cache( $this->user_id );
+
 			return true;
 		}
 
@@ -399,6 +427,8 @@ class BB_XProfile_Visibility {
 		 */
 		do_action_ref_array( 'xprofile_visibility_after_delete', array( $this ) );
 
+		self::delete_user_data_exists_cache( $this->user_id );
+
 		return true;
 	}
 
@@ -415,6 +445,16 @@ class BB_XProfile_Visibility {
 		global $wpdb;
 
 		$bp = buddypress();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$affected_user_ids = $wpdb->get_col(
+			$wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				"SELECT DISTINCT user_id FROM {$bp->profile->table_name_visibility} WHERE field_id = %d",
+				$field_id
+			)
+		);
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$deleted = $wpdb->query(
 			$wpdb->prepare(
@@ -425,6 +465,10 @@ class BB_XProfile_Visibility {
 
 		if ( empty( $deleted ) || is_wp_error( $deleted ) ) {
 			return false;
+		}
+
+		foreach ( $affected_user_ids as $affected_user_id ) {
+			self::delete_user_data_exists_cache( $affected_user_id );
 		}
 
 		return true;
@@ -482,6 +526,8 @@ class BB_XProfile_Visibility {
 		if ( empty( $deleted ) || is_wp_error( $deleted ) ) {
 			return false;
 		}
+
+		self::delete_user_data_exists_cache( $user_id );
 
 		return true;
 	}


### PR DESCRIPTION
PROD link: https://buddyboss.atlassian.net/browse/PROD-9998

> **Two-repo fix — this is the `buddyboss-platform` half.** Companion PR: buddyboss/buddyboss-theme#2817, which fixes the actual query-count scaling (the part visible in Query Monitor). **This PR alone does not fix that scaling** — its cache addition only matters on a site with a persistent object cache backend (Redis/Memcached) and produces no visible change in Query Monitor by itself. Merge both for the complete fix.

## Issue

Same underlying ticket as buddyboss/buddyboss-theme#2817: on a large site with a message thread that has a large recipient list, resolving each recipient's display name for the header's unread-messages dropdown triggers one xProfile visibility check per recipient. This PR addresses two things the theme-side fix alone doesn't cover: `BB_XProfile_Visibility::user_data_exists()` never used the persistent object cache at all, and the Platform ships its own separate copy of the same dropdown template for ReadyLaunch that has the identical unbounded-loop problem.

## Root cause

`BB_XProfile_Visibility::user_data_exists()` only cached its result in a per-request `static $cache` array, then fell straight through to `$wpdb->get_var()` on every cache miss. It never called `wp_cache_get()`/`wp_cache_set()`, so on a site running Redis or Memcached, the same user's visibility-scan result was recomputed from the database on **every single page load** instead of being reused across requests — the persistent cache layer existed for the rest of xProfile (the sibling method `is_valid_field()` in this same class already uses the standard `wp_cache_get()`/`wp_cache_set( ..., 'bp_xprofile' )` pattern) but was simply missing here.

Separately, `src/bp-templates/bp-nouveau/readylaunch/header/unread-messages.php` — the Platform's own template for sites using the ReadyLaunch header instead of the classic BuddyBoss Theme header — has the exact same recipient-loop structure as the theme's `template-parts/unread-messages.php`, so it has the exact same per-recipient-resolution problem the theme PR fixes.

## Fix

**Object cache for `user_data_exists()`:** added a `wp_cache_get( $cache_key, 'bp_xprofile' )` check before the DB query, and `wp_cache_set()` after computing the result, mirroring `is_valid_field()`'s existing pattern. Added a new `delete_user_data_exists_cache( $user_id )` helper and called it from every write path that can change a user's visibility-data existence: `save()`, `delete()`, and `delete_specific_data_for_user()`. `delete_for_field()` needed an extra step — it does a bulk `$wpdb->query()` across every user with data on a given field without going through `save()`/`delete()`, so no invalidation hook fires for the individual users affected. Fixed by first querying the affected `user_id`s (`SELECT DISTINCT user_id ... WHERE field_id = %d`) before the delete, then invalidating each one's cache afterward.

Note: this cache addition has **no visible effect on a single page-load's query count** — Query Monitor won't show a difference from it alone. It only matters on a site with a persistent cache backend, where it's the difference between "resolved once per cache lifetime" and "resolved fresh on every request." The query-count fix that actually shows up in Query Monitor is the theme-side loop cap in the companion PR.

**ReadyLaunch template:** applied the identical recipient-count cap as the theme PR — resolve `$recipient_data` only for the logged-in user or one of the first 3 "other" recipients, track the true total via `$other_recipient_total`, and switch every other `count( $other_recipients )` read in the file to that counter — to `src/bp-templates/bp-nouveau/readylaunch/header/unread-messages.php`, since it's structurally identical to the file the theme PR fixes.
