### PR TITLE
PROD-1: Improve accessibility across ReadyLaunch and Nouveau templates and scripts

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress/assets/emails/single-bp-email.php
+++ b/src/bp-templates/bp-nouveau/buddypress/assets/emails/single-bp-email.php
@@ -45,7 +45,7 @@ defined( 'ABSPATH' ) || exit;
 $settings = bp_email_get_appearance_settings();
 
 ?><!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<html <?php echo esc_attr( get_bloginfo( 'language' ) ); ?> xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 <head>
 	<meta charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_animations.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_animations.scss
@@ -247,3 +247,31 @@
 	}
 
 }
+
+// Respect user preference for reduced motion
+@media (prefers-reduced-motion: reduce) {
+
+	#buddypress-wrap * {
+		transition: none;
+	}
+
+	.buddypress-wrap {
+
+		a.loading,
+		input.loading {
+			animation: none;
+		}
+	}
+
+	.animate-spin {
+		animation: none;
+	}
+
+	.bb-loading-bg {
+		animation: none;
+	}
+
+	* {
+		scroll-behavior: auto;
+	}
+}

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_buttons.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_buttons.scss
@@ -35,6 +35,11 @@
 			text-align: center;
 			text-decoration: none;
 			width: auto;
+
+			&:focus-visible {
+				outline: 2px solid $blue;
+				outline-offset: 2px;
+			}
 		}
 
 		// Re-instate the quick-tag padding to avoid the above ruleset

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_filters.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_filters.scss
@@ -247,7 +247,7 @@
 
 	a {
 		border-bottom: 0;
-		color: #ccc;
+		color: #999;
 		padding: 0 6px;
 		line-height: 36px;
 
@@ -263,12 +263,19 @@
 		outline: none;
 	}
 
+	a:focus-visible {
+		outline: 2px solid $blue;
+		outline-offset: 2px;
+	}
+
 	a i {
 		vertical-align: middle;
 	}
 
 	a.active {
 		color: #222;
+		font-weight: 600;
+		border-bottom: 2px solid #222;
 	}
 }
 

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_forms.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_forms.scss
@@ -156,6 +156,14 @@
 			outline: 0;
 		}
 
+		input:focus-visible,
+		textarea:focus-visible,
+		select:focus-visible {
+			outline: 2px solid $blue;
+			outline-offset: 2px;
+			box-shadow: 0 0 0 1px $blue;
+		}
+
 		label,
 		span.label {
 			display: block;
@@ -172,6 +180,11 @@
 			display: block;
 			margin-top: $marg-xsml;
 			outline: none;
+
+			&:focus-visible {
+				outline: 2px solid $blue;
+				outline-offset: 2px;
+			}
 		}
 
 		.submit {

--- a/src/bp-templates/bp-nouveau/js/buddypress-activity.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-activity.js
@@ -483,12 +483,16 @@ window.bp = window.bp || {};
 			/**
 			 * Finally trigger a pending event containing the activity heartbeat data
 			 */
-			$( '#buddypress [data-bp-list="activity"]' ).trigger( 'bp_heartbeat_pending', this.heartbeat_data );
+$( '#buddypress [data-bp-list="activity"]' ).trigger( 'bp_heartbeat_pending', this.heartbeat_data );
 
-			if ( typeof bp.Nouveau !== 'undefined' ) {
-				bp.Nouveau.reportPopUp();
-			}
-		},
+		if ( typeof bp.Nouveau !== 'undefined' ) {
+			bp.Nouveau.reportPopUp();
+		}
+
+		// Add live region attributes for screen readers
+		$( '#buddypress [data-bp-list="activity"]' ).attr( 'aria-live', 'polite' );
+		$( '#buddypress [data-bp-list="activity"]' ).attr( 'aria-relevant', 'additions' );
+	},
 
 		/**
 		 * [injectQuery description]

--- a/src/bp-templates/bp-nouveau/js/buddypress-nouveau.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-nouveau.js
@@ -109,16 +109,20 @@ window.bp = window.bp || {};
 			this.cacheProfileCard = {};
 			this.cacheGroupCard = {};
 
-			// wrapNavigation dropdown events
-			$( document ).on(
-				'click',
-				'.more-action-button',
-				function ( e ) {
-					e.preventDefault();
-					$( this ).toggleClass( 'active open' ).next().toggleClass( 'active open' );
-					$( 'body' ).toggleClass( 'nav_more_option_open' );
+// wrapNavigation dropdown events
+		$( document ).on(
+			'click keydown',
+			'.more-action-button',
+			function ( e ) {
+				if ( e.type === 'keydown' && e.key !== 'Enter' && e.key !== ' ' ) {
+					return;
 				}
-			);
+				e.preventDefault();
+				$( this ).toggleClass( 'active open' ).next().toggleClass( 'active open' );
+				$( this ).attr( 'aria-expanded', $( this ).hasClass( 'active' ) );
+				$( 'body' ).toggleClass( 'nav_more_option_open' );
+			}
+		);
 
 			$( document ).click(
 				function ( e ) {
@@ -166,50 +170,53 @@ window.bp = window.bp || {};
 				$( currentEl ).removeClass( 'pull-animation' ).addClass( 'close-item' ).delay( 500 ).remove();
 			}
 
-			// Add Toast Message
-			var unique_id = 'unique-' + Math.floor( Math.random() * 1000000 );
-			var currentEl = '.' + unique_id;
-			var urlClass = '';
-			var bp_msg_type = '';
-			var bp_icon_type = '';
-			/* jshint ignore:start */
-			var autohide_interval = autohide_interval && typeof autohide_interval == 'number' ? ( autohide_interval * 1000 ) : 5000;
-			/* jshint ignore:end */
+// Add Toast Message
+		var unique_id = 'unique-' + Math.floor( Math.random() * 1000000 );
+		var currentEl = '.' + unique_id;
+		var urlClass = '';
+		var bp_msg_type = '';
+		var bp_icon_type = '';
+		/* jshint ignore:start */
+		var autohide_interval = autohide_interval && typeof autohide_interval == 'number' ? ( autohide_interval * 1000 ) : 5000;
+		/* jshint ignore:end */
 
