### PR TITLE
PROD-10353 - Fix: Emojis and Topic Selection windows out of focus in mobile with ReadyLaunch

### DIFF
--- a/src/bp-templates/bp-nouveau/readylaunch/css/activity.css
+++ b/src/bp-templates/bp-nouveau/readylaunch/css/activity.css
@@ -1545,10 +1545,25 @@ body.bb-rl-activity-modal-open .bb-rl-activity-update-form.modal-popup {
   padding: 0;
   border: 0;
 }
+@media (max-width: 420px) {
+  .bb-rl-activity-form #bb-rl-whats-new-toolbar .bb-rl-post-emoji {
+    position: static !important;
+  }
+  .bb-rl-activity-form #bb-rl-whats-new-toolbar .bb-rl-post-emoji .emojionearea.emojionearea-standalone {
+    position: static !important;
+  }
+}
 
 .bb-rl-activity-form #bb-rl-whats-new-toolbar .emojionearea-picker.emojionearea-picker-position-top {
   top: inherit;
   bottom: 40px;
+}
+@media (max-width: 420px) {
+  .bb-rl-activity-form #bb-rl-whats-new-toolbar .emojionearea-picker.emojionearea-picker-position-top {
+    left: 50% !important;
+    right: auto !important;
+    transform: translateX(-50%) !important;
+  }
 }
 
 .bb-rl-activity-form #bb-rl-whats-new-toolbar .emojionearea-button {

--- a/src/bp-templates/bp-nouveau/readylaunch/css/activity.css
+++ b/src/bp-templates/bp-nouveau/readylaunch/css/activity.css
@@ -2185,6 +2185,8 @@ body.bb-rl-activity-modal-open .bb-rl-activity-update-form.modal-popup {
   }
   .whats-new-topic-selector .bb-rl-topic-selector-list {
     z-index: 9;
+    left: 50%;
+    transform: translateX(-50%);
   }
   .whats-new-topic-selector .bb-rl-topic-selector-button {
     max-width: 100%;

--- a/src/bp-templates/bp-nouveau/readylaunch/css/sass/components/activity/_post_form.scss
+++ b/src/bp-templates/bp-nouveau/readylaunch/css/sass/components/activity/_post_form.scss
@@ -1469,6 +1469,8 @@
 
 		.bb-rl-topic-selector-list {
 			z-index: 9;
+			left: 50%;
+			transform: translateX(-50%);
 		}
 
 		.bb-rl-topic-selector-button {

--- a/src/bp-templates/bp-nouveau/readylaunch/css/sass/components/activity/_post_form.scss
+++ b/src/bp-templates/bp-nouveau/readylaunch/css/sass/components/activity/_post_form.scss
@@ -786,11 +786,29 @@
 		.bb-rl-post-emoji {
 			padding: 0;
 			border: 0;
+
+			@media (max-width: 420px) {
+				// Stop this icon wrapper (and the emojionearea wrapper inside it)
+				// from being the picker's containing block - both collapse to
+				// button-width, which threw off horizontal centering. Falls back
+				// to #bb-rl-whats-new-toolbar, which is wide and stable.
+				position: static !important;
+
+				.emojionearea.emojionearea-standalone {
+					position: static !important;
+				}
+			}
 		}
 
 		.emojionearea-picker.emojionearea-picker-position-top {
 			top: inherit;
 			bottom: 40px;
+
+			@media (max-width: 420px) {
+				left: 50% !important;
+				right: auto !important;
+				transform: translateX(-50%) !important;
+			}
 		}
 
 		.emojionearea-button {


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-10353

### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
