### PR TITLE
PROD-10344 - Fix:  Notification count cache collides across different query args (component_name, is_new, etc.) — keyed only by user_id

### DIFF
--- a/src/bp-notifications/bp-notifications-cache.php
+++ b/src/bp-notifications/bp-notifications-cache.php
@@ -36,6 +36,86 @@ function bp_notifications_update_meta_cache( $notification_ids = false ) {
 }
 
 /**
+ * Get (and lazily create) the cache-busting incrementor for a user's
+ * notification counts.
+ *
+ * The value is embedded into every notification-count cache key built by
+ * bp_notifications_get_count_cache_key(). Bumping it via
+ * bp_notifications_bump_user_count_cache_incrementor() makes every
+ * previously cached count for that user - no matter which component_name/
+ * item_id/etc. combination produced it - unreachable in one operation,
+ * without needing to enumerate or individually delete each variant's key.
+ *
+ * @since BuddyBoss [BBVERSION]
+ *
+ * @param int $user_id User ID.
+ * @return string Incrementor value.
+ */
+function bp_notifications_get_user_count_cache_incrementor( $user_id ) {
+	$incrementor = wp_cache_get( $user_id, 'bp_notifications_count_incrementor' );
+
+	if ( false === $incrementor ) {
+		$incrementor = microtime();
+		wp_cache_set( $user_id, $incrementor, 'bp_notifications_count_incrementor' );
+	}
+
+	return $incrementor;
+}
+
+/**
+ * Invalidate every cached notification count for a user, regardless of
+ * which component_name/item_id/etc. arguments produced it.
+ *
+ * @since BuddyBoss [BBVERSION]
+ *
+ * @param int $user_id User ID.
+ */
+function bp_notifications_bump_user_count_cache_incrementor( $user_id ) {
+	wp_cache_delete( $user_id, 'bp_notifications_count_incrementor' );
+}
+
+/**
+ * Build a cache key for a notification count query that reflects every
+ * argument affecting the underlying SQL, not just the user ID.
+ *
+ * Used by BP_Notifications_Notification::get_total_count() so that two
+ * queries for the same user with different filters (e.g. an unfiltered
+ * count vs. a component_name-filtered one) never collide on the same
+ * cache slot. See PROD-10344.
+ *
+ * @since BuddyBoss [BBVERSION]
+ *
+ * @param int   $user_id User ID the count belongs to.
+ * @param array $args    The full parsed args used to build the count query
+ *                       (see BP_Notifications_Notification::get_total_count()).
+ * @return string Cache key.
+ */
+function bp_notifications_get_count_cache_key( $user_id, $args ) {
+	// Only the args that actually shape the SQL WHERE clause should
+	// participate in the key.
+	$relevant = array_intersect_key(
+		$args,
+		array_flip(
+			array(
+				'id',
+				'item_id',
+				'secondary_item_id',
+				'component_name',
+				'component_action',
+				'excluded_action',
+				'search_terms',
+				'date_query',
+				'meta_query',
+			)
+		)
+	);
+
+	$incrementor = bp_notifications_get_user_count_cache_incrementor( $user_id );
+
+	return $user_id . ':' . $incrementor . ':' . md5( maybe_serialize( $relevant ) );
+}
+
+/**
  * Clear all notifications cache for a given user ID.
  *
  * @since BuddyPress 2.3.0
@@ -47,6 +127,7 @@ function bp_notifications_clear_all_for_user_cache( $user_id = 0 ) {
 	wp_cache_delete( $user_id, 'bp_notifications_unread_count' );
 	wp_cache_delete( $user_id, 'bp_notifications_read_count' );
 	wp_cache_delete( $user_id, 'bp_notifications_grouped_notifications' );
+	bp_notifications_bump_user_count_cache_incrementor( $user_id );
 }
 
 /**

--- a/src/bp-notifications/bp-notifications-functions.php
+++ b/src/bp-notifications/bp-notifications-functions.php
@@ -505,16 +505,15 @@ function bp_notifications_get_unread_notification_count( $user_id = 0 ) {
 		$user_id = ( bp_displayed_user_id() ) ? bp_displayed_user_id() : bp_loggedin_user_id();
 	}
 
-	$count = wp_cache_get( $user_id, 'bp_notifications_unread_count' );
-	if ( false === $count ) {
-		$count = BP_Notifications_Notification::get_total_count(
-			array(
-				'user_id' => $user_id,
-				'is_new'  => true,
-			)
-		);
-		wp_cache_set( $user_id, $count, 'bp_notifications_unread_count' );
-	}
+	// get_total_count() already caches this (keyed on the full args, not
+	// just user_id - see PROD-10344), so it isn't duplicated here to avoid
+	// a second, differently-keyed cache layer for the same value.
+	$count = BP_Notifications_Notification::get_total_count(
+		array(
+			'user_id' => $user_id,
+			'is_new'  => true,
+		)
+	);
 
 	/**
 	 * Filters the count of unread notification items for a user.

--- a/src/bp-notifications/classes/class-bp-notifications-component.php
+++ b/src/bp-notifications/classes/class-bp-notifications-component.php
@@ -298,6 +298,7 @@ class BP_Notifications_Component extends BP_Component {
 				'bp_notifications_unread_count',
 				'bp_notifications_read_count',
 				'bp_notifications_grouped_notifications',
+				'bp_notifications_count_incrementor',
 			)
 		);
 

--- a/src/bp-notifications/classes/class-bp-notifications-notification.php
+++ b/src/bp-notifications/classes/class-bp-notifications-notification.php
@@ -908,11 +908,15 @@ class BP_Notifications_Notification {
 		$sql = "{$select_sql} {$from_sql} {$join_sql} {$where_sql}";
 
 		// Set the cache.
+		// Cache key includes every arg that shapes the SQL above (not just
+		// user_id), so differently-filtered counts for the same user never
+		// collide on the same cache slot. See PROD-10344.
 		$cache_group = ( ! empty( $r['is_new'] ) ) ? 'bp_notifications_unread_count' : 'bp_notifications_read_count';
-		$count       = wp_cache_get( $r['user_id'], $cache_group );
+		$cache_key   = bp_notifications_get_count_cache_key( $r['user_id'], $r );
+		$count       = wp_cache_get( $cache_key, $cache_group );
 		if ( false === $count ) {
 			$count = (int) $wpdb->get_var( $sql );
-			wp_cache_set( $r['user_id'], $count, $cache_group );
+			wp_cache_set( $cache_key, $count, $cache_group );
 		}
 
 		// Return the queried results.

--- a/tests/phpunit/testcases/notifications/functions.php
+++ b/tests/phpunit/testcases/notifications/functions.php
@@ -35,7 +35,8 @@ class BP_Tests_Notifications_Functions extends BP_UnitTestCase {
 		) );
 
 		$this->assertFalse( wp_cache_get( 'all_for_user_' . $u, 'bp_notifications' ) );
-		$this->assertFalse( wp_cache_get( $u, 'bp_notifications_unread_count' ) );
+		$unread_cache_key = bp_notifications_get_count_cache_key( $u, array( 'user_id' => $u, 'is_new' => true ) );
+		$this->assertFalse( wp_cache_get( $unread_cache_key, 'bp_notifications_unread_count' ) );
 	}
 
 	/**
@@ -62,7 +63,8 @@ class BP_Tests_Notifications_Functions extends BP_UnitTestCase {
 		BP_Notifications_Notification::delete( array( 'id' => $n1, ) );
 
 		$this->assertFalse( wp_cache_get( 'all_for_user_' . $u, 'bp_notifications' ) );
-		$this->assertFalse( wp_cache_get( $u, 'bp_notifications_unread_count' ) );
+		$unread_cache_key = bp_notifications_get_count_cache_key( $u, array( 'user_id' => $u, 'is_new' => true ) );
+		$this->assertFalse( wp_cache_get( $unread_cache_key, 'bp_notifications_unread_count' ) );
 	}
 
 	/**
@@ -93,7 +95,8 @@ class BP_Tests_Notifications_Functions extends BP_UnitTestCase {
 		);
 
 		$this->assertFalse( wp_cache_get( 'all_for_user_' . $u, 'bp_notifications' ) );
-		$this->assertFalse( wp_cache_get( $u, 'bp_notifications_unread_count' ) );
+		$unread_cache_key = bp_notifications_get_count_cache_key( $u, array( 'user_id' => $u, 'is_new' => true ) );
+		$this->assertFalse( wp_cache_get( $unread_cache_key, 'bp_notifications_unread_count' ) );
 	}
 
 	/**
@@ -124,7 +127,8 @@ class BP_Tests_Notifications_Functions extends BP_UnitTestCase {
 		);
 
 		$this->assertFalse( wp_cache_get( 'all_for_user_' . $u, 'bp_notifications' ) );
-		$this->assertFalse( wp_cache_get( $u, 'bp_notifications_unread_count' ) );
+		$unread_cache_key = bp_notifications_get_count_cache_key( $u, array( 'user_id' => $u, 'is_new' => true ) );
+		$this->assertFalse( wp_cache_get( $unread_cache_key, 'bp_notifications_unread_count' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-10344


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
