### PR TITLE
PROD-10363 - Fix: Gender profile field shows untranslated value on Profile View page when translated using WPML (translates correctly on Edit page)

### DIFF
--- a/src/bp-core/compatibility/class-bb-wpml-helpers.php
+++ b/src/bp-core/compatibility/class-bb-wpml-helpers.php
@@ -76,6 +76,14 @@ if ( ! class_exists( 'BB_WPML_Helpers' ) ) {
 
 			add_action( 'bb_get_the_profile_field_options_select_html', array( $this, 'bb_wpml_profile_field_options_order' ), 10, 2 );
 
+			// Translate the Gender field's displayed value on the profile view page.
+			// The "BuddyPress Multilingual" bridge plugin translates radio/selectbox/checkbox/
+			// multiselectbox option values on view via `bp_get_the_profile_field_value`, but its
+			// switch statement has no `gender` case, so the Gender field silently falls through
+			// untranslated there (it is translated correctly in the edit-screen dropdown, via the
+			// separate `bp_get_the_profile_field_options_select_gender` filter that plugin also hooks).
+			add_filter( 'bp_get_the_profile_field_value', array( $this, 'bb_wpml_translate_gender_field_value' ), 20, 3 );
+
 			add_filter( 'bp_groups_get_where_conditions', array( $this, 'bb_wpml_groups_dir_search_where_conditions' ), 10, 2 );
 			add_filter( 'Bp_Search_Groups_sql', array( $this, 'bb_wpml_groups_search_global_sql' ), 10, 2 );
 
@@ -351,6 +359,63 @@ if ( ! class_exists( 'BB_WPML_Helpers' ) ) {
 			}
 
 			return $html;
+		}
+
+		/**
+		 * Translate the Gender field's displayed value on the profile view page.
+		 *
+		 * The "BuddyPress Multilingual" bridge plugin (`class.xprofile.php`,
+		 * `translate_value_profile_view()`) already translates radio/selectbox/checkbox/
+		 * multiselectbox option values via this same filter, but its switch statement has
+		 * no `gender` case, so a Gender field's value is returned untranslated here even
+		 * though the string is correctly registered/translated in WPML String Translation
+		 * (under the "Buddypress Multilingual" domain — the same domain/name pattern that
+		 * plugin already uses for every other option-based field type).
+		 *
+		 * @since BuddyBoss [BBVERSION]
+		 *
+		 * @param string $value      The field value to display.
+		 * @param string $field_type The type of the field.
+		 * @param int    $field_id   ID of the field being rendered.
+		 *
+		 * @return string The translated value, if a translation exists; otherwise the original value.
+		 */
+		public function bb_wpml_translate_gender_field_value( $value, $field_type, $field_id = 0 ) {
+			if ( 'gender' !== $field_type || empty( $value ) || ! class_exists( 'Sitepress' ) ) {
+				return $value;
+			}
+
+			$current_language = apply_filters( 'wpml_current_language', null );
+			$default_language = apply_filters( 'wpml_default_language', null );
+
+			// Nothing to translate when viewing in the default language.
+			if ( empty( $current_language ) || $current_language === $default_language ) {
+				return $value;
+			}
+
+			global $wpdb;
+
+			// Matches the string name buddypress-multilingual registers for each option,
+			// e.g. "profile field 28 - option 'female' name".
+			$string_name = sprintf( "profile field %d - option '%s' name", (int) $field_id, sanitize_title( $value ) );
+
+			$translated_value = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT st.value
+					FROM {$wpdb->prefix}icl_strings s
+					INNER JOIN {$wpdb->prefix}icl_string_translations st ON st.string_id = s.id
+					WHERE s.name = %s
+					AND s.context = %s
+					AND st.language = %s
+					AND st.status = %d",
+					$string_name,
+					'Buddypress Multilingual',
+					$current_language,
+					10 // ICL_TM_COMPLETE.
+				)
+			);
+
+			return ( ! empty( $translated_value ) ) ? $translated_value : $value;
 		}
 
 		/**


### PR DESCRIPTION
The Gender field's displayed value on the public profile view page was not translated when WPML String Translation had a translation for it, even though the same option labels translate correctly in the edit screen's dropdown.


### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-10363


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