-			if ( type ) {
-				bp_msg_type = type;
-				if ( bp_msg_type === 'success' ) {
-					bp_icon_type = 'check';
-				} else if ( bp_msg_type === 'warning' ) {
-					bp_icon_type = 'exclamation-triangle';
-				} else if ( bp_msg_type === 'delete' ) {
-					bp_icon_type = 'trash';
-					bp_msg_type = 'error';
-				} else {
-					bp_icon_type = 'info';
-				}
+		if ( type ) {
+			bp_msg_type = type;
+			if ( bp_msg_type === 'success' ) {
+				bp_icon_type = 'check';
+			} else if ( bp_msg_type === 'warning' ) {
+				bp_icon_type = 'exclamation-triangle';
+			} else if ( bp_msg_type === 'delete' ) {
+				bp_icon_type = 'trash';
+				bp_msg_type = 'error';
+			} else {
+				bp_icon_type = 'info';
 			}
+		}
 
-			if ( url !== null ) {
-				urlClass = 'has-url';
-			}
+		if ( url !== null ) {
+			urlClass = 'has-url';
+		}
 
-			var messageContent = '';
-			messageContent += '<div class="toast-messages-icon"><i class="bb-icon bb-icon-' + bp_icon_type + '"></i></div>';
-			messageContent += '<div class="toast-messages-content">';
-			if ( title ) {
-				messageContent += '<span class="toast-messages-title">' + title + '</span>';
-			}
+		var messageContent = '';
+		messageContent += '<div class="toast-messages-icon"><i class="bb-icon bb-icon-' + bp_icon_type + '" aria-hidden="true"></i></div>';
+		messageContent += '<div class="toast-messages-content">';
+		if ( title ) {
+			messageContent += '<span class="toast-messages-title">' + title + '</span>';
+		}
 
-			if ( message ) {
-				messageContent += '<span class="toast-messages-content">' + message + '</span>';
-			}
+		if ( message ) {
+			messageContent += '<span class="toast-messages-content">' + message + '</span>';
+		}
 
-			messageContent += '</div>';
-			messageContent += '<div class="actions"><a class="action-close primary" data-bp-tooltip-pos="left" data-bp-tooltip="' + BP_Nouveau.close + '"><i class="bb-icon bb-icon-times" aria-hidden="true"></i></a></div>';
-			messageContent += url ? '<a class="toast-messages-url" href="' + url + '"></a>' : '';
+		messageContent += '</div>';
+		messageContent += '<div class="actions"><a class="action-close primary" data-bp-tooltip-pos="left" data-bp-tooltip="' + BP_Nouveau.close + '" aria-label="' + BP_Nouveau.close + '"><i class="bb-icon bb-icon-times" aria-hidden="true"></i></a></div>';
+		messageContent += url ? '<a class="toast-messages-url" href="' + url + '"></a>' : '';
 
-			$( getTarget() ).append( '<li class="item-list read-item pull-animation bp-message-' + bp_msg_type + ' ' + unique_id + ' ' + urlClass + '"> ' + messageContent + ' </li>' );
+		var $target = $( getTarget() );
+		$target.attr( 'role', 'status' );
+		$target.attr( 'aria-live', 'polite' );
+		$target.append( '<li class="item-list read-item pull-animation bp-message-' + bp_msg_type + ' ' + unique_id + ' ' + urlClass + '"> ' + messageContent + ' </li>' );
 
 			if ( autoHide ) {
 				setInterval( function () {
@@ -1137,38 +1144,44 @@ window.bp = window.bp || {};
 			// Following widget more button click.
 			$( document ).on( 'click', '.more-following .count-more, .more-followers .count-more', this.bbWidgetMoreFollowingFollowers );
 
-			// Accordion open/close event
-			$( '.bb-accordion .bb-accordion_trigger' ).on( 'click', this.toggleAccordion );
+// Accordion open/close event
+		$( '.bb-accordion .bb-accordion_trigger' ).on( 'click keydown', function ( e ) {
+			if ( e.type === 'keydown' && e.key !== 'Enter' && e.key !== ' ' ) {
+				return;
+			}
+			e.preventDefault();
+			bp.Nouveau.toggleAccordion.call( this );
+		} );
 
 			// Prevent duplicated emoji from windows system emoji picker.
 			$( document ).keydown( this.mediumFormAction.bind( this ) );
 
-			// Profile/Group Popup Card.
-			$( document ).on( 'mouseenter', '[data-bb-hp-profile]', function ( event ) {
+// Profile/Group Popup Card.
+		$( document ).on( 'mouseenter focus', '[data-bb-hp-profile]', function ( event ) {
 
-				if ( 0 === $( event.currentTarget ).data( 'bb-hp-profile' ) ) {
-					return;
-				}
+			if ( 0 === $( event.currentTarget ).data( 'bb-hp-profile' ) ) {
+				return;
+			}
 
-				hoverAvatar = true;
-				hoverProfileAvatar = true;
+			hoverAvatar = true;
+			hoverProfileAvatar = true;
 
-				// Clear pending hide timeouts
-				if ( hideCardTimeout ) {
-					clearTimeout( hideCardTimeout );
-				}
+			// Clear pending hide timeouts
+			if ( hideCardTimeout ) {
+				clearTimeout( hideCardTimeout );
+			}
 
-				// Close open group card
-				if( $( '#group-card' ).hasClass( 'show' ) ) {
-					bp.Nouveau.hidePopupCard();
-					// Reset the loaded flag when switching between different card types
-					popupCardLoaded = false;
-				}
+			// Close open group card
+			if( $( '#group-card' ).hasClass( 'show' ) ) {
+				bp.Nouveau.hidePopupCard();
+				// Reset the loaded flag when switching between different card types
+				popupCardLoaded = false;
+			}
 
-				// Always attempt to load the profile card
-				bp.Nouveau.profilePopupCard.call( this );
-			} );
-			$( document ).on( 'mouseenter', '[data-bb-hp-group]', function ( event ) {
+			// Always attempt to load the profile card
+			bp.Nouveau.profilePopupCard.call( this );
+		} );
+		$( document ).on( 'mouseenter focus', '[data-bb-hp-group]', function ( event ) {
 				if ( 0 === $( event.currentTarget ).data( 'bb-hp-group' ) ) {
 					return;
 				}
@@ -1354,20 +1367,24 @@ window.bp = window.bp || {};
 				return;
 			}
 
-			// Show all notificaitons.
-			wrap.removeClass( 'close-all-items' );
+// Show all notificaitons.
+		wrap.removeClass( 'close-all-items' );
 
-			// Set class 'bb-more-item' in item when more than three notifications.
-			appendItems.eq( 2 ).nextAll().addClass( 'bb-more-item' );
+		// Set class 'bb-more-item' in item when more than three notifications.
+		appendItems.eq( 2 ).nextAll().addClass( 'bb-more-item' );
 
-			if ( appendItems.length > 3 ) {
-				list.addClass( 'bb-more-than-3' );
-			} else {
-				list.removeClass( 'bb-more-than-3' );
-			}
+		if ( appendItems.length > 3 ) {
+			list.addClass( 'bb-more-than-3' );
+		} else {
+			list.removeClass( 'bb-more-than-3' );
+		}
 
-			wrap.show();
-			list.empty().html( appendItems );
+		wrap.show();
+		wrap.attr( 'role', 'region' );
+		wrap.attr( 'aria-label', BP_Nouveau.notifications_text || 'Notifications' );
+		list.attr( 'aria-live', 'polite' );
+		list.attr( 'aria-atomic', 'false' );
+		list.empty().html( appendItems );
 
 			// Clear all button visibility status.
 			bp.Nouveau.visibilityOnScreenClearButton();

--- a/src/bp-templates/bp-nouveau/readylaunch/activate.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/activate.php
@@ -38,7 +38,7 @@ if ( 'choice' === $bb_rl_theme_mode ) {
 ?>
 
 <body <?php body_class( 'bb-readylaunch-template ' . $theme_mode_class ); ?>>
-
+<a href="#activate-page" class="skip-link bp-screen-reader-text"><?php esc_html_e( 'Skip to main content', 'buddyboss' ); ?></a>
 <?php
 bp_get_template_part( 'common/header-register' );
 ?>
@@ -52,8 +52,10 @@ bp_get_template_part( 'common/header-register' );
 	if ( bp_account_was_activated() ) {
 
 		if ( isset( $_GET['e'] ) ) { ?>
+			<h1><?php esc_html_e( 'Account Activated', 'buddyboss' ); ?></h1>
 			<p><?php esc_html_e( 'Your account was activated successfully! Your account details have been sent to you in a separate email.', 'buddyboss' ); ?></p>
 		<?php } else { ?>
+			<h1><?php esc_html_e( 'Account Activated', 'buddyboss' ); ?></h1>
 			<p><?php esc_html_e( 'Your account was activated successfully! You can now log in with the username and password you provided when you signed up.', 'buddyboss' ); ?></p>
 			<?php
 		}
@@ -65,6 +67,7 @@ bp_get_template_part( 'common/header-register' );
 		);
 	} else {
 		?>
+		<h1><?php esc_html_e( 'Activate Account', 'buddyboss' ); ?></h1>
 		<p><?php esc_html_e( 'Please provide a valid activation key.', 'buddyboss' ); ?></p>
 		<form action="" method="post" class="standard-form" id="activation-form">
 			<label for="key"><?php esc_html_e( 'Activation Key:', 'buddyboss' ); ?></label>

--- a/src/bp-templates/bp-nouveau/readylaunch/common/js-templates/activity/parts/bp-activity-link-preview.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/common/js-templates/activity/parts/bp-activity-link-preview.php
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 					<div id="activity-url-scrapper-img-holder">
 						<div class="activity-link-preview-image">
 							<div class="activity-link-preview-image-cover">
-								<img src="{{{data.link_images[data.link_image_index]}}}"/>
+								<img src="{{{data.link_images[data.link_image_index]}}}" alt="<?php esc_attr_e( 'Link preview image', 'buddyboss' ); ?>" />
 							</div>
 							<div class="activity-link-preview-icons">
 								<# if ( data.link_images.length > 1 ) { #>

--- a/src/bp-templates/bp-nouveau/readylaunch/common/js-templates/activity/parts/bp-activity-target-item.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/common/js-templates/activity/parts/bp-activity-target-item.php
@@ -17,7 +17,7 @@
 		<# } #>
 
 		<# if ( data.avatar_url ) { #>
-		<img src="{{data.avatar_url}}" class="avatar {{data.object_type}}-{{data.id}}-avatar photo" alt="" />
+		<img src="{{data.avatar_url}}" class="avatar {{data.object_type}}-{{data.id}}-avatar photo" alt="{{data.name}}" />
 		<# } #>
 
 		<span class="bp-item-name">{{data.name}}</span>

--- a/src/bp-templates/bp-nouveau/readylaunch/common/js-templates/activity/parts/bp-gif-result-item.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/common/js-templates/activity/parts/bp-gif-result-item.php
@@ -8,7 +8,7 @@
 
 ?>
 <script type="text/html" id="tmpl-gif-result-item">
-	<a class="found-media-item" href="{{{data.images.original.url}}}" data-id="{{data.id}}">
-		<img src="{{{data.images.fixed_width.url}}}" />
+	<a class="found-media-item" href="{{{data.images.original.url}}}" data-id="{{data.id}}" aria-label="<?php esc_attr_e( 'Select GIF', 'buddyboss' ); ?>">
+		<img src="{{{data.images.fixed_width.url}}}" alt="<?php esc_attr_e( 'GIF', 'buddyboss' ); ?>" />
 	</a>
 </script>

--- a/src/bp-templates/bp-nouveau/readylaunch/common/js-templates/messages/parts/bp-messages-single-list.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/common/js-templates/messages/parts/bp-messages-single-list.php
@@ -14,9 +14,9 @@
 			<# if ( ! data.is_user_suspended && ! data.is_user_blocked ) { #>
 				<div class="bp-avatar-wrap">
 					<# if ( data.is_deleted ) { #>
-						<img class="avatar" src="{{{data.sender_avatar}}}" alt="" />
+						<img class="avatar" src="{{{data.sender_avatar}}}" alt="{{{data.sender_name}}}" />
 					<# } else if ( data.is_user_suspended || data.is_user_blocked  ) { #>
-						<img class="avatar" src="{{{data.sender_avatar}}}" alt="" />
+						<img class="avatar" src="{{{data.sender_avatar}}}" alt="{{{data.sender_name}}}" />
 						<# if ( data.is_user_blocked ) { #>
 							<i class="user-status-icon bb-icon-f bb-icon-cancel"></i>
 						<# } else if ( data.is_user_blocked_by ) { #>
@@ -24,7 +24,7 @@
 						<# } #>
 					<# } else { #>
 						<a href="{{data.sender_link}}" class="bp-user-avatar" aria-label="{{{data.sender_name}}}">
-							<img class="avatar" src="{{{data.sender_avatar}}}" alt="" />
+							<img class="avatar" src="{{{data.sender_avatar}}}" alt="{{{data.sender_name}}}" />
 							<# if ( data.is_user_blocked_by ) { #>
 								<i class="user-status-icon bb-icon-f bb-icon-lock"></i>
 							<# } #>

--- a/src/bp-templates/bp-nouveau/readylaunch/document/doc-preview.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/document/doc-preview.php
@@ -25,7 +25,7 @@ if (
 ) {
 	?>
 	<div class="bb-rl-document-preview-wrap">
-		<img src="<?php echo esc_url( $attachment_url ); ?>" alt="" />
+		<img src="<?php echo esc_url( $attachment_url ); ?>" alt="<?php esc_attr_e( 'Document preview', 'buddyboss' ); ?>" />
 	</div><!-- .bb-rl-document-preview-wrap -->
 	<?php
 }

--- a/src/bp-templates/bp-nouveau/readylaunch/groups/group-card.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/groups/group-card.php
@@ -36,7 +36,7 @@ defined( 'ABSPATH' ) || exit;
 		<div class="bb-rl-card-content">
 			<div class="bb-rl-card-body">
 				<div class="bb-rl-card-avatar">
-					<img src="" alt="">
+					<img src="" alt="<?php esc_attr_e( 'Group avatar', 'buddyboss' ); ?>" />
 				</div>
 				<div class="bb-rl-card-entity">
 					<h4 class="bb-rl-card-heading"></h4>

--- a/src/bp-templates/bp-nouveau/readylaunch/header/readylaunch-header.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/header/readylaunch-header.php
@@ -45,6 +45,7 @@ if ( 'choice' === $bb_rl_theme_mode ) {
 wp_body_open();
 bp_get_template_part( 'sidebar/left-sidebar' );
 ?>
+<a href="#primary" class="skip-link bp-screen-reader-text"><?php esc_html_e( 'Skip to main content', 'buddyboss' ); ?></a>
 <div id="page" class="site bb-readylaunch">
 	<header id="masthead" class="bb-rl-header">
 		<div class="bb-rl-container bb-rl-header-container flex justify-between items-center">

--- a/src/bp-templates/bp-nouveau/readylaunch/media/album-entry.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/media/album-entry.php
@@ -30,7 +30,7 @@ $icons = array(
 	<div class="bb-album-cover-wrap">
 		<a class="bs-cover-wrap" href="<?php bp_album_link(); ?>">
 			<?php if ( ! empty( $media_album_template->album->media['medias'] ) ) : ?>
-				<img src="<?php echo esc_url( $media_album_template->album->media['medias'][0]->attachment_data->media_album_cover ); ?>" />
+				<img src="<?php echo esc_url( $media_album_template->album->media['medias'][0]->attachment_data->media_album_cover ); ?>" alt="<?php echo esc_attr( bp_get_album_title() ); ?>" />
 			<?php endif; ?>
 
 			<div class="bb-album-content-wrap">

--- a/src/bp-templates/bp-nouveau/readylaunch/media/theatre.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/media/theatre.php
@@ -17,12 +17,12 @@ defined( 'ABSPATH' ) || exit;
 <div class="bb-rl-media-model-wrapper bb-rl-internal-model media bb-rl-media-theatre" style="display: none;" id="buddypress">
 	<div id="bb-rl-media-model-container" class="bb-rl-media-model-container">
 		<div class="bb-rl-media-model-header">
-			<h2></h2>
-			<a data-balloon-pos="left" data-balloon="<?php esc_attr_e( 'Toggle Sidebar', 'buddyboss' ); ?>" class="bb-rl-toggle-theatre-sidebar" href="#">
-				<i class="bb-icons-rl-sidebar-simple"></i>
+			<h2><?php esc_html_e( 'Media', 'buddyboss' ); ?></h2>
+			<a data-balloon-pos="left" data-balloon="<?php esc_attr_e( 'Toggle Sidebar', 'buddyboss' ); ?>" class="bb-rl-toggle-theatre-sidebar" href="#" aria-label="<?php esc_attr_e( 'Toggle Sidebar', 'buddyboss' ); ?>">
+				<i class="bb-icons-rl-sidebar-simple" aria-hidden="true"></i>
 			</a>
-			<a data-balloon-pos="left" data-balloon="<?php esc_attr_e( 'Close', 'buddyboss' ); ?>" class="bb-rl-close-media-theatre bb-rl-close-model" href="#">
-				<i class="bb-icons-rl-x"></i>
+			<a data-balloon-pos="left" data-balloon="<?php esc_attr_e( 'Close', 'buddyboss' ); ?>" class="bb-rl-close-media-theatre bb-rl-close-model" href="#" aria-label="<?php esc_attr_e( 'Close', 'buddyboss' ); ?>">
+				<i class="bb-icons-rl-x" aria-hidden="true"></i>
 			</a>
 		</div>
 		<div class="bb-rl-media-model-inner">
@@ -34,7 +34,7 @@ defined( 'ABSPATH' ) || exit;
 					<i class="bb-icons-rl-caret-right"></i>
 				</a>
 				<figure class="">
-					<img src="" alt="" />
+					<img src="" alt="<?php esc_attr_e( 'Media image', 'buddyboss' ); ?>" />
 				</figure>
 				<div class="bb-rl-dropdown-wrap bb-rl-media-only-privacy">
 					<div class="bb-media-privacy-wrap" style="display: none;">

--- a/src/bp-templates/bp-nouveau/readylaunch/members/profile-card.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/members/profile-card.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 			<div class="bb-rl-card-body">
 				<div class="bb-rl-card-avatar">
 					<span class="card-profile-status"></span>
-					<img src="" alt="">
+					<img src="" alt="<?php esc_attr_e( 'Member avatar', 'buddyboss' ); ?>" />
 				</div>
 				<div class="bb-rl-card-entity">
 					<div class="bb-card-profile-type"></div>

--- a/src/bp-templates/bp-nouveau/readylaunch/single-bp-email.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/single-bp-email.php
@@ -44,7 +44,7 @@ defined( 'ABSPATH' ) || exit;
 $settings = bp_email_get_appearance_settings();
 
 ?><!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<html <?php echo esc_attr( get_bloginfo( 'language' ) ); ?> xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 <head>
 	<meta charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/bp-templates/bp-nouveau/readylaunch/video/album-entry.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/video/album-entry.php
@@ -20,7 +20,7 @@ global $video_album_template;
 	<div class="bb-album-cover-wrap">
 		<a class="bs-cover-wrap" href="<?php bp_video_album_link(); ?>">
 			<?php if ( ! empty( $video_album_template->album->video['videos'] ) ) : ?>
-				<img src="<?php echo esc_url( $video_album_template->album->video['videos'][0]->attachment_data->video_album_cover_thumb ); ?>" />
+				<img src="<?php echo esc_url( $video_album_template->album->video['videos'][0]->attachment_data->video_album_cover_thumb ); ?>" alt="<?php echo esc_attr( bp_get_video_album_title() ); ?>" />
 			<?php endif; ?>
 
 			<div class="bb-album-content-wrap">

--- a/src/bp-templates/bp-nouveau/readylaunch/video/theatre.php
+++ b/src/bp-templates/bp-nouveau/readylaunch/video/theatre.php
@@ -17,12 +17,12 @@ defined( 'ABSPATH' ) || exit;
 <div class="bb-rl-media-model-wrapper bb-rl-internal-model video bb-rl-video-theatre" style="display: none;" id="buddypress">
 	<div id="bb-rl-media-model-container" class="bb-rl-media-model-container">
 		<div class="bb-rl-media-model-header">
-			<h2></h2>
-			<a data-balloon-pos="left" data-balloon="<?php esc_attr_e( 'Toggle Sidebar', 'buddyboss' ); ?>" class="bb-rl-toggle-theatre-sidebar" href="#">
-				<i class="bb-icons-rl-sidebar-simple"></i>
+			<h2><?php esc_html_e( 'Video', 'buddyboss' ); ?></h2>
+			<a data-balloon-pos="left" data-balloon="<?php esc_attr_e( 'Toggle Sidebar', 'buddyboss' ); ?>" class="bb-rl-toggle-theatre-sidebar" href="#" aria-label="<?php esc_attr_e( 'Toggle Sidebar', 'buddyboss' ); ?>">
+				<i class="bb-icons-rl-sidebar-simple" aria-hidden="true"></i>
 			</a>
-			<a data-balloon-pos="left" data-balloon="<?php esc_attr_e( 'Close', 'buddyboss' ); ?>" class="bb-rl-close-media-theatre bb-rl-close-model" href="#">
-				<i class="bb-icons-rl-x"></i>
+			<a data-balloon-pos="left" data-balloon="<?php esc_attr_e( 'Close', 'buddyboss' ); ?>" class="bb-rl-close-media-theatre bb-rl-close-model" href="#" aria-label="<?php esc_attr_e( 'Close', 'buddyboss' ); ?>">
+				<i class="bb-icons-rl-x" aria-hidden="true"></i>
 			</a>
 		</div>
 		<div class="bb-rl-media-model-inner">
@@ -34,7 +34,7 @@ defined( 'ABSPATH' ) || exit;
 					<i class="bb-icons-rl-caret-right"></i>
 				</a>
 				<figure class="">
-					<img src="" alt="" />
+					<img src="" alt="<?php esc_attr_e( 'Video thumbnail', 'buddyboss' ); ?>" />
 				</figure>
 				<div class="bb-rl-dropdown-wrap bb-rl-media-only-privacy">
 					<div class="bb-media-privacy-wrap" style="display: none;">


### PR DESCRIPTION
Improve accessibility across ReadyLaunch and Nouveau templates and scripts: use site language in email HTML, add alt text for images, add skip links and headings, add ARIA roles/aria-live for activity/notifications/toasts, make toast close button accessible, add keyboard handlers for dropdowns/accordions and profile/group popups, add focus-visible outlines for buttons/forms, and respect prefers-reduced-motion. Also minor visual tweaks (active link styling). Files updated include email templates, multiple ReadyLaunch templates, SCSS partials, and core JS (buddypress-nouveau, buddypress-activity).

### Jira Issue:
<!-- Paste Jira issue link -->


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR's description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR's title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to "Needs Review" (or "Code Review" for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to "Needs QA" (or "Approved" for Dev Tasks)
