### PR TITLE
PROD-10394 - Fix admin manual activation with reCAPTCHA

### DIFF
--- a/src/bb-features/integrations/recaptcha/bb-recaptcha-filters.php
+++ b/src/bb-features/integrations/recaptcha/bb-recaptcha-filters.php
@@ -144,6 +144,11 @@ function bb_recaptcha_validate_activate( $retval ) {
 		return $retval;
 	}
 
+	// Bypass for wp-admin "Accept" bulk action, which never renders the widget.
+	if ( is_admin() ) {
+		return $retval;
+	}
+
 	$verified = bb_recaptcha_connection_status();
 
 	// If the connection is unverified and activation is not enabled, proceed to bypass the captcha.


### PR DESCRIPTION
Manual activation of pending users fails with "Google reCAPTCHA token is missing" when reCAPTCHA is enabled

### Jira Issue:
https://buddyboss.atlassian.net/browse/PROD-10394


### General Note
Keep all conversations related to this PR in the associated Jira issue(s). Do NOT add comment on this PR or edit this PR’s description.

### Notes to Developer
* Ensure the IDs (i.e. PROD-1) of all associated Jira issues are reference in this PR’s title
* Ensure that you have achieved the Definition of Done before submitting for review
* When this PR is ready for review, move the associate Jira issue(s) to “Needs Review” (or “Code Review” for Dev Tasks)

### Notes to Reviewer
* Ensure that the Definition of Done have been achieved before approving a PR
* When this PR is approved, move the associated Jira issue(s) to “Needs QA” (or “Approved” for Dev Tasks)
